### PR TITLE
Revert "Use cups' included ppd instead of including our own."

### DIFF
--- a/addprinters.sh
+++ b/addprinters.sh
@@ -23,6 +23,14 @@ if [ ! -f printers.conf ]; then
 	download $URL
 fi
 
+PPD="hp-laserjet-9050-$(uname).ppd"
+
+if [ ! -f $PPD ]; then
+	URL=https://raw.github.com/adicu/ninja-unix/master/$PPD
+	echo "No ppd file. Attempting to download."
+	download $URL
+fi
+
 LPADMIN=`which lpadmin`
 
 if [ -z $LPADMIN ]; then
@@ -32,7 +40,7 @@ if [ -z $LPADMIN ]; then
 fi
 
 add_ninja(){
-	$LPADMIN -p $1 -E -v lpd://$2/public -m drv:///sample.drv/generic.ppd -L $3
+	$LPADMIN -p $1 -E -v lpd://$2/public -P $PPD -L $3
 }
 
 read_config(){

--- a/hp-laserjet-9050-Darwin.ppd
+++ b/hp-laserjet-9050-Darwin.ppd
@@ -1,0 +1,8084 @@
+*PPD-Adobe: "4.3"
+*% =======================================================
+*% Disclaimer:  The above statement indicates
+*% that this PPD was written using the Adobe PPD
+*% File Format Specification 4.3, but does not
+*% intend to imply approval and acceptance by
+*% Adobe Systems, Inc.
+*% =======================================================
+*% Printer Description File
+*% (c) Copyright 2004-2010 Hewlett-Packard Development Company, L.P.
+*%========================================================
+*% PPD for HP LaserJet 9050
+*% For Macintosh
+*%========================================================
+
+*%=================================================
+*% 		 PPD File Version Information
+*%=================================================
+*FileVersion: "17.5"
+*HPBuildNumber: "005"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: English
+*cupsLanguages: "da de es fi fr it ja ko nl nb pt sv zh_CN zh_TW"
+*PCFileName: "HP9050_H.PPD"
+*cupsVersion: 1.3
+*APDialogExtension: "/Library/Printers/hp/PDEs/hpPostScriptPDE.plugin"
+*HPPDEPanel: "HPWatermarks"
+
+*HPPDEPanel: "HPFinishingPanel"
+
+*HPPDEPanel: "HPImagingOptions"
+*HPPDEPanel: "HPJobRetention"
+*APPrinterIconPath: "/Library/Printers/hp/Icons/HP LaserJet 9050.icns"
+*cupsFilter: "application/vnd.cups-postscript 0 /Library/Printers/hp/filter/hpPostProcessing.bundle/Contents/MacOS/hpPostProcessing"
+
+*%=================================================
+*% 		 Product Version Information
+*%=================================================
+*ModelName: "HP LaserJet 9050 "
+*ShortNickName: "HP LaserJet 9050 "
+*NickName: "HP LaserJet 9050"
+*Product: "(hp LaserJet 9050)"
+*Product: "(Hewlett-Packard hp LaserJet 9050)"
+*Product: "(HP LaserJet 9050)"
+*Manufacturer: "HP"
+
+*PSVersion: "(3010.107) 0"
+
+*%=================================================
+*%		 Device Capabilities
+*%=================================================
+*ColorDevice:       False
+*DefaultColorSpace: Gray
+*FileSystem:        True
+*?FileSystem: "
+   save
+     false
+     (%disk?%)
+     { currentdevparams dup /Writeable known
+        { /Writeable get {pop true} if }  { pop } ifelse
+     } 100 string /IODevice resourceforall
+     {(True)}{(False)} ifelse = flush
+   restore
+"
+*End
+
+*LanguageLevel: "3"
+*Throughput:    "50"
+*TTRasterizer:  Type42
+*?TTRasterizer: "
+   save
+      42 /FontType resourcestatus
+      { pop pop (Type42)} {pop pop (None)} ifelse = flush
+   restore
+"
+*End
+
+*%=================================================
+*%		 Emulations and Protocols
+*%=================================================
+*Protocols: TBCP
+
+*SuggestedJobTimeout:  "0"
+*SuggestedWaitTimeout: "120"
+
+*PrintPSErrors: True
+
+*%=== Output Bin ======================
+*PageStackOrder Upper: Normal
+*PageStackOrder Left: Reverse
+*PageStackOrder Stacker: Normal
+*PageStackOrder StackerFaceUp: Reverse
+*PageStackOrder UStapler: Normal
+*PageStackOrder HPBooklet: Normal
+*PageStackOrder HP8BinMB: Normal
+
+*%=================================================
+*%		 Installable Options
+*%=================================================
+*OpenGroup: InstallableOptions/Installed Options
+*da.Translation InstallableOptions/Installeret tilbehør: ""
+*de.Translation InstallableOptions/Installierte Optionen: ""
+*es.Translation InstallableOptions/Opciones instaladas: ""
+*fi.Translation InstallableOptions/Asennetut lisävarusteet: ""
+*fr.Translation InstallableOptions/Options installées: ""
+*it.Translation InstallableOptions/Installed Options: ""
+*ja.Translation InstallableOptions/インストール済オプション: ""
+*ko.Translation InstallableOptions/설치된 선택사양: ""
+*nl.Translation InstallableOptions/Geïnstalleerde opties: ""
+*nb.Translation InstallableOptions/Installerte alternativer: ""
+*pt.Translation InstallableOptions/Versıes Instaladas: ""
+*sv.Translation InstallableOptions/Installerade tillbehör: ""
+*zh_CN.Translation InstallableOptions/已安装的选项: ""
+*zh_TW.Translation InstallableOptions/安裝的選項: ""
+
+
+*OpenUI *HPOption_Tray1/Tray 1: Boolean
+*DefaultHPOption_Tray1: False
+*da.Translation HPOption_Tray1/Bakke 1: ""
+*de.Translation HPOption_Tray1/Zufuhrfach 1: ""
+*es.Translation HPOption_Tray1/Bandeja 1: ""
+*fi.Translation HPOption_Tray1/Lokero 1: ""
+*fr.Translation HPOption_Tray1/Bac 1: ""
+*it.Translation HPOption_Tray1/Vassoio 1: ""
+*ja.Translation HPOption_Tray1/トレイ 1: ""
+*ko.Translation HPOption_Tray1/용지함 1: ""
+*nl.Translation HPOption_Tray1/Lade 1: ""
+*nb.Translation HPOption_Tray1/Skuff 1: ""
+*pt.Translation HPOption_Tray1/Bandeja 1: ""
+*sv.Translation HPOption_Tray1/Fack 1: ""
+*zh_CN.Translation HPOption_Tray1/纸盒1: ""
+*zh_TW.Translation HPOption_Tray1/紙匣1: ""
+
+*HPOption_Tray1 True/Installed: ""
+*da.HPOption_Tray1 True/Installeret: ""
+*de.HPOption_Tray1 True/Installiert: ""
+*es.HPOption_Tray1 True/Instalado: ""
+*fi.HPOption_Tray1 True/Asennettu: ""
+*fr.HPOption_Tray1 True/Installé: ""
+*it.HPOption_Tray1 True/Installato: ""
+*ja.HPOption_Tray1 True/インストール済: ""
+*ko.HPOption_Tray1 True/설치됨: ""
+*nl.HPOption_Tray1 True/Geïnstalleerd: ""
+*nb.HPOption_Tray1 True/Installert: ""
+*pt.HPOption_Tray1 True/Instalada: ""
+*sv.HPOption_Tray1 True/Installerat: ""
+*zh_CN.HPOption_Tray1 True/已安装: ""
+*zh_TW.HPOption_Tray1 True/已安裝: ""
+
+*HPOption_Tray1 False/Not Installed: ""
+*da.HPOption_Tray1 False/Ikke installeret: ""
+*de.HPOption_Tray1 False/Nicht installiert: ""
+*es.HPOption_Tray1 False/No Instalado: ""
+*fi.HPOption_Tray1 False/Ei asennettu: ""
+*fr.HPOption_Tray1 False/Non installé: ""
+*it.HPOption_Tray1 False/Non installato: ""
+*ja.HPOption_Tray1 False/インストールされていない: ""
+*ko.HPOption_Tray1 False/설치되지 않음: ""
+*nl.HPOption_Tray1 False/Niet geïnstalleerd: ""
+*nb.HPOption_Tray1 False/Ikke installert: ""
+*pt.HPOption_Tray1 False/Não instalada: ""
+*sv.HPOption_Tray1 False/Ej installerat: ""
+*zh_CN.HPOption_Tray1 False/未安装: ""
+*zh_TW.HPOption_Tray1 False/尚未安裝: ""
+
+*?HPOption_Tray1: "
+  save
+    currentpagedevice /InputAttributes get 3 known
+    {(True)}{(False)} ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPOption_Tray1
+
+*OpenUI *HPOption_2000_Sheet_Tray/2000-Sheet Input Tray (Tray 4): Boolean
+*DefaultHPOption_2000_Sheet_Tray: False
+*da.Translation HPOption_2000_Sheet_Tray/Bakke 4: ""
+*de.Translation HPOption_2000_Sheet_Tray/2000-Blatt-Zufuhrfach (Fach 4): ""
+*es.Translation HPOption_2000_Sheet_Tray/Bandeja de entrada para 2000 hojas (Bandeja 4): ""
+*fi.Translation HPOption_2000_Sheet_Tray/2 000 arkin syöttölokero (lokero 4): ""
+*fr.Translation HPOption_2000_Sheet_Tray/Bac d'alim. de 2 000 feuilles (bac 4): ""
+*it.Translation HPOption_2000_Sheet_Tray/Vassoio da 2000 fogli (Vassoio 4): ""
+*ja.Translation HPOption_2000_Sheet_Tray/2000 枚給紙トレイ (トレイ 4): ""
+*ko.Translation HPOption_2000_Sheet_Tray/2,000매 입력 용지함(용지함 4): ""
+*nl.Translation HPOption_2000_Sheet_Tray/Invoerlade voor 2.000 vel (Lade 4): ""
+*nb.Translation HPOption_2000_Sheet_Tray/2000-arks innskuff (skuff 4): ""
+*pt.Translation HPOption_2000_Sheet_Tray/Bandeja de entrada para 2000 folhas (bandeja 4): ""
+*sv.Translation HPOption_2000_Sheet_Tray/Inmatningsfack för 2 000 ark (Fack 4): ""
+*zh_CN.Translation HPOption_2000_Sheet_Tray/2000 页进纸盒（纸盒 4）: ""
+*zh_TW.Translation HPOption_2000_Sheet_Tray/可容納 2000 張紙的進紙匣 (4 號紙匣): ""
+
+*HPOption_2000_Sheet_Tray True/Installed: ""
+*da.HPOption_2000_Sheet_Tray True/Installeret: ""
+*de.HPOption_2000_Sheet_Tray True/Installiert: ""
+*es.HPOption_2000_Sheet_Tray True/Instalado: ""
+*fi.HPOption_2000_Sheet_Tray True/Asennettu: ""
+*fr.HPOption_2000_Sheet_Tray True/Installé: ""
+*it.HPOption_2000_Sheet_Tray True/Installato: ""
+*ja.HPOption_2000_Sheet_Tray True/インストール済み: ""
+*ko.HPOption_2000_Sheet_Tray True/설치: ""
+*nl.HPOption_2000_Sheet_Tray True/Geïnstalleerd: ""
+*nb.HPOption_2000_Sheet_Tray True/Installert: ""
+*pt.HPOption_2000_Sheet_Tray True/Instalada: ""
+*sv.HPOption_2000_Sheet_Tray True/Installerat: ""
+*zh_CN.HPOption_2000_Sheet_Tray True/已安装: ""
+*zh_TW.HPOption_2000_Sheet_Tray True/已安裝: ""
+
+*HPOption_2000_Sheet_Tray False/Not Installed: ""
+*da.HPOption_2000_Sheet_Tray False/Ikke installeret: ""
+*de.HPOption_2000_Sheet_Tray False/Nicht installiert: ""
+*es.HPOption_2000_Sheet_Tray False/No instalado: ""
+*fi.HPOption_2000_Sheet_Tray False/Ei asennettu: ""
+*fr.HPOption_2000_Sheet_Tray False/Non installé: ""
+*it.HPOption_2000_Sheet_Tray False/Non Installato: ""
+*ja.HPOption_2000_Sheet_Tray False/インストールされていない: ""
+*ko.HPOption_2000_Sheet_Tray False/미설치: ""
+*nl.HPOption_2000_Sheet_Tray False/Geïnstalleerd: ""
+*nb.HPOption_2000_Sheet_Tray False/Ikke installert: ""
+*pt.HPOption_2000_Sheet_Tray False/Não Instalado: ""
+*sv.HPOption_2000_Sheet_Tray False/Ej installerad: ""
+*zh_CN.HPOption_2000_Sheet_Tray False/未安装: ""
+*zh_TW.HPOption_2000_Sheet_Tray False/未安裝: ""
+
+*?HPOption_2000_Sheet_Tray: "
+  save
+    currentpagedevice /InputAttributes get 5 known
+    {(True)}{(False)} ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPOption_2000_Sheet_Tray
+
+*OpenUI *HPOption_Duplexer/Duplex Unit: Boolean
+*DefaultHPOption_Duplexer: False
+*da.Translation HPOption_Duplexer/Dupleksudskrivningsudstyr: ""
+*de.Translation HPOption_Duplexer/Duplexdruck-Zubehör: ""
+*es.Translation HPOption_Duplexer/Accesorio para impresión dúplex: ""
+*fi.Translation HPOption_Duplexer/Kaksipuolisen tulostuksen lisälaite: ""
+*fr.Translation HPOption_Duplexer/Accessoire d'impression recto verso: ""
+*it.Translation HPOption_Duplexer/Accessorio per stampa duplex: ""
+*ja.Translation HPOption_Duplexer/両面印刷アクセサリ: ""
+*ko.Translation HPOption_Duplexer/양면 인쇄 부속품: ""
+*nl.Translation HPOption_Duplexer/Duplexeenheid: ""
+*nb.Translation HPOption_Duplexer/Ekstrautstyr for dobbeltsidig utskrift: ""
+*pt.Translation HPOption_Duplexer/Ùnidade dúplex: ""
+*sv.Translation HPOption_Duplexer/Tillbehör för dubbelsidig utskrift: ""
+*zh_CN.Translation HPOption_Duplexer/双面打印附件: ""
+*zh_TW.Translation HPOption_Duplexer/雙面列印裝置: ""
+
+*HPOption_Duplexer True/Installed: ""
+*da.HPOption_Duplexer True/Installeret: ""
+*de.HPOption_Duplexer True/Installiert: ""
+*es.HPOption_Duplexer True/Instalado: ""
+*fi.HPOption_Duplexer True/Asennettu: ""
+*fr.HPOption_Duplexer True/Installé: ""
+*it.HPOption_Duplexer True/Installato: ""
+*ja.HPOption_Duplexer True/インストール済み: ""
+*ko.HPOption_Duplexer True/설치: ""
+*nl.HPOption_Duplexer True/Geïnstalleerd: ""
+*nb.HPOption_Duplexer True/Installert: ""
+*pt.HPOption_Duplexer True/Instalado: ""
+*sv.HPOption_Duplexer True/Installerad: ""
+*zh_CN.HPOption_Duplexer True/已安装: ""
+*zh_TW.HPOption_Duplexer True/已安裝: ""
+
+*HPOption_Duplexer False/Not Installed: ""
+*da.HPOption_Duplexer False/Ikke installeret: ""
+*de.HPOption_Duplexer False/Nicht installiert: ""
+*es.HPOption_Duplexer False/No instalado: ""
+*fi.HPOption_Duplexer False/Ei asennettu: ""
+*fr.HPOption_Duplexer False/Non installé: ""
+*it.HPOption_Duplexer False/Non installato: ""
+*ja.HPOption_Duplexer False/インストールされていない: ""
+*ko.HPOption_Duplexer False/미설치: ""
+*nl.HPOption_Duplexer False/Niet geïnstalleerd: ""
+*nb.HPOption_Duplexer False/Ikke installert: ""
+*pt.HPOption_Duplexer False/Não Instalado: ""
+*sv.HPOption_Duplexer False/Ej installerad: ""
+*zh_CN.HPOption_Duplexer False/未安装: ""
+*zh_TW.HPOption_Duplexer False/未安裝: ""
+
+*?HPOption_Duplexer: "
+  save
+    currentpagedevice /Duplex known
+    {(True)}{(False)}ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPOption_Duplexer
+
+*OpenUI *HPOption_Disk/Printer Disk: PickOne
+*DefaultHPOption_Disk: None
+*da.Translation HPOption_Disk/Printerens harddisk: ""
+*de.Translation HPOption_Disk/Druckerfestplatte: ""
+*es.Translation HPOption_Disk/Disco de la impresora: ""
+*fi.Translation HPOption_Disk/Tulostimen kiintolevy: ""
+*fr.Translation HPOption_Disk/Disque dur de l'imprimante: ""
+*it.Translation HPOption_Disk/Disco rigido stampante: ""
+*ja.Translation HPOption_Disk/プリンタ ハード ディスク: ""
+*ko.Translation HPOption_Disk/프린터 하드 디스크: ""
+*nl.Translation HPOption_Disk/Harde schijf van printer: ""
+*nb.Translation HPOption_Disk/Skriverharddisk: ""
+*pt.Translation HPOption_Disk/Disco rÌgido da impressora: ""
+*sv.Translation HPOption_Disk/Skrivarens hårddisk: ""
+*zh_CN.Translation HPOption_Disk/打印机硬盘: ""
+*zh_TW.Translation HPOption_Disk/印表機硬碟: ""
+
+*HPOption_Disk None/None: ""
+*da.HPOption_Disk None/Ingen: ""
+*de.HPOption_Disk None/Keine: ""
+*es.HPOption_Disk None/Ninguno: ""
+*fi.HPOption_Disk None/Ei mitään: ""
+*fr.HPOption_Disk None/Aucun: ""
+*it.HPOption_Disk None/Nessuno: ""
+*ja.HPOption_Disk None/なし: ""
+*ko.HPOption_Disk None/없음: ""
+*nl.HPOption_Disk None/Geen: ""
+*nb.HPOption_Disk None/Ingen: ""
+*pt.HPOption_Disk None/Nenhuma: ""
+*sv.HPOption_Disk None/Inget: ""
+*zh_CN.HPOption_Disk None/无: ""
+*zh_TW.HPOption_Disk None/無: ""
+
+*HPOption_Disk RAMDisk/RAM Disk: ""
+*da.HPOption_Disk RAMDisk/RAM-disk: ""
+*de.HPOption_Disk RAMDisk/RAM-Disk: ""
+*es.HPOption_Disk RAMDisk/Disco RAM: ""
+*fi.HPOption_Disk RAMDisk/RAM-levy: ""
+*fr.HPOption_Disk RAMDisk/Disque MEV: ""
+*it.HPOption_Disk RAMDisk/Disco RAM: ""
+*ja.HPOption_Disk RAMDisk/RAMディスク: ""
+*ko.HPOption_Disk RAMDisk/RAM 디스크: ""
+*nl.HPOption_Disk RAMDisk/RAM-station: ""
+*nb.HPOption_Disk RAMDisk/RAM-disk: ""
+*pt.HPOption_Disk RAMDisk/Disco RAM: ""
+*sv.HPOption_Disk RAMDisk/RAM-disk: ""
+*zh_CN.HPOption_Disk RAMDisk/RAM 磁盘: ""
+*zh_TW.HPOption_Disk RAMDisk/RAM 磁碟: ""
+
+*HPOption_Disk HardDisk/Hard Disk: ""
+*da.HPOption_Disk HardDisk/Harddisk: ""
+*de.HPOption_Disk HardDisk/Festplatte: ""
+*es.HPOption_Disk HardDisk/Disco duro: ""
+*fi.HPOption_Disk HardDisk/Kiintolevy: ""
+*fr.HPOption_Disk HardDisk/Disque dur: ""
+*it.HPOption_Disk HardDisk/Disco rigido: ""
+*ja.HPOption_Disk HardDisk/ハードディスク: ""
+*ko.HPOption_Disk HardDisk/하드 디스크: ""
+*nl.HPOption_Disk HardDisk/Harde schijf: ""
+*nb.HPOption_Disk HardDisk/Harddisk: ""
+*pt.HPOption_Disk HardDisk/Disco rígido: ""
+*sv.HPOption_Disk HardDisk/Hårddisk: ""
+*zh_CN.HPOption_Disk HardDisk/硬盘: ""
+*zh_TW.HPOption_Disk HardDisk/硬碟: ""
+
+*?HPOption_Disk: "
+save
+  /FWMax 2048 def /RAMMax 500000 def
+  (HardDisk) (RAMDisk) (None)
+  0
+  (%disk?%)
+  { currentdevparams dup /Writeable known
+    { dup /Writeable get
+      { /PhysicalSize get dup FWMax gt
+        { RAMMax gt {2}{1} ifelse 2 copy lt { exch }if pop }
+        { pop } ifelse
+      }
+      { pop } ifelse
+    }
+    { pop } ifelse
+  } 100 string /IODevice resourceforall
+  index =  flush pop pop pop
+restore
+"
+*End
+*CloseUI: *HPOption_Disk
+
+*OpenUI *HPOption_MBM_Mixed/Accessory Output Bins: PickOne
+*OrderDependency: 10 AnySetup *HPOption_MBM_Mixed
+*DefaultHPOption_MBM_Mixed: Standard
+*da.Translation HPOption_MBM_Mixed/Tilbehørudskriftsbakker: ""
+*de.Translation HPOption_MBM_Mixed/Zusatzausgabefächer: ""
+*es.Translation HPOption_MBM_Mixed/Bandejas de salida accesorias: ""
+*fi.Translation HPOption_MBM_Mixed/Lisätulostelokerot: ""
+*fr.Translation HPOption_MBM_Mixed/Bacs de sortie optionnels: ""
+*it.Translation HPOption_MBM_Mixed/Scomparti di uscita accessori: ""
+*ja.Translation HPOption_MBM_Mixed/アクセサリ排出ビン: ""
+*ko.Translation HPOption_MBM_Mixed/부속품 출력함: ""
+*nl.Translation HPOption_MBM_Mixed/Accessoire-uitvoerbakken: ""
+*nb.Translation HPOption_MBM_Mixed/Ekstra utskuffer: ""
+*pt.Translation HPOption_MBM_Mixed/Compartimentos acessórios de saída: ""
+*sv.Translation HPOption_MBM_Mixed/Extra utmatningsfack: ""
+*zh_CN.Translation HPOption_MBM_Mixed/附加出纸槽: ""
+*zh_TW.Translation HPOption_MBM_Mixed/附件輸出紙槽: ""
+
+*HPOption_MBM_Mixed Standard/Not Installed: ""
+*da.HPOption_MBM_Mixed Standard/Ingen: ""
+*de.HPOption_MBM_Mixed Standard/Nicht installiert: ""
+*es.HPOption_MBM_Mixed Standard/Ninguna: ""
+*fi.HPOption_MBM_Mixed Standard/Ei asennettu: ""
+*fr.HPOption_MBM_Mixed Standard/Non installé: ""
+*it.HPOption_MBM_Mixed Standard/Nessuno: ""
+*ja.HPOption_MBM_Mixed Standard/インストールされていない: ""
+*ko.HPOption_MBM_Mixed Standard/설치되지 않았음: ""
+*nl.HPOption_MBM_Mixed Standard/Niet geïnstalleerd: ""
+*nb.HPOption_MBM_Mixed Standard/Ikke installert: ""
+*pt.HPOption_MBM_Mixed Standard/Nenhum: ""
+*sv.HPOption_MBM_Mixed Standard/Inget: ""
+*zh_CN.HPOption_MBM_Mixed Standard/未安装: ""
+*zh_TW.HPOption_MBM_Mixed Standard/尚未安裝: ""
+
+*HPOption_MBM_Mixed MBMStaplerStacker/HP 3000-Sheet Stapler-Stacker: "userdict /HPConfigurableStapler 0 put"
+*da.HPOption_MBM_Mixed MBMStaplerStacker/hphæfter/stabler: ""
+*de.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000-Blatt-Hefter/Ablage: ""
+*es.HPOption_MBM_Mixed MBMStaplerStacker/Grapadora y apilador de 3000 hojas de HP : ""
+*fi.HPOption_MBM_Mixed MBMStaplerStacker/HP<3A>n 3000 arkin nitoja/pinoaja: ""
+*fr.HPOption_MBM_Mixed MBMStaplerStacker/Agrafeuse-empileuse de 3000 feuilles HP: ""
+*it.HPOption_MBM_Mixed MBMStaplerStacker/Cucitrice-Fascicolatrice HP da 3000 fogli: ""
+*ja.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000枚ホチキス/スタッカ: ""
+*ko.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000매 스테이플러-스택커: ""
+*nl.HPOption_MBM_Mixed MBMStaplerStacker/hp-nietmachine/stapelaar voor 3000 vel: ""
+*nb.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000-arks stifteenhets-magasin: ""
+*pt.HPOption_MBM_Mixed MBMStaplerStacker/Empilhador/Grampeador de 3000 Folhas HP: ""
+*sv.HPOption_MBM_Mixed MBMStaplerStacker/hp Häftning och stapling för 3000 ark: ""
+*zh_CN.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000页装订堆栈器: ""
+*zh_TW.HPOption_MBM_Mixed MBMStaplerStacker/hp 300紙頁裝訂機/堆疊機: ""
+
+*HPOption_MBM_Mixed MBMStacker/HP 3000-Sheet Stacker: ""
+*da.HPOption_MBM_Mixed MBMStacker/hp 3000-ark hphæfter: ""
+*de.HPOption_MBM_Mixed MBMStacker/hp 3000-Blatt-Ablage: ""
+*es.HPOption_MBM_Mixed MBMStacker/Apilador de 3000 hojas de hp: ""
+*fi.HPOption_MBM_Mixed MBMStacker/hp<3A>n 3000 arkin pinoaja: ""
+*fr.HPOption_MBM_Mixed MBMStacker/Empileuse de 3000 feuilles hp: ""
+*it.HPOption_MBM_Mixed MBMStacker/Impilatrice HP da 3000 fogli: ""
+*ja.HPOption_MBM_Mixed MBMStacker/hp 3000枚スタッカ: ""
+*ko.HPOption_MBM_Mixed MBMStacker/hp 3000-스태커 용지함: ""
+*nl.HPOption_MBM_Mixed MBMStacker/HP stapelaar: ""
+*nb.HPOption_MBM_Mixed MBMStacker/hp 3000-arks magasin: ""
+*pt.HPOption_MBM_Mixed MBMStacker/hp 3000 Folhas empilhador: ""
+*sv.HPOption_MBM_Mixed MBMStacker/HP staplingsenhet för 3000 ark: ""
+*zh_CN.HPOption_MBM_Mixed MBMStacker/HP 3000 页堆栈器: ""
+*zh_TW.HPOption_MBM_Mixed MBMStacker/可容納 3000 張紙的 HP 堆疊器: ""
+
+*HPOption_MBM_Mixed HPFinisher/HP Multifunction Finisher: ""
+*da.HPOption_MBM_Mixed HPFinisher/hp-multifunktionsfinisher: ""
+*de.HPOption_MBM_Mixed HPFinisher/hp Mehrzweck-Abschlussgerät: ""
+*es.HPOption_MBM_Mixed HPFinisher/Dispositivo de acabados multifunción de hp: ""
+*fi.HPOption_MBM_Mixed HPFinisher/hp monitoiminen viimeistelylaite: ""
+*fr.HPOption_MBM_Mixed HPFinisher/Module de finition multifonction hp: ""
+*it.HPOption_MBM_Mixed HPFinisher/Unità di finitura multifunzione hp: ""
+*ja.HPOption_MBM_Mixed HPFinisher/hp 多目的仕上げデバイス: ""
+*ko.HPOption_MBM_Mixed HPFinisher/hp 다기능 마감장치: ""
+*nl.HPOption_MBM_Mixed HPFinisher/hp Multifunctioneel afwerkingsapparaat: ""
+*nb.HPOption_MBM_Mixed HPFinisher/hp flerfunksjonsetterbeh: ""
+*pt.HPOption_MBM_Mixed HPFinisher/Dispositivo de acabamento multifunção hp: ""
+*sv.HPOption_MBM_Mixed HPFinisher/hp efterbehandlare med fler funktioner: ""
+*zh_CN.HPOption_MBM_Mixed HPFinisher/hp 多功能装订器: ""
+*zh_TW.HPOption_MBM_Mixed HPFinisher/hp 多功能處理機: ""
+
+*HPOption_MBM_Mixed HPMultiBinMailbox/HP Multi-Bin Mailbox: ""
+*da.HPOption_MBM_Mixed HPMultiBinMailbox/HP Postkasse med flere bakker: ""
+*de.HPOption_MBM_Mixed HPMultiBinMailbox/hp Multifächer-Mailbox: ""
+*es.HPOption_MBM_Mixed HPMultiBinMailbox/Buzón de bandejas múltiples: ""
+*fi.HPOption_MBM_Mixed HPMultiBinMailbox/Monilokeroinen postilaatikko: ""
+*fr.HPOption_MBM_Mixed HPMultiBinMailbox/Trieuse à bacs multiples: ""
+*it.HPOption_MBM_Mixed HPMultiBinMailbox/Casella a più scomparti: ""
+*ja.HPOption_MBM_Mixed HPMultiBinMailbox/マルチトレイメールボックス: ""
+*ko.HPOption_MBM_Mixed HPMultiBinMailbox/hp 다단 우편함: ""
+*nl.HPOption_MBM_Mixed HPMultiBinMailbox/Postbus met multibakken: ""
+*nb.HPOption_MBM_Mixed HPMultiBinMailbox/Postkasse med flere skuffer: ""
+*pt.HPOption_MBM_Mixed HPMultiBinMailbox/Caixa de correio com vários compartimentos: ""
+*sv.HPOption_MBM_Mixed HPMultiBinMailbox/Extra utmatningsfack: ""
+*zh_CN.HPOption_MBM_Mixed HPMultiBinMailbox/多槽信箱: ""
+*zh_TW.HPOption_MBM_Mixed HPMultiBinMailbox/多槽式信箱: ""
+
+*?HPOption_MBM_Mixed: "
+currentpagedevice /OutputAttributes known{
+	currentpagedevice /MediaProcessingDetails known{
+		currentpagedevice /MediaProcessingDetails get /ModelID known{
+			currentpagedevice /MediaProcessingDetails get /ModelID get (C8088B) search
+				{pop pop pop (HPFinisher)}
+				  {(C8085A) search
+				  {pop pop pop (MBMStaplerStacker)}
+				  {(C8084A) search
+				  {pop pop pop (MBMStacker)}
+				  {(Q5693A) search
+				    {pop pop pop (HPMultiBinMailbox)} {pop (Standard)} ifelse}
+				 ifelse}
+				 ifelse}
+				 ifelse}
+			{(Standard)}
+			ifelse}
+		{(Standard)}
+		ifelse}
+	{(Standard)}
+ifelse = flush"
+*End
+*CloseUI: *HPOption_MBM_Mixed
+
+*%=== 8 Bin MultiBin MailBox Modes =========================
+*OpenUI *HPMailboxMode/Mailbox Mode: PickOne
+*OrderDependency: 46 AnySetup *HPMailboxMode
+*DefaultHPMailboxMode: PrintersDefault
+*da.Translation HPMailboxMode/Postkasse-tilstand: ""
+*de.Translation HPMailboxMode/Mailbox-Modus: ""
+*es.Translation HPMailboxMode/Modo Buzón: ""
+*fi.Translation HPMailboxMode/Postilaatikkotila: ""
+*fr.Translation HPMailboxMode/Mode trieuse: ""
+*it.Translation HPMailboxMode/Modalità Mailbox: ""
+*ja.Translation HPMailboxMode/メールボックスモード: ""
+*ko.Translation HPMailboxMode/우편함 모드: ""
+*nl.Translation HPMailboxMode/Postbusmodus: ""
+*nb.Translation HPMailboxMode/Postkassemodus: ""
+*pt.Translation HPMailboxMode/Modo de caixa de correio: ""
+*sv.Translation HPMailboxMode/Sorterarlåge: ""
+*zh_CN.Translation HPMailboxMode/信箱模式: ""
+*zh_TW.Translation HPMailboxMode/信箱模式: ""
+
+*HPMailboxMode PrintersDefault/Printer's Current Setting: ""
+*da.HPMailboxMode PrintersDefault/Ingen: ""
+*de.HPMailboxMode PrintersDefault/Aktuelle Einstellung: ""
+*es.HPMailboxMode PrintersDefault/Valor actual: ""
+*fi.HPMailboxMode PrintersDefault/Nykyinen asetus: ""
+*fr.HPMailboxMode PrintersDefault/Paramétre actuel: ""
+*it.HPMailboxMode PrintersDefault/Impostazione corrente: ""
+*ja.HPMailboxMode PrintersDefault/現在の設定: ""
+*ko.HPMailboxMode PrintersDefault/현재 설정: ""
+*nl.HPMailboxMode PrintersDefault/Huidige instelling: ""
+*nb.HPMailboxMode PrintersDefault/Ingen: ""
+*pt.HPMailboxMode PrintersDefault/Configuração atual: ""
+*sv.HPMailboxMode PrintersDefault/Aktuell inställning: ""
+*zh_CN.HPMailboxMode PrintersDefault/当前设置: ""
+*zh_TW.HPMailboxMode PrintersDefault/目前設定值: ""
+
+*HPMailboxMode Standard/Not Installed: ""
+*da.HPMailboxMode Standard/Ikke installeret: ""
+*de.HPMailboxMode Standard/Nicht installiert: ""
+*es.HPMailboxMode Standard/No Instalado: ""
+*fi.HPMailboxMode Standard/Ei asennettu: ""
+*fr.HPMailboxMode Standard/Non installé: ""
+*it.HPMailboxMode Standard/Non installato: ""
+*ja.HPMailboxMode Standard/取り付けられていない: ""
+*ko.HPMailboxMode Standard/설치되지 않음: ""
+*nl.HPMailboxMode Standard/Niet geïnstalleerd: ""
+*nb.HPMailboxMode Standard/Ikke installert: ""
+*pt.HPMailboxMode Standard/Não instalada: ""
+*sv.HPMailboxMode Standard/Ej installerat: ""
+*zh_CN.HPMailboxMode Standard/未安装: ""
+*zh_TW.HPMailboxMode Standard/未安裝: ""
+
+*HPMailboxMode MBMode/Mailbox Mode: ""
+*da.HPMailboxMode MBMode/Postkassetilstand: ""
+*de.HPMailboxMode MBMode/Mailbox-Modus: ""
+*es.HPMailboxMode MBMode/Modo buzón: ""
+*fi.HPMailboxMode MBMode/Postilaatikkotila: ""
+*fr.HPMailboxMode MBMode/Mode Trieuse: ""
+*it.HPMailboxMode MBMode/modalità Cassetta postale: ""
+*ja.HPMailboxMode MBMode/メールボックスモード: ""
+*ko.HPMailboxMode MBMode/우편함 모드: ""
+*nl.HPMailboxMode MBMode/Modus voor postbus: ""
+*nb.HPMailboxMode MBMode/Postkassemodus: ""
+*pt.HPMailboxMode MBMode/Modo de caixa de correio: ""
+*sv.HPMailboxMode MBMode/Sorterarlåge: ""
+*zh_CN.HPMailboxMode MBMode/邮箱模式: ""
+*zh_TW.HPMailboxMode MBMode/信箱模式: ""
+
+*HPMailboxMode StackerMode/Stacker Mode: ""
+*da.HPMailboxMode StackerMode/Stablertilstand: ""
+*de.HPMailboxMode StackerMode/Stapelmodus: ""
+*es.HPMailboxMode StackerMode/Modo apilador: ""
+*fi.HPMailboxMode StackerMode/Pinontatila: ""
+*fr.HPMailboxMode StackerMode/Mode Réceptacle: ""
+*it.HPMailboxMode StackerMode/modalità Raccoglitore: ""
+*ja.HPMailboxMode StackerMode/排紙トレイモード: ""
+*ko.HPMailboxMode StackerMode/스태커 모드: ""
+*nl.HPMailboxMode StackerMode/Modus voor stapelaar: ""
+*nb.HPMailboxMode StackerMode/Stablingsmodus: ""
+*pt.HPMailboxMode StackerMode/Modo de empilhador: ""
+*sv.HPMailboxMode StackerMode/Låget Stapling: ""
+*zh_CN.HPMailboxMode StackerMode/堆栈器模式: ""
+*zh_TW.HPMailboxMode StackerMode/堆疊器模式: ""
+
+*HPMailboxMode SeparatorMode/Separator Mode: ""
+*da.HPMailboxMode SeparatorMode/Jobadskillertilstand: ""
+*de.HPMailboxMode SeparatorMode/Jobtrennmodus: ""
+*es.HPMailboxMode SeparatorMode/Modo separador de trabajos: ""
+*fi.HPMailboxMode SeparatorMode/Työn erottelutila: ""
+*fr.HPMailboxMode SeparatorMode/Mode Séparateur de tâche: ""
+*it.HPMailboxMode SeparatorMode/modalità Separatore processi: ""
+*ja.HPMailboxMode SeparatorMode/ジョブ仕分けモード: ""
+*ko.HPMailboxMode SeparatorMode/작업 분리기 모드: ""
+*nl.HPMailboxMode SeparatorMode/Modus voor taakscheiding: ""
+*nb.HPMailboxMode SeparatorMode/Jobbskillingsmodus: ""
+*pt.HPMailboxMode SeparatorMode/Modo de separador de trabalhos: ""
+*sv.HPMailboxMode SeparatorMode/Låget Dokumentseparation: ""
+*zh_CN.HPMailboxMode SeparatorMode/作业分隔器模式: ""
+*zh_TW.HPMailboxMode SeparatorMode/工作分隔器模式: ""
+
+*HPMailboxMode SorterCollatorMode/Sorter Collator Mode: ""
+*da.HPMailboxMode SorterCollatorMode/Sorteringsenhedstilstand: ""
+*de.HPMailboxMode SorterCollatorMode/Sortiermodus: ""
+*es.HPMailboxMode SorterCollatorMode/Modo clasificador/organizador: ""
+*fi.HPMailboxMode SorterCollatorMode/Lajittelutila: ""
+*fr.HPMailboxMode SorterCollatorMode/Mode Trieur/Classeur: ""
+*it.HPMailboxMode SorterCollatorMode/modalità Fascicolatore: ""
+*ja.HPMailboxMode SorterCollatorMode/分類/丁合いモード: ""
+*ko.HPMailboxMode SorterCollatorMode/분류기/조합기 모드: ""
+*nl.HPMailboxMode SorterCollatorMode/Modus voor sorteerder: ""
+*nb.HPMailboxMode SorterCollatorMode/Stablings-/sorteringsmodus: ""
+*pt.HPMailboxMode SorterCollatorMode/Modo de classificador/intercalador: ""
+*sv.HPMailboxMode SorterCollatorMode/Låget Dokumentsorterare: ""
+*zh_CN.HPMailboxMode SorterCollatorMode/排序器/分页器模式: ""
+*zh_TW.HPMailboxMode SorterCollatorMode/分類器/分頁器模式: ""
+
+*?HPMailboxMode: "
+currentpagedevice /OutputAttributes known{
+	currentpagedevice /MediaProcessingDetails known{
+		currentpagedevice /MediaProcessingDetails get /DeviceID known{
+			currentpagedevice /MediaProcessingDetails get /DeviceID get (HP 8-BIN MAILBOX) search
+				{pop pop pop (MBMode)}
+				  {(HP 8-BIN STACKER) search
+				  {pop pop pop (StackerMode)}
+				  {(HP 8-BIN JOB SEPARATOR) search
+				  {pop pop pop (SeparatorMode)}
+				  {(HP 8-BIN SORTER/COLLATOR) search
+				    {pop pop pop (SorterCollatorMode)} {pop (Standard)} ifelse}
+				 ifelse}
+				 ifelse}
+				 ifelse}
+			{(Standard)}
+			ifelse}
+		{(Standard)}
+		ifelse}
+	{(Standard)}
+ifelse = flush"
+*End
+*CloseUI: *HPMailboxMode
+
+*OpenUI *InstalledMemory/Total Printer Memory: PickOne
+*DefaultInstalledMemory: 64-127MB
+*da.Translation InstalledMemory/Printerhukommelse i alt: ""
+*de.Translation InstalledMemory/Druckerspeicher insgesamt: ""
+*es.Translation InstalledMemory/Memoria total de la impresora: ""
+*fi.Translation InstalledMemory/Kirjoittimen kokonaismuisti: ""
+*fr.Translation InstalledMemory/Mémoire totale de l’imprimante: ""
+*it.Translation InstalledMemory/Configurazione della memoria: ""
+*ja.Translation InstalledMemory/プリンタ総メモリ容量: ""
+*ko.Translation InstalledMemory/메모리 구성: ""
+*nl.Translation InstalledMemory/Geheugenconfiguratie: ""
+*nb.Translation InstalledMemory/Total skriverhukommelse: ""
+*pt.Translation InstalledMemory/Configuração de memória: ""
+*sv.Translation InstalledMemory/Minneskonfiguration: ""
+*zh_CN.Translation InstalledMemory/内存配置: ""
+*zh_TW.Translation InstalledMemory/記憶體設定: ""
+
+*InstalledMemory 64-127MB/64 - 127 MB: ""
+*da.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*de.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*es.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*fi.InstalledMemory 64-127MB/64 - 127 megatavua: ""
+*fr.InstalledMemory 64-127MB/64 - 127 Mo de RAM: ""
+*it.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*ja.InstalledMemory 64-127MB/64 〜 127 MB RAM: ""
+*ko.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*nl.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*nb.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*pt.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*sv.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*zh_CN.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*zh_TW.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+
+*InstalledMemory 128-255MB/128 - 255 MB: ""
+*da.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*de.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*es.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*fi.InstalledMemory 128-255MB/128 - 255 megatavua: ""
+*fr.InstalledMemory 128-255MB/128 - 255 Mo de RAM: ""
+*it.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*ja.InstalledMemory 128-255MB/128 〜 255 MB RAM: ""
+*ko.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*nl.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*nb.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*pt.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*sv.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*zh_CN.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*zh_TW.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+
+*InstalledMemory 256-383MB/256 - 383 MB: ""
+*da.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*de.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*es.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*fi.InstalledMemory 256-383MB/256 - 383 megatavua: ""
+*fr.InstalledMemory 256-383MB/256 - 383 Mo de RAM: ""
+*it.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*ja.InstalledMemory 256-383MB/256 〜 383 MB RAM: ""
+*ko.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*nl.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*nb.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*pt.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*sv.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*zh_CN.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*zh_TW.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+
+*InstalledMemory 384-512MB/384 - 512 MB: ""
+*da.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*de.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*es.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*fi.InstalledMemory 384-512MB/384 - 512 megatavua: ""
+*fr.InstalledMemory 384-512MB/384 - 512 Mo de RAM: ""
+*it.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*ja.InstalledMemory 384-512MB/384 〜 512 MB RAM: ""
+*ko.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*nl.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*nb.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*pt.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*sv.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*zh_CN.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*zh_TW.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+
+*?InstalledMemory: "
+  save
+    currentsystemparams /RamSize get
+    524288 div ceiling cvi 2 div
+    /size exch def
+    size 384 ge
+       {(384-512MB)}
+       {size 256 ge
+          {(256-383MB)}
+          {size 128 ge
+             {(128-255MB)}
+             {(64-127MB)} ifelse
+          } ifelse
+    	} ifelse = flush
+  	restore
+	"
+*End
+*CloseUI: *InstalledMemory
+
+*%=================================================
+*%		 Fit to Page
+*%=================================================
+*OpenUI *HPOption_PaperPolicy/Fit to Page: PickOne
+*OrderDependency: 10 AnySetup *HPOption_PaperPolicy
+*DefaultHPOption_PaperPolicy: PromptUser
+*da.Translation HPOption_PaperPolicy/Tilpas til siden: ""
+*de.Translation HPOption_PaperPolicy/An Seite anpassen: ""
+*es.Translation HPOption_PaperPolicy/Hacer que quepa en la hoja: ""
+*fi.Translation HPOption_PaperPolicy/Sovita sivulle: ""
+*fr.Translation HPOption_PaperPolicy/Ajuster à la page: ""
+*it.Translation HPOption_PaperPolicy/Adatta alle dimensioni della pagina: ""
+*ja.Translation HPOption_PaperPolicy/用紙のマッチング: ""
+*ko.Translation HPOption_PaperPolicy/용지 일치: ""
+*nl.Translation HPOption_PaperPolicy/Papieraanpassing: ""
+*nb.Translation HPOption_PaperPolicy/Papirtilpasning: ""
+*pt.Translation HPOption_PaperPolicy/Correspondência de papel: ""
+*sv.Translation HPOption_PaperPolicy/Pappersmatchning: ""
+*zh_CN.Translation HPOption_PaperPolicy/纸张匹配: ""
+*zh_TW.Translation HPOption_PaperPolicy/紙張相符: ""
+
+*HPOption_PaperPolicy PromptUser/Prompt User: "
+   <</DeferredMediaSelection true>> setpagedevice"
+*End
+*da.HPOption_PaperPolicy PromptUser/Spørg brugeren: ""
+*de.HPOption_PaperPolicy PromptUser/Benutzer auffordern: ""
+*es.HPOption_PaperPolicy PromptUser/Informar al usuario: ""
+*fi.HPOption_PaperPolicy PromptUser/Kysy käyttäjältä: ""
+*fr.HPOption_PaperPolicy PromptUser/Demander à l’utilisateur: ""
+*it.HPOption_PaperPolicy PromptUser/Avvisa utente: ""
+*ja.HPOption_PaperPolicy PromptUser/正しいサイズを入力するように要求: ""
+*ko.HPOption_PaperPolicy PromptUser/프롬프트 사용자: ""
+*nl.HPOption_PaperPolicy PromptUser/Gebruiker waarschuwen: ""
+*nb.HPOption_PaperPolicy PromptUser/Gi beskjed til bruker: ""
+*pt.HPOption_PaperPolicy PromptUser/Avisar usuário: ""
+*sv.HPOption_PaperPolicy PromptUser/Meddela användaren: ""
+*zh_CN.HPOption_PaperPolicy PromptUser/提示用户: ""
+*zh_TW.HPOption_PaperPolicy PromptUser/提示使用者: ""
+
+*HPOption_PaperPolicy NearestSizeAdjust/Nearest Size and Scale: "
+   <</DeferredMediaSelection false /Policies << /PageSize 3 >> >> setpagedevice"
+*End
+*da.HPOption_PaperPolicy NearestSizeAdjust/Nærmeste størrelse og skalering: ""
+*de.HPOption_PaperPolicy NearestSizeAdjust/Nächstkleineres/größeres Format mit Skalierung: ""
+*es.HPOption_PaperPolicy NearestSizeAdjust/Usar tamaño más parecido y cambiar a escala: ""
+*fi.HPOption_PaperPolicy NearestSizeAdjust/Lähin koko ja skaalaus: ""
+*fr.HPOption_PaperPolicy NearestSizeAdjust/Format et échelle les plus proches: ""
+*it.HPOption_PaperPolicy NearestSizeAdjust/Usa le dimensioni più vicine e adatta: ""
+*ja.HPOption_PaperPolicy NearestSizeAdjust/近似サイズに拡大/縮小: ""
+*ko.HPOption_PaperPolicy NearestSizeAdjust/근사 크기와 축소/확대: ""
+*nl.HPOption_PaperPolicy NearestSizeAdjust/Dichtst benaderende afmeting en schaal: ""
+*nb.HPOption_PaperPolicy NearestSizeAdjust/Nærmeste størrelse og skala: ""
+*pt.HPOption_PaperPolicy NearestSizeAdjust/Tamanho mais próximo e ajusta a escala: ""
+*sv.HPOption_PaperPolicy NearestSizeAdjust/Närmaste storlek och skala: ""
+*zh_CN.HPOption_PaperPolicy NearestSizeAdjust/最接近之尺寸和缩放度: ""
+*zh_TW.HPOption_PaperPolicy NearestSizeAdjust/最接近的尺寸並按比例縮放: ""
+
+*HPOption_PaperPolicy NearestSizeNoAdjust/Nearest Size and Crop: "
+   <</DeferredMediaSelection false /Policies << /PageSize 5 >> >> setpagedevice"
+*End
+*da.HPOption_PaperPolicy NearestSizeNoAdjust/Nærmeste størrelse og beskæring: ""
+*de.HPOption_PaperPolicy NearestSizeNoAdjust/Nächstkleineres/größeres Format mit Beschnitt: ""
+*es.HPOption_PaperPolicy NearestSizeNoAdjust/Usar tamaño más parecido y recortar: ""
+*fi.HPOption_PaperPolicy NearestSizeNoAdjust/Lähin koko ja rajaus: ""
+*fr.HPOption_PaperPolicy NearestSizeNoAdjust/Format et coupe les plus proches: ""
+*it.HPOption_PaperPolicy NearestSizeNoAdjust/Usa le dimensioni più vicine e taglia: ""
+*ja.HPOption_PaperPolicy NearestSizeNoAdjust/近似サイズにトリミング: ""
+*ko.HPOption_PaperPolicy NearestSizeNoAdjust/근사 크기와 자르기: ""
+*nl.HPOption_PaperPolicy NearestSizeNoAdjust/Dichtst benaderende grootte en trim: ""
+*nb.HPOption_PaperPolicy NearestSizeNoAdjust/Nærmeste størrelse og beskjæring: ""
+*pt.HPOption_PaperPolicy NearestSizeNoAdjust/Tamanho mais próximo e corta: ""
+*sv.HPOption_PaperPolicy NearestSizeNoAdjust/Närmaste storlek och beskär: ""
+*zh_CN.HPOption_PaperPolicy NearestSizeNoAdjust/最接近之尺寸和剪裁: ""
+*zh_TW.HPOption_PaperPolicy NearestSizeNoAdjust/最接近的尺寸並裁剪: ""
+
+*?HPOption_PaperPolicy: "(PromptUser) = flush"
+*CloseUI: *HPOption_PaperPolicy
+
+*CloseGroup: InstallableOptions
+*%The following are here for the Mac OS X Watermark plugin
+
+
+*%=================================================
+*%		 UI Constraints
+*%=================================================
+*% If A than not B  (Also include the reverse constraints if appropriate)
+*%
+*% Constraints against Installable Options
+*%-------------------------------------------------------------------------
+*UIConstraints: *HPOption_Tray1 False *InputSlot Tray1
+*UIConstraints: *HPOption_Tray1 False *ManualFeed True
+*UIConstraints: *HPOption_2000_Sheet_Tray False *InputSlot Tray4Optional
+
+*UIConstraints: *InputSlot Tray1 *HPOption_Tray1 False
+*UIConstraints: *ManualFeed True *HPOption_Tray1 False
+*UIConstraints: *InputSlot Tray4Optional *HPOption_2000_Sheet_Tray False
+
+*% Constraints on Output devices and the OutputBins
+*%-------------------------------------------------------------------
+*% Standard (Nothing Attaced)
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin Stacker
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin StackerFaceUp
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin UStapler
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin HPBooklet
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin HP8BinMB
+
+*UIConstraints: *OutputBin Stacker *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin StackerFaceUp *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin UStapler *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed Standard
+
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed Standard
+
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed Standard
+
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 1parallel
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 2parallel
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 1parallel *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 2parallel *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed Standard
+
+*% Stacker
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin UStapler
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin HP8BinMB
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin HPBooklet
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin StackerFaceUp
+
+
+*UIConstraints: *OutputBin UStapler *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *OutputBin StackerFaceUp *HPOption_MBM_Mixed MBMStacker
+
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed MBMStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed MBMStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 1parallel
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 2parallel
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 1parallel *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 2parallel *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed MBMStacker
+
+*% StaplerStacker
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *OutputBin HP8BinMB
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *OutputBin HPBooklet
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *OutputBin StackerFaceUp
+
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *OutputBin StackerFaceUp *HPOption_MBM_Mixed MBMStaplerStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed MBMStaplerStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed MBMStaplerStacker
+
+
+*% BookletMaker
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *OutputBin HP8BinMB
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *OutputBin Left
+
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *OutputBin Left *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin HPBooklet
+
+
+
+*% MultiBin Mailbox HPMBM
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin Left
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin Stacker
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin UStapler
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin HPBooklet
+
+*UIConstraints: *OutputBin Left *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *OutputBin Stacker *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *OutputBin UStapler *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed HPMultiBinMailbox
+
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 1parallel
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 2parallel
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 1parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 2parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin8
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin2 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin3 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin4 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin5 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin6 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin7 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin8 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPMailboxMode Standard
+
+*% Constraints on the Paper Sizes and Output Bins
+*%------------------------------------------------------------
+*% Trays 2, 3.
+*UIConstraints: *PageSize 12X18       *InputSlot Tray2
+*UIConstraints: *PageRegion 12X18       *InputSlot Tray2
+*UIConstraints: *PageSize 12X18       *InputSlot Tray3
+*UIConstraints: *PageRegion 12X18       *InputSlot Tray3
+*UIConstraints: *PageSize RA3       *InputSlot Tray2
+*UIConstraints: *PageRegion RA3       *InputSlot Tray2
+*UIConstraints: *PageSize RA3       *InputSlot Tray3
+*UIConstraints: *PageRegion RA3       *InputSlot Tray3
+*UIConstraints: *PageSize DoublePostcard       *InputSlot Tray2
+*UIConstraints: *PageRegion DoublePostcard       *InputSlot Tray2
+*UIConstraints: *PageSize DoublePostcard       *InputSlot Tray3
+*UIConstraints: *PageRegion DoublePostcard       *InputSlot Tray3
+*UIConstraints: *PageSize Env10       *InputSlot Tray2
+*UIConstraints: *PageRegion Env10       *InputSlot Tray2
+*UIConstraints: *PageSize Env10       *InputSlot Tray3
+*UIConstraints: *PageRegion Env10       *InputSlot Tray3
+*UIConstraints: *PageSize EnvMonarch  *InputSlot Tray2
+*UIConstraints: *PageRegion EnvMonarch  *InputSlot Tray2
+*UIConstraints: *PageSize EnvMonarch  *InputSlot Tray3
+*UIConstraints: *PageRegion EnvMonarch  *InputSlot Tray3
+*UIConstraints: *PageSize EnvDL       *InputSlot Tray2
+*UIConstraints: *PageRegion EnvDL       *InputSlot Tray2
+*UIConstraints: *PageSize EnvDL       *InputSlot Tray3
+*UIConstraints: *PageRegion EnvDL       *InputSlot Tray3
+*UIConstraints: *PageSize EnvC5       *InputSlot Tray2
+*UIConstraints: *PageRegion EnvC5       *InputSlot Tray2
+*UIConstraints: *PageSize EnvC5       *InputSlot Tray3
+*UIConstraints: *PageRegion EnvC5       *InputSlot Tray3
+*UIConstraints: *PageSize EnvISOB5    *InputSlot Tray2
+*UIConstraints: *PageRegion EnvISOB5    *InputSlot Tray2
+*UIConstraints: *PageSize EnvISOB5    *InputSlot Tray3
+*UIConstraints: *PageRegion EnvISOB5    *InputSlot Tray3
+
+*UIConstraints: *InputSlot Tray2	  *PageSize 12X18
+*UIConstraints: *InputSlot Tray2	  *PageRegion 12X18
+*UIConstraints: *InputSlot Tray3	  *PageSize 12X18
+*UIConstraints: *InputSlot Tray3	  *PageRegion 12X18
+*UIConstraints: *InputSlot Tray2	  *PageSize RA3
+*UIConstraints: *InputSlot Tray2	  *PageRegion RA3
+*UIConstraints: *InputSlot Tray3	  *PageSize RA3
+*UIConstraints: *InputSlot Tray3	  *PageRegion RA3
+*UIConstraints: *InputSlot Tray2	  *PageSize DoublePostcard
+*UIConstraints: *InputSlot Tray2	  *PageRegion DoublePostcard
+*UIConstraints: *InputSlot Tray3	  *PageSize DoublePostcard
+*UIConstraints: *InputSlot Tray3	  *PageRegion DoublePostcard
+*UIConstraints: *InputSlot Tray2	  *PageSize Env10
+*UIConstraints: *InputSlot Tray2	  *PageRegion Env10
+*UIConstraints: *InputSlot Tray3	  *PageSize Env10
+*UIConstraints: *InputSlot Tray3	  *PageRegion Env10
+*UIConstraints: *InputSlot Tray2      *PageSize EnvMonarch
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvMonarch
+*UIConstraints: *InputSlot Tray3      *PageSize EnvMonarch
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvMonarch
+*UIConstraints: *InputSlot Tray2      *PageSize EnvDL
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvDL
+*UIConstraints: *InputSlot Tray3      *PageSize EnvDL
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvDL
+*UIConstraints: *InputSlot Tray2      *PageSize EnvC5
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvC5
+*UIConstraints: *InputSlot Tray3      *PageSize EnvC5
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvC5
+*UIConstraints: *InputSlot Tray2      *PageSize EnvISOB5
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvISOB5
+*UIConstraints: *InputSlot Tray3      *PageSize EnvISOB5
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvISOB5
+
+*% Tray 4 (Supports only A4 and Letter sizes).
+
+*UIConstraints: *PageSize HalfLetter      *InputSlot Tray4Optional
+*UIConstraints: *PageRegion HalfLetter    *InputSlot Tray4Optional
+*UIConstraints: *PageSize 12X18        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion 12X18      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize RA3        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion RA3      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize A5        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion A5      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize DoublePostcard  *InputSlot Tray4Optional
+*UIConstraints: *PageRegion DoublePostcard *InputSlot Tray4Optional
+*UIConstraints: *PageSize Env10        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion Env10      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvMonarch    	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvMonarch  	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvC5        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvC5      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvDL        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvDL      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvISOB5      	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvISOB5    	*InputSlot Tray4Optional
+
+*UIConstraints: *InputSlot Tray4Optional	*PageSize HalfLetter
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion HalfLetter
+*UIConstraints: *InputSlot Tray4Optional	*PageSize 12X18
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion 12X18
+*UIConstraints: *InputSlot Tray4Optional	*PageSize A3
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion A3
+*UIConstraints: *InputSlot Tray4Optional	*PageSize RA3
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion RA3
+*UIConstraints: *InputSlot Tray4Optional	*PageSize A5
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion A5
+*UIConstraints: *InputSlot Tray4Optional	*PageSize DoublePostcard
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion DoublePostcard
+*UIConstraints: *InputSlot Tray4Optional	*PageSize Env10
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion Env10
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvMonarch
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvMonarch
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvC5
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvC5
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvDL
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvDL
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvISOB5
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvISOB5
+
+*% MBMStacker and MBMStaplerStacker, HPBooklet and Mailbox which all use the  OutputBin Stacker
+
+*HPConstraints: *HPBookletFilter False *PageSize DoublePostcard *OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageRegion DoublePostcard *OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageSize Env10 		*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageRegion Env10		*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageSize EnvMonarch	*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageRegion EnvMonarch	*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageSize EnvC5			*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageRegion EnvC5		*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageSize EnvDL			*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageRegion EnvDL		*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageSize EnvISOB5		*OutputBin Stacker
+*HPConstraints: *HPBookletFilter False *PageRegion EnvISOB5	*OutputBin Stacker
+
+*% Duplex Constraints
+*%--------------------------------------------------------------------
+*UIConstraints: *PageSize DoublePostcard	*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion DoublePostcard *Duplex DuplexNoTumble
+*UIConstraints: *PageSize Env10		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion Env10         *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvMonarch	*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvMonarch    *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvDL		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvDL         *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvC5		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvC5         *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvISOB5		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvISOB5      *Duplex DuplexNoTumble
+
+*UIConstraints: *PageSize DoublePostcard  *Duplex DuplexTumble
+*UIConstraints: *PageRegion DoublePostcard *Duplex DuplexTumble
+*UIConstraints: *PageSize Env10           *Duplex DuplexTumble
+*UIConstraints: *PageRegion Env10         *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvMonarch      *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvMonarch    *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvDL           *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvDL         *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvC5           *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvC5         *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvISOB5        *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvISOB5      *Duplex DuplexTumble
+
+*UIConstraints: *Duplex DuplexNoTumble 	*PageSize DoublePostcard
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion DoublePostcard
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize Env10
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion Env10
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvMonarch
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvMonarch
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvDL
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvDL
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvC5
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvC5
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvISOB5
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvISOB5
+
+*UIConstraints: *Duplex DuplexTumble	*PageSize DoublePostcard
+*UIConstraints: *Duplex DuplexTumble	*PageRegion DoublePostcard
+*UIConstraints: *Duplex DuplexTumble	*PageSize Env10
+*UIConstraints: *Duplex DuplexTumble	*PageRegion Env10
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvMonarch
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvMonarch
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvDL
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvDL
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvC5
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvC5
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvISOB5
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvISOB5
+
+*% Constrain Stapling to the stapling bin (Output Destination and Stapler Option Menus)
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin PrinterDefault
+
+*UIConstraints: *OutputBin Left *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin Left *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin Left *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin Left *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin Left *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin Left
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin Left
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin Left
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin Left
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin Left
+
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin Upper
+
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin Stacker
+
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin StackerFaceUp
+
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin HP8BinMB
+
+*% Booklet Bin
+
+
+*% Collate
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 1diagonal
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 1parallel
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 2parallel
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 3parallel
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 6parallel
+
+
+*% Constrain Stapling to the stapling bin (Output Destination and Stapler Option Menus)
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin1
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin2
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin3
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin4
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin5
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin6
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin7
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin8
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 6parallel
+
+*% Constrained PageSizes (Constrains Stacker/Stapler/and Mailbox attachments)
+*HPConstraints: *HPBookletFilter False *PageSize DoublePostcard   *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageRegion DoublePostcard *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageSize Env10        *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageRegion Env10      *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageSize EnvMonarch   *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageRegion EnvMonarch *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageSize EnvDL        *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageRegion EnvDL      *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageSize EnvC5        *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageRegion EnvC5      *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageSize EnvISOB5     *OutputBin UStapler
+*HPConstraints: *HPBookletFilter False *PageRegion EnvISOB5   *OutputBin UStapler
+
+
+*% Booklet Bin
+*HPConstraints: *HPBookletFilter False *PageSize Executive   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion Executive *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize HalfLetter   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion HalfLetter *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize w612h935   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion w612h935 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize 12X18   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion 12X18 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize A5   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion A5 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize RA3   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion RA3 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize B5   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion B5 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize w612h936   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion w612h936 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize DoublePostcard   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion DoublePostcard *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize w558h774   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion w558h774 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize w774h1116   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion w774h1116 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize Env10   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion Env10 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize EnvMonarch   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion EnvMonarch *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize EnvDL   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion EnvDL *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize EnvC5   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion EnvC5 *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageSize EnvISOB5   *OutputBin HPBooklet
+*HPConstraints: *HPBookletFilter False *PageRegion EnvISOB5 *OutputBin HPBooklet
+
+
+*% Force Output destination to MailBox  if any of the Mailbox options are choosen
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin PrinterDefault
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin Upper
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin Left
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin StackerFaceUp
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin Stacker
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin UStapler
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin HPBooklet
+
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin1_8
+
+*% Media types
+*%------------------------------------------------------
+*% Trays 2,3 or 4
+*UIConstraints: *InputSlot Tray2 *MediaType Envelope
+*UIConstraints: *InputSlot Tray3 *MediaType Envelope
+*UIConstraints: *InputSlot Tray4Optional *MediaType Envelope
+
+*UIConstraints: *MediaType Envelope *InputSlot Tray2
+*UIConstraints: *MediaType Envelope *InputSlot Tray3
+*UIConstraints: *MediaType Envelope *InputSlot Tray4Optional
+
+*UIConstraints: *InputSlot Tray2 *MediaType Labels
+*UIConstraints: *InputSlot Tray3 *MediaType Labels
+*UIConstraints: *InputSlot Tray4Optional *MediaType Labels
+
+*UIConstraints: *MediaType Labels *InputSlot Tray2
+*UIConstraints: *MediaType Labels *InputSlot Tray3
+*UIConstraints: *MediaType Labels *InputSlot Tray4Optional
+
+*% Duplex
+*UIConstraints: *MediaType Transparency *Duplex DuplexNoTumble
+*UIConstraints: *MediaType Labels       *Duplex DuplexNoTumble
+*UIConstraints: *MediaType Envelope     *Duplex DuplexNoTumble
+*UIConstraints: *Duplex DuplexNoTumble	*MediaType Transparency
+*UIConstraints: *Duplex DuplexNoTumble	*MediaType Labels
+*UIConstraints: *Duplex DuplexNoTumble	*MediaType Envelope
+
+*UIConstraints: *MediaType Transparency *Duplex DuplexTumble
+*UIConstraints: *MediaType Labels       *Duplex DuplexTumble
+*UIConstraints: *MediaType Envelope     *Duplex DuplexTumble
+*UIConstraints: *Duplex DuplexTumble	*MediaType Transparency
+*UIConstraints: *Duplex DuplexTumble	*MediaType Labels
+*UIConstraints: *Duplex DuplexTumble	*MediaType Envelope
+
+*% Face up Stacker bin for Stacker, Stapler, Booklet Maker
+*UIConstraints: *OutputBin Stacker *MediaType Labels
+*UIConstraints: *OutputBin Stacker *MediaType Transparency
+*UIConstraints: *OutputBin Stacker *MediaType Rough
+*UIConstraints: *OutputBin Stacker *MediaType Envelope
+
+*UIConstraints: *MediaType Labels *OutputBin Stacker
+*UIConstraints: *MediaType Transparency *OutputBin Stacker
+*UIConstraints: *MediaType Rough *OutputBin Stacker
+*UIConstraints: *MediaType Envelope *OutputBin Stacker
+
+*% Stapler
+*UIConstraints: *OutputBin UStapler *MediaType Labels
+*UIConstraints: *OutputBin UStapler *MediaType Envelope
+*UIConstraints: *OutputBin UStapler *MediaType Transparency
+
+*UIConstraints: *MediaType Labels *OutputBin UStapler
+*UIConstraints: *MediaType Envelope *OutputBin UStapler
+*UIConstraints: *MediaType Transparency *OutputBin UStapler
+
+*% Booklet bin
+*UIConstraints: *OutputBin HPBooklet *MediaType Transparency
+*UIConstraints: *OutputBin HPBooklet *MediaType Labels
+*UIConstraints: *OutputBin HPBooklet *MediaType Envelope
+
+*UIConstraints: *MediaType Transparency *OutputBin HPBooklet
+*UIConstraints: *MediaType Labels *OutputBin HPBooklet
+*UIConstraints: *MediaType Envelope *OutputBin HPBooklet
+
+*% Can't staple Custom sizes in the Booklet Maker, Booklet Bin or Tray 4)
+*%---------------------------------------------------------------------
+*NonUIConstraints: *CustomPageSize True *OutputBin HPBooklet
+*NonUIConstraints: *OutputBin HPBooklet *CustomPageSize True
+
+
+
+*% Contraints on Mailbox Mode and the Mailbox Bins
+*%---------------------------------------------------
+*%Mailbox Mode
+*UIConstraints: *HPMailboxMode MBMode *HPMailboxOptions Bin1_8
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPMailboxMode MBMode
+
+*% Stacker Mode
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin2 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin3 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin4 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin5 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin6 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin7 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin8 *HPMailboxMode StackerMode
+
+*% Separator Mode
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin2 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin3 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin4 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin5 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin6 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin7 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin8 *HPMailboxMode SeparatorMode
+
+*% Sorter Collator Mode
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin2 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin3 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin4 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin5 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin6 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin7 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin8 *HPMailboxMode SorterCollatorMode
+
+*% Fills not allowed with overlays
+*%=============================================
+*UIConstraints: *HPwmSwitch Overlay *HPwmTextStyle Fill
+*UIConstraints: *HPwmTextStyle Fill *HPwmSwitch Overlay
+*% Halo style does not work with Watermarks
+*UIConstraints: *HPwmSwitch Watermark *HPwmTextStyle Halo
+*UIConstraints: *HPwmTextStyle Halo *HPwmSwitch Watermark
+
+
+*% ### The following lines are left in for visibility but commented out because though it
+*% ### seems like requiring a PIN for a private job is the thing to do, the way it works
+*% ### from the driver is very annoying. If you select a Private Job the UI constraint
+*% ### immediately presents an alert saying that you must have a PIN without giving the
+*% ### user a chance to even get to the PIN field yet. It would be nice if the alert were
+*% ### presented when the Print button is pushed, but it isn't.
+*% PIN is required when Job Retention is HPJobRetentionPrivate or HPJobRetentionPrivateStore
+*%Job Retention not allowed unless printer has a hard disk
+*UIConstraints: *HPOption_Disk None *HPJobRetentionOption HPJobRetentionQuickCopy
+*UIConstraints: *HPOption_Disk None *HPJobRetentionOption HPJobRetentionStore
+*UIConstraints: *HPOption_Disk RAMDisk *HPJobRetentionOption HPJobRetentionQuickCopy
+*UIConstraints: *HPOption_Disk RAMDisk *HPJobRetentionOption HPJobRetentionStore
+
+
+*% ===================================
+*OpenGroup: HPJobRetention/Job Storage
+*da.Translation HPJobRetention/Joblagring: ""
+*de.Translation HPJobRetention/Jobspeicherung: ""
+*es.Translation HPJobRetention/Almacenamiento de trabajos: ""
+*fi.Translation HPJobRetention/Työn säilytys: ""
+*fr.Translation HPJobRetention/Stockage des tâches: ""
+*it.Translation HPJobRetention/Memorizzazione processo: ""
+*ja.Translation HPJobRetention/ジョブ保存: ""
+*ko.Translation HPJobRetention/작업 저장: ""
+*nl.Translation HPJobRetention/Taakopslag: ""
+*nb.Translation HPJobRetention/Jobblagring: ""
+*pt.Translation HPJobRetention/Armazenamento de trabalhos: ""
+*sv.Translation HPJobRetention/Lagra utskrift: ""
+*zh_CN.Translation HPJobRetention/作业存储: ""
+*zh_TW.Translation HPJobRetention/工作儲存: ""
+
+
+*% =================================
+*% Job Retention
+*% =================================
+*% The UserName setting is obtained from the print job. This may not work on non-Mac drivers.
+*OpenUI *HPJobRetentionOption/Mode: PickOne
+*OrderDependency: 13 Prolog *HPJobRetentionOption
+*DefaultHPJobRetentionOption: HPJobRetentionOff
+*da.Translation HPJobRetentionOption/Tilstand: ""
+*de.Translation HPJobRetentionOption/Modus: ""
+*es.Translation HPJobRetentionOption/Modo: ""
+*fi.Translation HPJobRetentionOption/Tila: ""
+*fr.Translation HPJobRetentionOption/Mode: ""
+*it.Translation HPJobRetentionOption/Modalità: ""
+*ja.Translation HPJobRetentionOption/モード: ""
+*ko.Translation HPJobRetentionOption/모드: ""
+*nl.Translation HPJobRetentionOption/Modus: ""
+*nb.Translation HPJobRetentionOption/Modus: ""
+*pt.Translation HPJobRetentionOption/Modo: ""
+*sv.Translation HPJobRetentionOption/Läge: ""
+*zh_CN.Translation HPJobRetentionOption/模式: ""
+*zh_TW.Translation HPJobRetentionOption/模式: ""
+
+*HPJobRetentionOption HPJobRetentionQuickCopy/Quick Copy: "
+	<< /Collate true /CollateDetails
+		<< /Type 8 /Hold 1 >>
+	>> setpagedevice
+"
+*End
+*da.HPJobRetentionOption HPJobRetentionQuickCopy/Hurtig kopi: ""
+*de.HPJobRetentionOption HPJobRetentionQuickCopy/Schnellkopie: ""
+*es.HPJobRetentionOption HPJobRetentionQuickCopy/Copia rápida: ""
+*fi.HPJobRetentionOption HPJobRetentionQuickCopy/Pikakopio: ""
+*fr.HPJobRetentionOption HPJobRetentionQuickCopy/Copie rapide: ""
+*it.HPJobRetentionOption HPJobRetentionQuickCopy/Copia veloce: ""
+*ja.HPJobRetentionOption HPJobRetentionQuickCopy/クイックコピー: ""
+*ko.HPJobRetentionOption HPJobRetentionQuickCopy/고속 복사: ""
+*nl.HPJobRetentionOption HPJobRetentionQuickCopy/Snelkopiëren: ""
+*nb.HPJobRetentionOption HPJobRetentionQuickCopy/Hurtigkopi: ""
+*pt.HPJobRetentionOption HPJobRetentionQuickCopy/Cópia rápida: ""
+*sv.HPJobRetentionOption HPJobRetentionQuickCopy/Snabbkopiering: ""
+*zh_CN.HPJobRetentionOption HPJobRetentionQuickCopy/快速拷贝: ""
+*zh_TW.HPJobRetentionOption HPJobRetentionQuickCopy/快速拷貝: ""
+
+*HPJobRetentionOption HPJobRetentionProof/Proof and Hold: "
+	<< /Collate true /CollateDetails
+		<< /Type 8 /Hold 3 >>
+	>> setpagedevice
+"
+*End
+*da.HPJobRetentionOption HPJobRetentionProof/Udskriv korrekturkopi og tilbagehold job: ""
+*de.HPJobRetentionOption HPJobRetentionProof/Prüfen und aufbewahren: ""
+*es.HPJobRetentionOption HPJobRetentionProof/Imprimir galerada y esperar: ""
+*fi.HPJobRetentionOption HPJobRetentionProof/Tarkista ja säilytä: ""
+*fr.HPJobRetentionOption HPJobRetentionProof/Mise en attente après la 1ère page: ""
+*it.HPJobRetentionOption HPJobRetentionProof/Prova e trattieni: ""
+*ja.HPJobRetentionOption HPJobRetentionProof/校正用印刷: ""
+*ko.HPJobRetentionOption HPJobRetentionProof/교정쇄 및 보유: ""
+*nl.HPJobRetentionOption HPJobRetentionProof/Controleren en aanhouden: ""
+*nb.HPJobRetentionOption HPJobRetentionProof/Korrektur og hold: ""
+*pt.HPJobRetentionOption HPJobRetentionProof/Prova com espera: ""
+*sv.HPJobRetentionOption HPJobRetentionProof/Korrektur och vänta: ""
+*zh_CN.HPJobRetentionOption HPJobRetentionProof/审校待打印: ""
+*zh_TW.HPJobRetentionOption HPJobRetentionProof/校對和暫停: ""
+
+*HPJobRetentionOption HPJobRetentionStore/Stored Job: "
+	<< /Collate true /CollateDetails
+		<< /Type 8 /Hold 2 >>
+	>> setpagedevice
+"
+*End
+*da.HPJobRetentionOption HPJobRetentionStore/Lagret job: ""
+*de.HPJobRetentionOption HPJobRetentionStore/Gespeicherter Job: ""
+*es.HPJobRetentionOption HPJobRetentionStore/Trabajo almacenado: ""
+*fi.HPJobRetentionOption HPJobRetentionStore/Tallennettu työ: ""
+*fr.HPJobRetentionOption HPJobRetentionStore/Tâche en mémoire: ""
+*it.HPJobRetentionOption HPJobRetentionStore/Processo memorizzato: ""
+*ja.HPJobRetentionOption HPJobRetentionStore/保存ジョブ: ""
+*ko.HPJobRetentionOption HPJobRetentionStore/인쇄 작업 저장: ""
+*nl.HPJobRetentionOption HPJobRetentionStore/Opgeslagen taak: ""
+*nb.HPJobRetentionOption HPJobRetentionStore/Lagret jobb: ""
+*pt.HPJobRetentionOption HPJobRetentionStore/Trabalho armazenado: ""
+*sv.HPJobRetentionOption HPJobRetentionStore/Lagrad utskrift: ""
+*zh_CN.HPJobRetentionOption HPJobRetentionStore/存储的作业: ""
+*zh_TW.HPJobRetentionOption HPJobRetentionStore/已儲存的列印: ""
+
+
+*HPJobRetentionOption HPJobRetentionPrivate/Private Job: "
+	<< /Collate true /CollateDetails
+		<< /Type 8 /Hold 1 /HoldType 1 >>
+	>> setpagedevice
+"
+*End
+*da.HPJobRetentionOption HPJobRetentionPrivate/Privat job: ""
+*de.HPJobRetentionOption HPJobRetentionPrivate/Privater Job: ""
+*es.HPJobRetentionOption HPJobRetentionPrivate/Trabajo privado: ""
+*fi.HPJobRetentionOption HPJobRetentionPrivate/Yksityinen työ: ""
+*fr.HPJobRetentionOption HPJobRetentionPrivate/Tâche personnelle: ""
+*it.HPJobRetentionOption HPJobRetentionPrivate/Processo privato: ""
+*ja.HPJobRetentionOption HPJobRetentionPrivate/プライベート ジョブ: ""
+*ko.HPJobRetentionOption HPJobRetentionPrivate/PIN 필요 작업: ""
+*nl.HPJobRetentionOption HPJobRetentionPrivate/Privétaak: ""
+*nb.HPJobRetentionOption HPJobRetentionPrivate/Privat jobb: ""
+*pt.HPJobRetentionOption HPJobRetentionPrivate/Trabalho particular: ""
+*sv.HPJobRetentionOption HPJobRetentionPrivate/Privat utskrift: ""
+*zh_CN.HPJobRetentionOption HPJobRetentionPrivate/私人的作业: ""
+*zh_TW.HPJobRetentionOption HPJobRetentionPrivate/個人的工作: ""
+
+
+*HPJobRetentionOption HPJobRetentionOff/Off: "
+	<< /CollateDetails
+	<< /Type 8 /Hold 0 >> >> setpagedevice
+"
+*End
+*da.HPJobRetentionOption HPJobRetentionOff/Fra: ""
+*de.HPJobRetentionOption HPJobRetentionOff/Aus: ""
+*es.HPJobRetentionOption HPJobRetentionOff/No: ""
+*fi.HPJobRetentionOption HPJobRetentionOff/Ei: ""
+*fr.HPJobRetentionOption HPJobRetentionOff/Désactivé: ""
+*it.HPJobRetentionOption HPJobRetentionOff/Disattivata: ""
+*ja.HPJobRetentionOption HPJobRetentionOff/オフ: ""
+*ko.HPJobRetentionOption HPJobRetentionOff/끄기: ""
+*nl.HPJobRetentionOption HPJobRetentionOff/Uit: ""
+*nb.HPJobRetentionOption HPJobRetentionOff/Av: ""
+*pt.HPJobRetentionOption HPJobRetentionOff/Desligado: ""
+*sv.HPJobRetentionOption HPJobRetentionOff/Av: ""
+*zh_CN.HPJobRetentionOption HPJobRetentionOff/关: ""
+*zh_TW.HPJobRetentionOption HPJobRetentionOff/關: ""
+
+*CloseUI: *HPJobRetentionOption
+
+*% ================= Job Storage Descriptions ====================
+*HPJobRetentionOptionDS HPJobRetentionQuickCopy: HPJOBRETENTIONOPTION_QUICKCOPY_DS
+
+*HPJobRetentionOptionDS HPJobRetentionProof: HPJOBRETENTIONOPTION_PROOFANDPRINT_DS
+
+*HPJobRetentionOptionDS HPJobRetentionStore: HPJOBRETENTIONOPTION_STOREDJOB_DS
+
+*HPJobRetentionOptionDS HPJobRetentionPrivate: HPJOBRETENTIONOPTION_PRIVATE_DS
+
+*HPJobRetentionOptionDS HPJobRetentionOff: HPJOBRETENTIONOPTION_OFF_DS
+
+*% ===========================================================
+*OpenUI *HPDuplicateJobMode/If Job Name Exists: PickOne
+*OrderDependency: 14 Prolog *HPDuplicateJobMode
+*DefaultHPDuplicateJobMode: Unique
+*da.Translation HPDuplicateJobMode/Hvis jobnavn findes: ""
+*de.Translation HPDuplicateJobMode/Bei bereits vorhandenem Jobnamen gilt: ""
+*es.Translation HPDuplicateJobMode/Si el nombre de trabajo ya existe: ""
+*fi.Translation HPDuplicateJobMode/Jos työn nimi on olemassa: ""
+*fr.Translation HPDuplicateJobMode/Si le nom de tâche existe: ""
+*it.Translation HPDuplicateJobMode/Se esiste nome processo: ""
+*ja.Translation HPDuplicateJobMode/ジョブ名が存在する場合: ""
+*ko.Translation HPDuplicateJobMode/작업명이 있는 경우: ""
+*nl.Translation HPDuplicateJobMode/Als taaknaam bestaat: ""
+*nb.Translation HPDuplicateJobMode/Hvis jobbnavn finnes: ""
+*pt.Translation HPDuplicateJobMode/Se o nome do trabalho existir: ""
+*sv.Translation HPDuplicateJobMode/Om utskriftsnamn finns: ""
+*zh_CN.Translation HPDuplicateJobMode/如果作业名存在: ""
+*zh_TW.Translation HPDuplicateJobMode/如果工作名稱存在: ""
+
+
+*HPDuplicateJobMode Unique/Use Job Name + (1-99): "
+	<< /CollateDetails << /Type 8 /DuplicateJob 0 >> >> setpagedevice
+"
+*End
+*da.HPDuplicateJobMode Unique/Brug jobnavn + (1-99): ""
+*de.HPDuplicateJobMode Unique/Jobnamen + (1-99) verwenden: ""
+*es.HPDuplicateJobMode Unique/Añadir número (1-99) al nombre: ""
+*fi.HPDuplicateJobMode Unique/Käytä työn nimeä + (1-99): ""
+*fr.HPDuplicateJobMode Unique/Ajouter + (1-99) au nom de tâche: ""
+*it.HPDuplicateJobMode Unique/Aggiungi (1-99) a nome processo: ""
+*ja.HPDuplicateJobMode Unique/ジョブ名と数字 (1〜99) を使用: ""
+*ko.HPDuplicateJobMode Unique/작업명 + (1-99) 사용: ""
+*nl.HPDuplicateJobMode Unique/Gebruik taaknaam + (1-99): ""
+*nb.HPDuplicateJobMode Unique/Bruk jobbnavn + (1-99): ""
+*pt.HPDuplicateJobMode Unique/Usar nome do trabalho + (1-99): ""
+*sv.HPDuplicateJobMode Unique/Använd utskriftsnamn + (1-99): ""
+*zh_CN.HPDuplicateJobMode Unique/使用作业名 + (1-99): ""
+*zh_TW.HPDuplicateJobMode Unique/使用工作名稱 + (1-99): ""
+
+*HPDuplicateJobMode Overwrite/Replace Existing File: "
+	<< /CollateDetails << /Type 8 /DuplicateJob 1 >> >> setpagedevice
+"
+*End
+*da.HPDuplicateJobMode Overwrite/Erstat eksisterende fil: ""
+*de.HPDuplicateJobMode Overwrite/Vorhandene Datei ersetzen: ""
+*es.HPDuplicateJobMode Overwrite/Sustituir el archivo existente: ""
+*fi.HPDuplicateJobMode Overwrite/Korvaa aiempi tiedosto: ""
+*fr.HPDuplicateJobMode Overwrite/Remplacer le fichier existant: ""
+*it.HPDuplicateJobMode Overwrite/Sostituisci file esistente: ""
+*ja.HPDuplicateJobMode Overwrite/既存のファイルを置換: ""
+*ko.HPDuplicateJobMode Overwrite/기존 파일 바꾸기: ""
+*nl.HPDuplicateJobMode Overwrite/Bestaand bestand vervangen: ""
+*nb.HPDuplicateJobMode Overwrite/Erstatt eksisterende fil: ""
+*pt.HPDuplicateJobMode Overwrite/Substituir arquivo existente: ""
+*sv.HPDuplicateJobMode Overwrite/Ersätt befintlig fil: ""
+*zh_CN.HPDuplicateJobMode Overwrite/替换现有文件: ""
+*zh_TW.HPDuplicateJobMode Overwrite/更換現有檔案: ""
+
+*CloseUI: *HPDuplicateJobMode
+
+*OpenUI *HPUserName/User Name: PickOne
+*% The UserName setting is obtained from the print job. This will not work unchanged on non-Mac drivers.
+*% The PS code has been written to put in default user and job names if they are not available from the job.
+*% User specification of UserName works only with LW 8.5.1 or later. It will not work with non-Mac drivers.
+*% If the driver does not support text entry UI the UserName will always be obtained from the print job.
+*% The user is allowed to set the user name to allow organization of jobs in the printer.
+*% For example, all forms could be stored under UserName "Forms".
+*OrderDependency: 15 Prolog *HPUserName
+*DefaultHPUserName: FileSharingName
+*da.Translation HPUserName/Brugernavn: ""
+*de.Translation HPUserName/Benutzername: ""
+*es.Translation HPUserName/Nombre de usuario: ""
+*fi.Translation HPUserName/Käyttäjänimi: ""
+*fr.Translation HPUserName/Nom d’utilisateur: ""
+*it.Translation HPUserName/Nome utente: ""
+*ja.Translation HPUserName/ﾕｰｻﾞｰ名: ""
+*ko.Translation HPUserName/사용자 이름: ""
+*nl.Translation HPUserName/Gebruikersnaam: ""
+*nb.Translation HPUserName/Brukernavn: ""
+*pt.Translation HPUserName/Nome do usuário: ""
+*sv.Translation HPUserName/Användarnamn: ""
+*zh_CN.Translation HPUserName/用户名称: ""
+*zh_TW.Translation HPUserName/使用者名稱: ""
+
+*HPUserName FileSharingName/Use file sharing name: "
+	<< /CollateDetails
+		<< /Type 8
+			/UserName /dscInfo where
+				{ /dscInfo get dup /For known
+					{/For get}
+					{pop (No User Name)} ifelse}
+				{(No User Name)}ifelse
+			dup length 80 gt { 0 80 getinterval } if
+			dup true exch { 32 eq not { false exch pop } if } forall
+			{ pop (No User Name) } if
+			0 1 2 index length 1 sub
+			{ dup 2 index exch get dup 97 ge 1 index 122 le and
+				{ 32 sub 2 index 3 1 roll put }
+				{ pop pop } ifelse
+			} for
+		>>
+	>> setpagedevice
+"
+*End
+*da.HPUserName FileSharingName/Brug arkivdelingsnavn: ""
+*de.HPUserName FileSharingName/Name für File Sharing verwenden: ""
+*es.HPUserName FileSharingName/Utilizar el nombre de Archivos compartidos: ""
+*fi.HPUserName FileSharingName/Käytä tiedostojakonimeä: ""
+*fr.HPUserName FileSharingName/Utiliser nom de partage de fichiers: ""
+*it.HPUserName FileSharingName/Usa nome di Condivisione: ""
+*ja.HPUserName FileSharingName/ﾌｧｲﾙ共有名を使用: ""
+*ko.HPUserName FileSharingName/파일 공유 이름 사용: ""
+*nl.HPUserName FileSharingName/Gebruik naam van samen gebruikte bestanden: ""
+*nb.HPUserName FileSharingName/Bruk fildelingsnavn: ""
+*pt.HPUserName FileSharingName/Use o nome de Compartilhamento de Arquivos: ""
+*sv.HPUserName FileSharingName/Använd fildelningsnamn: ""
+*zh_CN.HPUserName FileSharingName/使用文件共享名: ""
+*zh_TW.HPUserName FileSharingName/使用檔案分享名稱: ""
+
+*HPUserName Forms/Forms: "
+	<< /CollateDetails
+		<< /Type 8
+			/UserName (Forms)
+			0 1 2 index length 1 sub
+			{ dup 2 index exch get dup 97 ge 1 index 122 le and
+				{ 32 sub 2 index 3 1 roll put }
+				{ pop pop } ifelse
+			} for
+		>>
+	>> setpagedevice
+"
+*End
+*da.HPUserName Forms/Formularer: ""
+*de.HPUserName Forms/Formulare: ""
+*es.HPUserName Forms/Fomularios: ""
+*fi.HPUserName Forms/Lomakkeet: ""
+*fr.HPUserName Forms/Formulaires: ""
+*it.HPUserName Forms/Moduli: ""
+*ja.HPUserName Forms/ﾌｫｰﾑ: ""
+*ko.HPUserName Forms/양식: ""
+*nl.HPUserName Forms/Formulieren: ""
+*nb.HPUserName Forms/Skjemaer: ""
+*pt.HPUserName Forms/Formulários: ""
+*sv.HPUserName Forms/Blanketter: ""
+*zh_CN.HPUserName Forms/表格: ""
+*zh_TW.HPUserName Forms/表格: ""
+
+*HPUserName Set/Custom User Name: "
+	<< /CollateDetails
+		<< /Type 8
+			/UserName /dscInfo where
+				{ /dscInfo get dup /For known
+					{/For get}
+					{pop (No User Name)} ifelse}
+				{(No User Name)}ifelse
+			dup length 80 gt { 0 80 getinterval } if
+			dup true exch { 32 eq not { false exch pop } if } forall
+			{ pop (No User Name) } if
+			0 1 2 index length 1 sub
+			{ dup 2 index exch get dup 97 ge 1 index 122 le and
+				{ 32 sub 2 index 3 1 roll put }
+				{ pop pop } ifelse
+			} for
+		>>
+	>> setpagedevice
+"
+*End
+*da.HPUserName Set/Brugerdefineret brugernavn: ""
+*de.HPUserName Set/Angepaßter Benutzername: ""
+*es.HPUserName Set/Nombre de usuario personalizado: ""
+*fi.HPUserName Set/Mukautettu käyttäjänimi: ""
+*fr.HPUserName Set/Nom d’utilisateur personnalisé: ""
+*it.HPUserName Set/Nome utente personalizzato: ""
+*ja.HPUserName Set/ｶｽﾀﾑ ﾕｰｻﾞｰ名: ""
+*ko.HPUserName Set/사용자 정의 사용자 이름: ""
+*nl.HPUserName Set/Speciale gebruikersnaam: ""
+*nb.HPUserName Set/Egendefinert brukernavn: ""
+*pt.HPUserName Set/Nome do usuário personalizado: ""
+*sv.HPUserName Set/Anpassat användarnamn: ""
+*zh_CN.HPUserName Set/自定义用户名称: ""
+*zh_TW.HPUserName Set/自訂使用者名稱: ""
+
+*CloseUI: *HPUserName
+
+*OpenUI *HPJobName/Job Name: PickOne
+*% The JobMgrName setting is obtained from the print job. This may not work on non-Mac drivers.
+*% User specification of Jobname works only with LW 8.5.1 or later. It will not work with non-Mac drivers.
+*% If the driver does not support text entry UI the JobMgrName will always be obtained from the print job.
+*OrderDependency: 16 Prolog *HPJobName
+*DefaultHPJobName: DocName
+*da.Translation HPJobName/Jobnavn: ""
+*de.Translation HPJobName/Jobname: ""
+*es.Translation HPJobName/Nombre del trabajo: ""
+*fi.Translation HPJobName/Työn nimi: ""
+*fr.Translation HPJobName/Nom de tâche: ""
+*it.Translation HPJobName/Nome processo: ""
+*ja.Translation HPJobName/ｼﾞｮﾌﾞ名: ""
+*ko.Translation HPJobName/작업명: ""
+*nl.Translation HPJobName/Taaknaam: ""
+*nb.Translation HPJobName/Jobbnavn: ""
+*pt.Translation HPJobName/Nome do trabalho: ""
+*sv.Translation HPJobName/Dokumentnamn: ""
+*zh_CN.Translation HPJobName/作业名称: ""
+*zh_TW.Translation HPJobName/列印工作名稱: ""
+
+*HPJobName DocName/Use Document Name: "
+	<< /CollateDetails
+		<< /Type 8
+			/JobMgrName /dscInfo where
+				{ /dscInfo get dup /Title known
+					{/Title get}
+					{pop ()} ifelse}
+				{()}ifelse
+			/dscInfo where
+				{ /dscInfo get dup /Creator known
+					{
+						/Creator get dup 0 exch
+						{ dup 32 eq exch dup 64 gt exch 122 le and or { 1 add } { exit } ifelse } forall
+						0 exch getinterval anchorsearch { pop } if
+					}
+					{pop} ifelse
+				} if
+			{ (:) search
+				{ pop pop }
+				{ exit }
+				ifelse
+			} loop
+			dup 0 exch { false ( -) { 2 index eq or } forall exch pop { 1 add } { exit } ifelse } forall
+			dup 0 eq { pop } { dup 2 index length exch sub getinterval } ifelse
+			dup length 80 gt { 0 80 getinterval } if
+			dup true exch { 32 eq not { false exch pop } if } forall
+			{ pop () } if
+			0 1 2 index length 1 sub
+			{ dup 2 index exch get dup 97 ge 1 index 122 le and
+				{ 32 sub 2 index 3 1 roll put }
+				{ pop pop } ifelse
+			} for
+		>>
+	>> setpagedevice
+"
+*End
+*da.HPJobName DocName/Brug dokumentnavn: ""
+*de.HPJobName DocName/Dokumentenname verwenden: ""
+*es.HPJobName DocName/Utilizar el nombre del documento: ""
+*fi.HPJobName DocName/Käytä asiakirjan nimeä: ""
+*fr.HPJobName DocName/Utiliser nom de document: ""
+*it.HPJobName DocName/Usa nome del documento: ""
+*ja.HPJobName DocName/書類名を使用: ""
+*ko.HPJobName DocName/문서명 사용: ""
+*nl.HPJobName DocName/Gebruik documentnaam: ""
+*nb.HPJobName DocName/Bruk dokumentnavn: ""
+*pt.HPJobName DocName/Use o nome do documento: ""
+*sv.HPJobName DocName/Använd dokumentnamn: ""
+*zh_CN.HPJobName DocName/使用文档名称: ""
+*zh_TW.HPJobName DocName/使用文件名稱: ""
+
+*HPJobName Set/User Specified Job Name: "
+	<< /CollateDetails
+		<< /Type 8
+			/JobMgrName /dscInfo where
+				{ /dscInfo get dup /Title known
+					{/Title get}
+					{pop ()} ifelse}
+				{()}ifelse
+			/dscInfo where
+				{ /dscInfo get dup /Creator known
+					{
+						/Creator get dup 0 exch
+						{ dup 32 eq exch dup 64 gt exch 122 le and or { 1 add } { exit } ifelse } forall
+						0 exch getinterval anchorsearch { pop } if
+					}
+					{pop} ifelse
+				} if
+			{ (:) search
+				{ pop pop }
+				{ exit }
+				ifelse
+			} loop
+			dup 0 exch { false ( -) { 2 index eq or } forall exch pop { 1 add } { exit } ifelse } forall
+			dup 0 eq { pop } { dup 2 index length exch sub getinterval } ifelse
+			dup length 80 gt { 0 80 getinterval } if
+			dup true exch { 32 eq not { false exch pop } if } forall
+			{ pop () } if
+			0 1 2 index length 1 sub
+			{ dup 2 index exch get dup 97 ge 1 index 122 le and
+				{ 32 sub 2 index 3 1 roll put }
+				{ pop pop } ifelse
+			} for
+		>>
+	>> setpagedevice
+"
+*End
+*da.HPJobName Set/Brugerdefineret jobnavn: ""
+*de.HPJobName Set/Benutzerdefinierter Jobname: ""
+*es.HPJobName Set/Nombre del trabajo personalizado: ""
+*fi.HPJobName Set/Mukautettu työn nimi: ""
+*fr.HPJobName Set/Nom de tâche personnalisé: ""
+*it.HPJobName Set/Nome processo personalizzato: ""
+*ja.HPJobName Set/ｶｽﾀﾑ ｼﾞｮﾌﾞ名: ""
+*ko.HPJobName Set/사용자 정의 작업명: ""
+*nl.HPJobName Set/Speciale taaknaam: ""
+*nb.HPJobName Set/Egendefinert jobbnavn: ""
+*pt.HPJobName Set/Nome do trabalho personalizado: ""
+*sv.HPJobName Set/Anpassat dokumentnamn: ""
+*zh_CN.HPJobName Set/自定义作业名称: ""
+*zh_TW.HPJobName Set/自訂列印工作名稱: ""
+
+*CloseUI: *HPJobName
+*HPCustomUserName Title/User Name: ""
+*da.HPCustomUserName Title/Brugernavn: ""
+*de.HPCustomUserName Title/Benutzername: ""
+*es.HPCustomUserName Title/Nombre de usuario: ""
+*fi.HPCustomUserName Title/Käyttäjänimi: ""
+*fr.HPCustomUserName Title/Nom d’utilisateur: ""
+*it.HPCustomUserName Title/Nome utente: ""
+*ja.HPCustomUserName Title/ﾕｰｻﾞｰ名: ""
+*ko.HPCustomUserName Title/사용자 이름: ""
+*nl.HPCustomUserName Title/Gebruikersnaam: ""
+*nb.HPCustomUserName Title/Brukernavn: ""
+*pt.HPCustomUserName Title/Nome do usuário: ""
+*sv.HPCustomUserName Title/Användarnamn: ""
+*zh_CN.HPCustomUserName Title/用户名称: ""
+*zh_TW.HPCustomUserName Title/使用者名稱: ""
+
+*HPCustomUserName Range: 1 15
+*HPCustomUserName Type: string
+
+*HPCustomJobName Title/Job Name: ""
+*da.HPCustomJobName Title/Jobnavn: ""
+*de.HPCustomJobName Title/Jobname: ""
+*es.HPCustomJobName Title/Nombre del trabajo: ""
+*fi.HPCustomJobName Title/Työn nimi: ""
+*fr.HPCustomJobName Title/Nom de tâche: ""
+*it.HPCustomJobName Title/Nome processo: ""
+*ja.HPCustomJobName Title/ｼﾞｮﾌﾞ名: ""
+*ko.HPCustomJobName Title/작업명: ""
+*nl.HPCustomJobName Title/Taaknaam: ""
+*nb.HPCustomJobName Title/Jobbnavn: ""
+*pt.HPCustomJobName Title/Nome do trabalho: ""
+*sv.HPCustomJobName Title/Dokumentnamn: ""
+*zh_CN.HPCustomJobName Title/作业名称: ""
+*zh_TW.HPCustomJobName Title/列印工作名稱: ""
+
+*HPCustomJobName Range: 1 15
+*HPCustomJobName Type: string
+
+*HPPinToPrint Title/PIN To Print: ""
+*da.HPPinToPrint Title/PIN til udskrivn.: ""
+*de.HPPinToPrint Title/Druckfreigabe-PIN: ""
+*es.HPPinToPrint Title/NIP para imprimir: ""
+*fi.HPPinToPrint Title/Tulostuksen PIN: ""
+*fr.HPPinToPrint Title/NIP pour imprimer: ""
+*it.HPPinToPrint Title/PIN per la stampa: ""
+*ja.HPPinToPrint Title/印刷の PIN: ""
+*ko.HPPinToPrint Title/인쇄 PIN: ""
+*nl.HPPinToPrint Title/PIN voor afdruk: ""
+*nb.HPPinToPrint Title/PIN for å skrive ut: ""
+*pt.HPPinToPrint Title/PIN para imprimir: ""
+*sv.HPPinToPrint Title/Utskriftskod: ""
+*zh_CN.HPPinToPrint Title/打印 PIN: ""
+*zh_TW.HPPinToPrint Title/列印的 PIN: ""
+
+*HPPinToPrint Range: 1 4
+*HPPinToPrint Type: string
+*HPPinToPrint Default: "0000"
+*HPPinToPrint CharSet: "0x0030 0x0039"
+
+*CloseGroup: HPJobRetention
+
+*% =================================
+*%  Watermark Printing
+*% =================================
+*OpenGroup: HPWaterOverlayPanel/Watermark/Overlay
+*da.Translation HPWaterOverlayPanel/Vandmærke/maske: ""
+*de.Translation HPWaterOverlayPanel/Wasserzeichen/Überlagerung: ""
+*es.Translation HPWaterOverlayPanel/Filigrana/Cubierta: ""
+*fi.Translation HPWaterOverlayPanel/Vesileima/peitto: ""
+*fr.Translation HPWaterOverlayPanel/Filigrane/Superposition: ""
+*it.Translation HPWaterOverlayPanel/Filigrana/sovrapposizione: ""
+*ja.Translation HPWaterOverlayPanel/Watermark/Overlay: ""
+*ko.Translation HPWaterOverlayPanel/Watermark/Overlay: ""
+*nl.Translation HPWaterOverlayPanel/Watermerk/sjabloon: ""
+*nb.Translation HPWaterOverlayPanel/Vannmerke/overlegg: ""
+*pt.Translation HPWaterOverlayPanel/Marca d'água/decalque: ""
+*sv.Translation HPWaterOverlayPanel/Vattenstämpel/tangentmall: ""
+*zh_CN.Translation HPWaterOverlayPanel/Watermark/Overlay: ""
+*zh_TW.Translation HPWaterOverlayPanel/Watermark/Overlay: ""
+
+
+*OpenUI *HPwmSwitch/Mode:  PickOne
+*OrderDependency: 10000 AnySetup *HPwmSwitch
+*DefaultHPwmSwitch: Off
+*da.Translation HPwmSwitch/Tilstand: ""
+*de.Translation HPwmSwitch/Modus: ""
+*es.Translation HPwmSwitch/Modo: ""
+*fi.Translation HPwmSwitch/Tila: ""
+*fr.Translation HPwmSwitch/Mode: ""
+*it.Translation HPwmSwitch/Modalità: ""
+*ja.Translation HPwmSwitch/モード: ""
+*ko.Translation HPwmSwitch/모드: ""
+*nl.Translation HPwmSwitch/Modus: ""
+*nb.Translation HPwmSwitch/Modus: ""
+*pt.Translation HPwmSwitch/Modo: ""
+*sv.Translation HPwmSwitch/Läge: ""
+*zh_CN.Translation HPwmSwitch/模式: ""
+*zh_TW.Translation HPwmSwitch/模式: ""
+
+*HPwmSwitch Off/None: ""
+*da.HPwmSwitch Off/Ingen: ""
+*de.HPwmSwitch Off/Keine: ""
+*es.HPwmSwitch Off/Ninguno: ""
+*fi.HPwmSwitch Off/Ei mitään: ""
+*fr.HPwmSwitch Off/Aucun: ""
+*it.HPwmSwitch Off/Nessuna: ""
+*ja.HPwmSwitch Off/なし: ""
+*ko.HPwmSwitch Off/없음: ""
+*nl.HPwmSwitch Off/Geen: ""
+*nb.HPwmSwitch Off/Ingen: ""
+*pt.HPwmSwitch Off/Nenhuma: ""
+*sv.HPwmSwitch Off/Ingen: ""
+*zh_CN.HPwmSwitch Off/无: ""
+*zh_TW.HPwmSwitch Off/無: ""
+
+*HPwmSwitch Watermark/Watermark: ""
+*da.HPwmSwitch Watermark/Vandmærke: ""
+*de.HPwmSwitch Watermark/Wasserzeichen: ""
+*es.HPwmSwitch Watermark/Filigrana: ""
+*fi.HPwmSwitch Watermark/Vesileima: ""
+*fr.HPwmSwitch Watermark/Filigrane: ""
+*it.HPwmSwitch Watermark/Filigrana: ""
+*ja.HPwmSwitch Watermark/透かし: ""
+*ko.HPwmSwitch Watermark/워터마크: ""
+*nl.HPwmSwitch Watermark/Watermerk: ""
+*nb.HPwmSwitch Watermark/Vannmerke: ""
+*pt.HPwmSwitch Watermark/Marca d'água: ""
+*sv.HPwmSwitch Watermark/Vattenstämpel: ""
+*zh_CN.HPwmSwitch Watermark/水印: ""
+*zh_TW.HPwmSwitch Watermark/浮水印: ""
+
+*HPwmSwitch Overlay/Overlay: ""
+*da.HPwmSwitch Overlay/Maske: ""
+*de.HPwmSwitch Overlay/Überlagerung: ""
+*es.HPwmSwitch Overlay/Plantilla: ""
+*fi.HPwmSwitch Overlay/Peittokuva: ""
+*fr.HPwmSwitch Overlay/Cache: ""
+*it.HPwmSwitch Overlay/Sovrapposizione: ""
+*ja.HPwmSwitch Overlay/重ね合わせ: ""
+*ko.HPwmSwitch Overlay/중첩: ""
+*nl.HPwmSwitch Overlay/Sjabloon: ""
+*nb.HPwmSwitch Overlay/Overlegg: ""
+*pt.HPwmSwitch Overlay/Deacalque: ""
+*sv.HPwmSwitch Overlay/Överlägg: ""
+*zh_CN.HPwmSwitch Overlay/覆盖: ""
+*zh_TW.HPwmSwitch Overlay/重疊: ""
+
+*CloseUI: *HPwmSwitch
+
+*% =================================
+*%  Watermark Pages
+*% =================================
+*OpenUI *HPwmPages/Pages:  PickOne
+*OrderDependency: 67 AnySetup *HPwmPages
+*DefaultHPwmPages: AllPages
+*da.Translation HPwmPages/Sider: ""
+*de.Translation HPwmPages/Seiten: ""
+*es.Translation HPwmPages/Páginas: ""
+*fi.Translation HPwmPages/Sivut: ""
+*fr.Translation HPwmPages/Pages: ""
+*it.Translation HPwmPages/Pagine: ""
+*ja.Translation HPwmPages/ページ: ""
+*ko.Translation HPwmPages/페이지: ""
+*nl.Translation HPwmPages/Pagina's: ""
+*nb.Translation HPwmPages/Sider: ""
+*pt.Translation HPwmPages/Páginas: ""
+*sv.Translation HPwmPages/Sidor: ""
+*zh_CN.Translation HPwmPages/页面: ""
+*zh_TW.Translation HPwmPages/頁數: ""
+
+*HPwmPages AllPages/All Pages: ""
+*da.HPwmPages AllPages/Alle sider: ""
+*de.HPwmPages AllPages/Alle Seiten: ""
+*es.HPwmPages AllPages/En todas las páginas: ""
+*fi.HPwmPages AllPages/Kaikki sivut: ""
+*fr.HPwmPages AllPages/Toutes les pages: ""
+*it.HPwmPages AllPages/Tutte le pagine: ""
+*ja.HPwmPages AllPages/全ページ: ""
+*ko.HPwmPages AllPages/모든 페이지: ""
+*nl.HPwmPages AllPages/Alle pagina's: ""
+*nb.HPwmPages AllPages/Alle sidene: ""
+*pt.HPwmPages AllPages/Todas as páginas: ""
+*sv.HPwmPages AllPages/Alla sidor: ""
+*zh_CN.HPwmPages AllPages/所有页: ""
+*zh_TW.HPwmPages AllPages/所有頁: ""
+
+*HPwmPages FirstPage/First Only: ""
+*da.HPwmPages FirstPage/Kun første: ""
+*de.HPwmPages FirstPage/Nur erste Seite: ""
+*es.HPwmPages FirstPage/Primera página: ""
+*fi.HPwmPages FirstPage/Vain ensimmäinen: ""
+*fr.HPwmPages FirstPage/Première page: ""
+*it.HPwmPages FirstPage/Solo la prima: ""
+*ja.HPwmPages FirstPage/最初のページ: ""
+*ko.HPwmPages FirstPage/첫 페이지: ""
+*nl.HPwmPages FirstPage/Alleen eerste: ""
+*nb.HPwmPages FirstPage/Bare første: ""
+*pt.HPwmPages FirstPage/Primeira página: ""
+*sv.HPwmPages FirstPage/Endast första: ""
+*zh_CN.HPwmPages FirstPage/第一页: ""
+*zh_TW.HPwmPages FirstPage/第一頁: ""
+
+*CloseUI: *HPwmPages
+
+*% =================================
+*%  Watermark Text
+*% =================================
+*OpenUI *HPwmTextMessage/Text:  PickOne
+*OrderDependency: 65 AnySetup *HPwmTextMessage
+*DefaultHPwmTextMessage: Draft
+*da.Translation HPwmTextMessage/Tekst: ""
+*de.Translation HPwmTextMessage/Text: ""
+*es.Translation HPwmTextMessage/Texto: ""
+*fi.Translation HPwmTextMessage/Teksti: ""
+*fr.Translation HPwmTextMessage/Texte: ""
+*it.Translation HPwmTextMessage/Testo: ""
+*ja.Translation HPwmTextMessage/文字: ""
+*ko.Translation HPwmTextMessage/문자: ""
+*nl.Translation HPwmTextMessage/Tekst: ""
+*nb.Translation HPwmTextMessage/Tekst: ""
+*pt.Translation HPwmTextMessage/Texto: ""
+*sv.Translation HPwmTextMessage/Text: ""
+*zh_CN.Translation HPwmTextMessage/文本: ""
+*zh_TW.Translation HPwmTextMessage/文字: ""
+
+*HPwmTextMessage Draft/Draft: ""
+*da.HPwmTextMessage Draft/Kladde: ""
+*de.HPwmTextMessage Draft/Entwurf: ""
+*es.HPwmTextMessage Draft/Borrador: ""
+*fi.HPwmTextMessage Draft/Vedos: ""
+*fr.HPwmTextMessage Draft/Ebauche: ""
+*it.HPwmTextMessage Draft/Bozza: ""
+*ja.HPwmTextMessage Draft/ドラフト: ""
+*ko.HPwmTextMessage Draft/초안: ""
+*nl.HPwmTextMessage Draft/Klad: ""
+*nb.HPwmTextMessage Draft/Klad: ""
+*pt.HPwmTextMessage Draft/Rascunho: ""
+*sv.HPwmTextMessage Draft/Enkel: ""
+*zh_CN.HPwmTextMessage Draft/草稿: ""
+*zh_TW.HPwmTextMessage Draft/草稿: ""
+
+*HPwmTextMessage CompanyConfidential/Company Confidential: ""
+*da.HPwmTextMessage CompanyConfidential/Fortroligt firmaeksemplar: ""
+*de.HPwmTextMessage CompanyConfidential/Firmengeheimnis: ""
+*es.HPwmTextMessage CompanyConfidential/Información confidencial de la compañía: ""
+*fi.HPwmTextMessage CompanyConfidential/Yhtiön luottamuksellinen: ""
+*fr.HPwmTextMessage CompanyConfidential/Confidentiel à l'entreprise: ""
+*it.HPwmTextMessage CompanyConfidential/Aziendale - Riservato: ""
+*ja.HPwmTextMessage CompanyConfidential/社内機密: ""
+*ko.HPwmTextMessage CompanyConfidential/대외비: ""
+*nl.HPwmTextMessage CompanyConfidential/Vertrouwelijke bedrijfsinformatie: ""
+*nb.HPwmTextMessage CompanyConfidential/Vertrouwelijke bedrijfsinformatie: ""
+*pt.HPwmTextMessage CompanyConfidential/Confidencial da empresa: ""
+*sv.HPwmTextMessage CompanyConfidential/Konfidentiellt inom företaget: ""
+*zh_CN.HPwmTextMessage CompanyConfidential/公司机密: ""
+*zh_TW.HPwmTextMessage CompanyConfidential/公司機密: ""
+
+*HPwmTextMessage CompanyProprietary/Company Proprietary: ""
+*da.HPwmTextMessage CompanyProprietary/Firmaets ejendom: ""
+*de.HPwmTextMessage CompanyProprietary/Firmeneigentum: ""
+*es.HPwmTextMessage CompanyProprietary/Propietario de la compañía: ""
+*fi.HPwmTextMessage CompanyProprietary/Yhtiön omistusoikeus: ""
+*fr.HPwmTextMessage CompanyProprietary/Propriété de l'entreprise: ""
+*it.HPwmTextMessage CompanyProprietary/Proprietà aziendale: ""
+*ja.HPwmTextMessage CompanyProprietary/私有文書: ""
+*ko.HPwmTextMessage CompanyProprietary/회사 소유: ""
+*nl.HPwmTextMessage CompanyProprietary/Bedrijfseigendom: ""
+*nb.HPwmTextMessage CompanyProprietary/Bedrijfseigendom: ""
+*pt.HPwmTextMessage CompanyProprietary/Propriedade da empresa: ""
+*sv.HPwmTextMessage CompanyProprietary/Företagets egendom: ""
+*zh_CN.HPwmTextMessage CompanyProprietary/公司专有: ""
+*zh_TW.HPwmTextMessage CompanyProprietary/公司專有: ""
+
+*HPwmTextMessage CompanyPrivate/Company Private: ""
+*da.HPwmTextMessage CompanyPrivate/Til privat firmabrug: ""
+*de.HPwmTextMessage CompanyPrivate/Firmenintern: ""
+*es.HPwmTextMessage CompanyPrivate/Información privada de la compañía: ""
+*fi.HPwmTextMessage CompanyPrivate/Yhtiön yksityinen: ""
+*fr.HPwmTextMessage CompanyPrivate/Privé à l'entreprise: ""
+*it.HPwmTextMessage CompanyPrivate/Aziendale - Privato: ""
+*ja.HPwmTextMessage CompanyPrivate/私書: ""
+*ko.HPwmTextMessage CompanyPrivate/회사 비밀: ""
+*nl.HPwmTextMessage CompanyPrivate/Bedrijfsgeheim: ""
+*nb.HPwmTextMessage CompanyPrivate/Bedrijfsgeheim: ""
+*pt.HPwmTextMessage CompanyPrivate/Privado da empresa: ""
+*sv.HPwmTextMessage CompanyPrivate/Privat inom företaget: ""
+*zh_CN.HPwmTextMessage CompanyPrivate/公司专用: ""
+*zh_TW.HPwmTextMessage CompanyPrivate/公司私有資料: ""
+
+*HPwmTextMessage Confidential/Confidential: ""
+*da.HPwmTextMessage Confidential/Fortroligt: ""
+*de.HPwmTextMessage Confidential/Vertraulich: ""
+*es.HPwmTextMessage Confidential/Confidencial: ""
+*fi.HPwmTextMessage Confidential/Luottamuksellinen: ""
+*fr.HPwmTextMessage Confidential/Confidentiel: ""
+*it.HPwmTextMessage Confidential/Riservato: ""
+*ja.HPwmTextMessage Confidential/部外秘: ""
+*ko.HPwmTextMessage Confidential/기밀 문서: ""
+*nl.HPwmTextMessage Confidential/Vertrouwelijk: ""
+*nb.HPwmTextMessage Confidential/Vertrouwelijk: ""
+*pt.HPwmTextMessage Confidential/Confidencial: ""
+*sv.HPwmTextMessage Confidential/Konfidentiellt: ""
+*zh_CN.HPwmTextMessage Confidential/机密: ""
+*zh_TW.HPwmTextMessage Confidential/機密文件: ""
+
+*HPwmTextMessage Copy/Copy: ""
+*da.HPwmTextMessage Copy/Kopi: ""
+*de.HPwmTextMessage Copy/Kopie: ""
+*es.HPwmTextMessage Copy/Realización de copias: ""
+*fi.HPwmTextMessage Copy/Kopio: ""
+*fr.HPwmTextMessage Copy/Copie: ""
+*it.HPwmTextMessage Copy/Copia: ""
+*ja.HPwmTextMessage Copy/コピー: ""
+*ko.HPwmTextMessage Copy/사본: ""
+*nl.HPwmTextMessage Copy/Kopie: ""
+*nb.HPwmTextMessage Copy/Kopie: ""
+*pt.HPwmTextMessage Copy/Copiar: ""
+*sv.HPwmTextMessage Copy/Kopia: ""
+*zh_CN.HPwmTextMessage Copy/拷贝: ""
+*zh_TW.HPwmTextMessage Copy/副本: ""
+
+*HPwmTextMessage Copyright/Copyright: ""
+*da.HPwmTextMessage Copyright/Copyright: ""
+*de.HPwmTextMessage Copyright/Copyright: ""
+*es.HPwmTextMessage Copyright/Copyright: ""
+*fi.HPwmTextMessage Copyright/Tekijänoikeus: ""
+*fr.HPwmTextMessage Copyright/Copyright: ""
+*it.HPwmTextMessage Copyright/Copyright: ""
+*ja.HPwmTextMessage Copyright/著作権: ""
+*ko.HPwmTextMessage Copyright/저작권: ""
+*nl.HPwmTextMessage Copyright/Copyright: ""
+*nb.HPwmTextMessage Copyright/Opphavsrett: ""
+*pt.HPwmTextMessage Copyright/Direito autoral: ""
+*sv.HPwmTextMessage Copyright/Copyright: ""
+*zh_CN.HPwmTextMessage Copyright/版权所有: ""
+*zh_TW.HPwmTextMessage Copyright/著作權: ""
+
+*HPwmTextMessage FileCopy/File Copy: ""
+*da.HPwmTextMessage FileCopy/Arkivkopi: ""
+*de.HPwmTextMessage FileCopy/Dateikopie: ""
+*es.HPwmTextMessage FileCopy/Copia de archivo: ""
+*fi.HPwmTextMessage FileCopy/Arkistokopio: ""
+*fr.HPwmTextMessage FileCopy/Copie de fichier: ""
+*it.HPwmTextMessage FileCopy/Copia archivio: ""
+*ja.HPwmTextMessage FileCopy/ファイルのコピー: ""
+*ko.HPwmTextMessage FileCopy/파일 사본: ""
+*nl.HPwmTextMessage FileCopy/Archiefexemplaar: ""
+*nb.HPwmTextMessage FileCopy/Archiefexemplaar: ""
+*pt.HPwmTextMessage FileCopy/Cópia de arquivo: ""
+*sv.HPwmTextMessage FileCopy/Arkivexemplar: ""
+*zh_CN.HPwmTextMessage FileCopy/文件拷贝: ""
+*zh_TW.HPwmTextMessage FileCopy/檔案拷貝: ""
+
+*HPwmTextMessage Final/Final: ""
+*da.HPwmTextMessage Final/Endelig udgave: ""
+*de.HPwmTextMessage Final/Endgültig: ""
+*es.HPwmTextMessage Final/Versión final: ""
+*fi.HPwmTextMessage Final/Lopullinen: ""
+*fr.HPwmTextMessage Final/Finale: ""
+*it.HPwmTextMessage Final/Finale: ""
+*ja.HPwmTextMessage Final/最終稿: ""
+*ko.HPwmTextMessage Final/최종: ""
+*nl.HPwmTextMessage Final/Eindversie: ""
+*nb.HPwmTextMessage Final/Eindversie: ""
+*pt.HPwmTextMessage Final/Final: ""
+*sv.HPwmTextMessage Final/Slutlig: ""
+*zh_CN.HPwmTextMessage Final/终稿: ""
+*zh_TW.HPwmTextMessage Final/最終定稿: ""
+
+*HPwmTextMessage ForInternalUse/For Internal Use Only: ""
+*da.HPwmTextMessage ForInternalUse/Kun til intern brug: ""
+*de.HPwmTextMessage ForInternalUse/Nur für internen Gebrauch: ""
+*es.HPwmTextMessage ForInternalUse/Sólo para uso interno: ""
+*fi.HPwmTextMessage ForInternalUse/Vain sisäiseen käyttöön: ""
+*fr.HPwmTextMessage ForInternalUse/Usage interne uniquement: ""
+*it.HPwmTextMessage ForInternalUse/Solo per uso interno: ""
+*ja.HPwmTextMessage ForInternalUse/社外秘: ""
+*ko.HPwmTextMessage ForInternalUse/내부용: ""
+*nl.HPwmTextMessage ForInternalUse/Alleen voor intern gebruik: ""
+*nb.HPwmTextMessage ForInternalUse/Alleen voor intern gebruik: ""
+*pt.HPwmTextMessage ForInternalUse/Somente para uso interno: ""
+*sv.HPwmTextMessage ForInternalUse/Endast för internt bruk: ""
+*zh_CN.HPwmTextMessage ForInternalUse/仅限内部使用: ""
+*zh_TW.HPwmTextMessage ForInternalUse/僅供內部使用: ""
+
+*HPwmTextMessage Preliminary/Preliminary: ""
+*da.HPwmTextMessage Preliminary/Foreløbig: ""
+*de.HPwmTextMessage Preliminary/Vorläufig: ""
+*es.HPwmTextMessage Preliminary/Preliminar: ""
+*fi.HPwmTextMessage Preliminary/Alustava: ""
+*fr.HPwmTextMessage Preliminary/Préliminaire: ""
+*it.HPwmTextMessage Preliminary/Preliminare: ""
+*ja.HPwmTextMessage Preliminary/初校: ""
+*ko.HPwmTextMessage Preliminary/준비용: ""
+*nl.HPwmTextMessage Preliminary/Voorlopig: ""
+*nb.HPwmTextMessage Preliminary/Voorlopig: ""
+*pt.HPwmTextMessage Preliminary/Preliminar: ""
+*sv.HPwmTextMessage Preliminary/Preliminärt: ""
+*zh_CN.HPwmTextMessage Preliminary/初稿: ""
+*zh_TW.HPwmTextMessage Preliminary/初稿: ""
+
+*HPwmTextMessage Proof/Proof: ""
+*da.HPwmTextMessage Proof/Korrektur: ""
+*de.HPwmTextMessage Proof/Korrekturfahne: ""
+*es.HPwmTextMessage Proof/Prueba: ""
+*fi.HPwmTextMessage Proof/Koevedos: ""
+*fr.HPwmTextMessage Proof/Vérifier: ""
+*it.HPwmTextMessage Proof/Prova di stampa: ""
+*ja.HPwmTextMessage Proof/校正: ""
+*ko.HPwmTextMessage Proof/교정용: ""
+*nl.HPwmTextMessage Proof/Proefafdruk: ""
+*nb.HPwmTextMessage Proof/Proefafdruk: ""
+*pt.HPwmTextMessage Proof/Prova: ""
+*sv.HPwmTextMessage Proof/Korrektur: ""
+*zh_CN.HPwmTextMessage Proof/校样: ""
+*zh_TW.HPwmTextMessage Proof/校對稿: ""
+
+*HPwmTextMessage ReviewCopy/Review Copy: ""
+*da.HPwmTextMessage ReviewCopy/Til gennemsyn: ""
+*de.HPwmTextMessage ReviewCopy/Korrekturausdruck: ""
+*es.HPwmTextMessage ReviewCopy/Copia de revisión: ""
+*fi.HPwmTextMessage ReviewCopy/Tarkistuskappale: ""
+*fr.HPwmTextMessage ReviewCopy/Copie à réviser: ""
+*it.HPwmTextMessage ReviewCopy/Copia da rivedere: ""
+*ja.HPwmTextMessage ReviewCopy/レビューコピー: ""
+*ko.HPwmTextMessage ReviewCopy/검토 사본: ""
+*nl.HPwmTextMessage ReviewCopy/Correctie-exemplaar: ""
+*nb.HPwmTextMessage ReviewCopy/Correctie-exemplaar: ""
+*pt.HPwmTextMessage ReviewCopy/Cópia de revisão: ""
+*sv.HPwmTextMessage ReviewCopy/Granskningskopia: ""
+*zh_CN.HPwmTextMessage ReviewCopy/审阅稿: ""
+*zh_TW.HPwmTextMessage ReviewCopy/審閱稿: ""
+
+*HPwmTextMessage Sample/Sample: ""
+*da.HPwmTextMessage Sample/Prøve: ""
+*de.HPwmTextMessage Sample/Muster: ""
+*es.HPwmTextMessage Sample/Muestra: ""
+*fi.HPwmTextMessage Sample/Näyte: ""
+*fr.HPwmTextMessage Sample/Echantillon: ""
+*it.HPwmTextMessage Sample/Esempio: ""
+*ja.HPwmTextMessage Sample/サンプル: ""
+*ko.HPwmTextMessage Sample/견본: ""
+*nl.HPwmTextMessage Sample/Voorbeeld: ""
+*nb.HPwmTextMessage Sample/Voorbeeld: ""
+*pt.HPwmTextMessage Sample/Amostra: ""
+*sv.HPwmTextMessage Sample/Exempel: ""
+*zh_CN.HPwmTextMessage Sample/样本: ""
+*zh_TW.HPwmTextMessage Sample/樣本: ""
+
+*HPwmTextMessage TopSecret/Top Secret: ""
+*da.HPwmTextMessage TopSecret/Hemmeligt: ""
+*de.HPwmTextMessage TopSecret/Streng geheim: ""
+*es.HPwmTextMessage TopSecret/Confidencial: ""
+*fi.HPwmTextMessage TopSecret/Salainen: ""
+*fr.HPwmTextMessage TopSecret/Ultra-Secret: ""
+*it.HPwmTextMessage TopSecret/Segreto: ""
+*ja.HPwmTextMessage TopSecret/極秘: ""
+*ko.HPwmTextMessage TopSecret/일급 비밀: ""
+*nl.HPwmTextMessage TopSecret/Zeer geheim: ""
+*nb.HPwmTextMessage TopSecret/Zeer geheim: ""
+*pt.HPwmTextMessage TopSecret/Ultra-secreto: ""
+*sv.HPwmTextMessage TopSecret/Hemligstämplat: ""
+*zh_CN.HPwmTextMessage TopSecret/绝密: ""
+*zh_TW.HPwmTextMessage TopSecret/最高機密: ""
+
+*HPwmTextMessage Urgent/Urgent: ""
+*da.HPwmTextMessage Urgent/Haster: ""
+*de.HPwmTextMessage Urgent/Eilt: ""
+*es.HPwmTextMessage Urgent/Urgente: ""
+*fi.HPwmTextMessage Urgent/Kiireellinen: ""
+*fr.HPwmTextMessage Urgent/Pressant: ""
+*it.HPwmTextMessage Urgent/Urgente: ""
+*ja.HPwmTextMessage Urgent/緊急: ""
+*ko.HPwmTextMessage Urgent/긴급: ""
+*nl.HPwmTextMessage Urgent/Dringend: ""
+*nb.HPwmTextMessage Urgent/Dringend: ""
+*pt.HPwmTextMessage Urgent/Urgente: ""
+*sv.HPwmTextMessage Urgent/Brådskande: ""
+*zh_CN.HPwmTextMessage Urgent/急件: ""
+*zh_TW.HPwmTextMessage Urgent/緊急的: ""
+
+*HPwmTextMessage Set/Custom: ""
+*da.HPwmTextMessage Set/Speciel: ""
+*de.HPwmTextMessage Set/Benutzerdefiniert: ""
+*es.HPwmTextMessage Set/Personalizada: ""
+*fi.HPwmTextMessage Set/Mukautettu: ""
+*fr.HPwmTextMessage Set/Personnalisée: ""
+*it.HPwmTextMessage Set/Personalizzata: ""
+*ja.HPwmTextMessage Set/ユーザー設定: ""
+*ko.HPwmTextMessage Set/사용자 정의: ""
+*nl.HPwmTextMessage Set/Speciaal: ""
+*nb.HPwmTextMessage Set/Speciaal: ""
+*pt.HPwmTextMessage Set/Personalizar: ""
+*sv.HPwmTextMessage Set/Egen: ""
+*zh_CN.HPwmTextMessage Set/这是自定义颜色设置: ""
+*zh_TW.HPwmTextMessage Set/自訂: ""
+
+*CloseUI: *HPwmTextMessage
+
+
+*% ========================================================
+*% Custom support text field for HPwmTextMessage Set/Custom
+*% ========================================================
+
+*HPwmCustomText Title: ""
+*HPwmCustomText Range: 1 50
+*HPwmCustomText Type: string
+*HPwmCustomText Default: ""
+
+
+*% =================================
+*%  Watermark Font
+*% =================================
+*OpenUI *HPwmFontName/Font:  PickOne
+*OrderDependency: 65 AnySetup *HPwmFontName
+*DefaultHPwmFontName: HelveticaB
+*da.Translation HPwmFontName/Skrifttype: ""
+*de.Translation HPwmFontName/Schrift: ""
+*es.Translation HPwmFontName/Fuente: ""
+*fi.Translation HPwmFontName/Fontti: ""
+*fr.Translation HPwmFontName/Police: ""
+*it.Translation HPwmFontName/Carattere: ""
+*ja.Translation HPwmFontName/フォント: ""
+*ko.Translation HPwmFontName/폰트: ""
+*nl.Translation HPwmFontName/Lettertype: ""
+*nb.Translation HPwmFontName/Skrifttype: ""
+*pt.Translation HPwmFontName/Fonte: ""
+*sv.Translation HPwmFontName/Typsnitt: ""
+*zh_CN.Translation HPwmFontName/字体: ""
+*zh_TW.Translation HPwmFontName/字型: ""
+
+*HPwmFontName CourierB/Courier Bold: ""
+*da.HPwmFontName CourierB/Courier fed: ""
+*de.HPwmFontName CourierB/Courier Fett: ""
+*es.HPwmFontName CourierB/Courier Negrita: ""
+*fi.HPwmFontName CourierB/Courier lihavoitu: ""
+*fr.HPwmFontName CourierB/Courier Gras: ""
+*it.HPwmFontName CourierB/Courier grassetto: ""
+*ja.HPwmFontName CourierB/Courier Bold: ""
+*ko.HPwmFontName CourierB/Courier Bold: ""
+*nl.HPwmFontName CourierB/Courier vet: ""
+*nb.HPwmFontName CourierB/Courier, fet: ""
+*pt.HPwmFontName CourierB/Courier Bold: ""
+*sv.HPwmFontName CourierB/Courier Fet: ""
+*zh_CN.HPwmFontName CourierB/Courier 黑体: ""
+*zh_TW.HPwmFontName CourierB/Courier 粗體: ""
+
+*HPwmFontName HelveticaB/Helvetica Bold: ""
+*da.HPwmFontName HelveticaB/Helvetica fed: ""
+*de.HPwmFontName HelveticaB/Helvetica Fett: ""
+*es.HPwmFontName HelveticaB/Helvetica Negrita: ""
+*fi.HPwmFontName HelveticaB/Helvetica lihavoitu: ""
+*fr.HPwmFontName HelveticaB/Helvetica Gras: ""
+*it.HPwmFontName HelveticaB/Helvetica grassetto: ""
+*ja.HPwmFontName HelveticaB/Helvetica Bold: ""
+*ko.HPwmFontName HelveticaB/Helvetica Bold: ""
+*nl.HPwmFontName HelveticaB/Helvetica vet: ""
+*nb.HPwmFontName HelveticaB/Helvetica, fet: ""
+*pt.HPwmFontName HelveticaB/Helvetica Bold: ""
+*sv.HPwmFontName HelveticaB/Helvetica Fet: ""
+*zh_CN.HPwmFontName HelveticaB/Helvetica 黑体: ""
+*zh_TW.HPwmFontName HelveticaB/Helvetica 粗體: ""
+
+*HPwmFontName TimesB/Times Bold: ""
+*da.HPwmFontName TimesB/Times fed: ""
+*de.HPwmFontName TimesB/Times Fett: ""
+*es.HPwmFontName TimesB/Times Negrita: ""
+*fi.HPwmFontName TimesB/Times lihavoitu: ""
+*fr.HPwmFontName TimesB/Times Gras: ""
+*it.HPwmFontName TimesB/Times grassetto: ""
+*ja.HPwmFontName TimesB/Times Bold: ""
+*ko.HPwmFontName TimesB/Times Bold: ""
+*nl.HPwmFontName TimesB/Times vet: ""
+*nb.HPwmFontName TimesB/Times, fet: ""
+*pt.HPwmFontName TimesB/Times Bold: ""
+*sv.HPwmFontName TimesB/Times Fet: ""
+*zh_CN.HPwmFontName TimesB/Times 黑体: ""
+*zh_TW.HPwmFontName TimesB/Times 粗體: ""
+
+*CloseUI: *HPwmFontName
+
+*% =================================
+*%  Watermark Size
+*% =================================
+*OpenUI *HPwmFontSize/Size:  PickOne
+*OrderDependency: 65 AnySetup *HPwmFontSize
+*DefaultHPwmFontSize: pt48
+*da.Translation HPwmFontSize/Størrelse (punkter): ""
+*de.Translation HPwmFontSize/Größe (Punkte): ""
+*es.Translation HPwmFontSize/Tamaño (puntos): ""
+*fi.Translation HPwmFontSize/Koko (pisteinä): ""
+*fr.Translation HPwmFontSize/Taille (en points): ""
+*it.Translation HPwmFontSize/Formato (punti): ""
+*ja.Translation HPwmFontSize/サイズ (ポイント): ""
+*ko.Translation HPwmFontSize/크기(포인트): ""
+*nl.Translation HPwmFontSize/Puntgrootte: ""
+*nb.Translation HPwmFontSize/Størrelse (punkt): ""
+*pt.Translation HPwmFontSize/Tamanho (pontos): ""
+*sv.Translation HPwmFontSize/Storlek (punkter): ""
+*zh_CN.Translation HPwmFontSize/字号（磅）: ""
+*zh_TW.Translation HPwmFontSize/大小 (以點數計): ""
+
+*HPwmFontSize pt24/24: ""
+*da.HPwmFontSize pt24/24: ""
+*de.HPwmFontSize pt24/24: ""
+*es.HPwmFontSize pt24/24: ""
+*fi.HPwmFontSize pt24/24: ""
+*fr.HPwmFontSize pt24/24: ""
+*it.HPwmFontSize pt24/24: ""
+*ja.HPwmFontSize pt24/24: ""
+*ko.HPwmFontSize pt24/24: ""
+*nl.HPwmFontSize pt24/24: ""
+*nb.HPwmFontSize pt24/24: ""
+*pt.HPwmFontSize pt24/24: ""
+*sv.HPwmFontSize pt24/24: ""
+*zh_CN.HPwmFontSize pt24/24: ""
+*zh_TW.HPwmFontSize pt24/24: ""
+
+*HPwmFontSize pt30/30: ""
+*da.HPwmFontSize pt30/30: ""
+*de.HPwmFontSize pt30/30: ""
+*es.HPwmFontSize pt30/30: ""
+*fi.HPwmFontSize pt30/30: ""
+*fr.HPwmFontSize pt30/30: ""
+*it.HPwmFontSize pt30/30: ""
+*ja.HPwmFontSize pt30/30: ""
+*ko.HPwmFontSize pt30/30: ""
+*nl.HPwmFontSize pt30/30: ""
+*nb.HPwmFontSize pt30/30: ""
+*pt.HPwmFontSize pt30/30: ""
+*sv.HPwmFontSize pt30/30: ""
+*zh_CN.HPwmFontSize pt30/30: ""
+*zh_TW.HPwmFontSize pt30/30: ""
+
+*HPwmFontSize pt36/36: ""
+*da.HPwmFontSize pt36/36: ""
+*de.HPwmFontSize pt36/36: ""
+*es.HPwmFontSize pt36/36: ""
+*fi.HPwmFontSize pt36/36: ""
+*fr.HPwmFontSize pt36/36: ""
+*it.HPwmFontSize pt36/36: ""
+*ja.HPwmFontSize pt36/36: ""
+*ko.HPwmFontSize pt36/36: ""
+*nl.HPwmFontSize pt36/36: ""
+*nb.HPwmFontSize pt36/36: ""
+*pt.HPwmFontSize pt36/36: ""
+*sv.HPwmFontSize pt36/36: ""
+*zh_CN.HPwmFontSize pt36/36: ""
+*zh_TW.HPwmFontSize pt36/36: ""
+
+*HPwmFontSize pt42/42: ""
+*da.HPwmFontSize pt42/42: ""
+*de.HPwmFontSize pt42/42: ""
+*es.HPwmFontSize pt42/42: ""
+*fi.HPwmFontSize pt42/42: ""
+*fr.HPwmFontSize pt42/42: ""
+*it.HPwmFontSize pt42/42: ""
+*ja.HPwmFontSize pt42/42: ""
+*ko.HPwmFontSize pt42/42: ""
+*nl.HPwmFontSize pt42/42: ""
+*nb.HPwmFontSize pt42/42: ""
+*pt.HPwmFontSize pt42/42: ""
+*sv.HPwmFontSize pt42/42: ""
+*zh_CN.HPwmFontSize pt42/42: ""
+*zh_TW.HPwmFontSize pt42/42: ""
+
+*HPwmFontSize pt48/48: ""
+*da.HPwmFontSize pt48/48: ""
+*de.HPwmFontSize pt48/48: ""
+*es.HPwmFontSize pt48/48: ""
+*fi.HPwmFontSize pt48/48: ""
+*fr.HPwmFontSize pt48/48: ""
+*it.HPwmFontSize pt48/48: ""
+*ja.HPwmFontSize pt48/48: ""
+*ko.HPwmFontSize pt48/48: ""
+*nl.HPwmFontSize pt48/48: ""
+*nb.HPwmFontSize pt48/48: ""
+*pt.HPwmFontSize pt48/48: ""
+*sv.HPwmFontSize pt48/48: ""
+*zh_CN.HPwmFontSize pt48/48: ""
+*zh_TW.HPwmFontSize pt48/48: ""
+
+*HPwmFontSize pt54/54: ""
+*da.HPwmFontSize pt54/54: ""
+*de.HPwmFontSize pt54/54: ""
+*es.HPwmFontSize pt54/54: ""
+*fi.HPwmFontSize pt54/54: ""
+*fr.HPwmFontSize pt54/54: ""
+*it.HPwmFontSize pt54/54: ""
+*ja.HPwmFontSize pt54/54: ""
+*ko.HPwmFontSize pt54/54: ""
+*nl.HPwmFontSize pt54/54: ""
+*nb.HPwmFontSize pt54/54: ""
+*pt.HPwmFontSize pt54/54: ""
+*sv.HPwmFontSize pt54/54: ""
+*zh_CN.HPwmFontSize pt54/54: ""
+*zh_TW.HPwmFontSize pt54/54: ""
+
+*HPwmFontSize pt60/60: ""
+*da.HPwmFontSize pt60/60: ""
+*de.HPwmFontSize pt60/60: ""
+*es.HPwmFontSize pt60/60: ""
+*fi.HPwmFontSize pt60/60: ""
+*fr.HPwmFontSize pt60/60: ""
+*it.HPwmFontSize pt60/60: ""
+*ja.HPwmFontSize pt60/60: ""
+*ko.HPwmFontSize pt60/60: ""
+*nl.HPwmFontSize pt60/60: ""
+*nb.HPwmFontSize pt60/60: ""
+*pt.HPwmFontSize pt60/60: ""
+*sv.HPwmFontSize pt60/60: ""
+*zh_CN.HPwmFontSize pt60/60: ""
+*zh_TW.HPwmFontSize pt60/60: ""
+
+*HPwmFontSize pt66/66: ""
+*da.HPwmFontSize pt66/66: ""
+*de.HPwmFontSize pt66/66: ""
+*es.HPwmFontSize pt66/66: ""
+*fi.HPwmFontSize pt66/66: ""
+*fr.HPwmFontSize pt66/66: ""
+*it.HPwmFontSize pt66/66: ""
+*ja.HPwmFontSize pt66/66: ""
+*ko.HPwmFontSize pt66/66: ""
+*nl.HPwmFontSize pt66/66: ""
+*nb.HPwmFontSize pt66/66: ""
+*pt.HPwmFontSize pt66/66: ""
+*sv.HPwmFontSize pt66/66: ""
+*zh_CN.HPwmFontSize pt66/66: ""
+*zh_TW.HPwmFontSize pt66/66: ""
+
+*HPwmFontSize pt72/72: ""
+*da.HPwmFontSize pt72/72: ""
+*de.HPwmFontSize pt72/72: ""
+*es.HPwmFontSize pt72/72: ""
+*fi.HPwmFontSize pt72/72: ""
+*fr.HPwmFontSize pt72/72: ""
+*it.HPwmFontSize pt72/72: ""
+*ja.HPwmFontSize pt72/72: ""
+*ko.HPwmFontSize pt72/72: ""
+*nl.HPwmFontSize pt72/72: ""
+*nb.HPwmFontSize pt72/72: ""
+*pt.HPwmFontSize pt72/72: ""
+*sv.HPwmFontSize pt72/72: ""
+*zh_CN.HPwmFontSize pt72/72: ""
+*zh_TW.HPwmFontSize pt72/72: ""
+
+*HPwmFontSize pt78/78: ""
+*da.HPwmFontSize pt78/78: ""
+*de.HPwmFontSize pt78/78: ""
+*es.HPwmFontSize pt78/78: ""
+*fi.HPwmFontSize pt78/78: ""
+*fr.HPwmFontSize pt78/78: ""
+*it.HPwmFontSize pt78/78: ""
+*ja.HPwmFontSize pt78/78: ""
+*ko.HPwmFontSize pt78/78: ""
+*nl.HPwmFontSize pt78/78: ""
+*nb.HPwmFontSize pt78/78: ""
+*pt.HPwmFontSize pt78/78: ""
+*sv.HPwmFontSize pt78/78: ""
+*zh_CN.HPwmFontSize pt78/78: ""
+*zh_TW.HPwmFontSize pt78/78: ""
+
+*HPwmFontSize pt84/84: ""
+*da.HPwmFontSize pt84/84: ""
+*de.HPwmFontSize pt84/84: ""
+*es.HPwmFontSize pt84/84: ""
+*fi.HPwmFontSize pt84/84: ""
+*fr.HPwmFontSize pt84/84: ""
+*it.HPwmFontSize pt84/84: ""
+*ja.HPwmFontSize pt84/84: ""
+*ko.HPwmFontSize pt84/84: ""
+*nl.HPwmFontSize pt84/84: ""
+*nb.HPwmFontSize pt84/84: ""
+*pt.HPwmFontSize pt84/84: ""
+*sv.HPwmFontSize pt84/84: ""
+*zh_CN.HPwmFontSize pt84/84: ""
+*zh_TW.HPwmFontSize pt84/84: ""
+
+*HPwmFontSize pt90/90: ""
+*da.HPwmFontSize pt90/90: ""
+*de.HPwmFontSize pt90/90: ""
+*es.HPwmFontSize pt90/90: ""
+*fi.HPwmFontSize pt90/90: ""
+*fr.HPwmFontSize pt90/90: ""
+*it.HPwmFontSize pt90/90: ""
+*ja.HPwmFontSize pt90/90: ""
+*ko.HPwmFontSize pt90/90: ""
+*nl.HPwmFontSize pt90/90: ""
+*nb.HPwmFontSize pt90/90: ""
+*pt.HPwmFontSize pt90/90: ""
+*sv.HPwmFontSize pt90/90: ""
+*zh_CN.HPwmFontSize pt90/90: ""
+*zh_TW.HPwmFontSize pt90/90: ""
+
+*CloseUI: *HPwmFontSize
+
+*% =================================
+*%  Watermark Angle
+*% =================================
+*OpenUI *HPwmTextAngle/Angle:  PickOne
+*OrderDependency: 65 AnySetup *HPwmTextAngle
+*DefaultHPwmTextAngle: Deg45
+*da.Translation HPwmTextAngle/Vinkel: ""
+*de.Translation HPwmTextAngle/Winkel: ""
+*es.Translation HPwmTextAngle/Ángulo: ""
+*fi.Translation HPwmTextAngle/Kulma: ""
+*fr.Translation HPwmTextAngle/Angle: ""
+*it.Translation HPwmTextAngle/Angolazione: ""
+*ja.Translation HPwmTextAngle/角度: ""
+*ko.Translation HPwmTextAngle/각도: ""
+*nl.Translation HPwmTextAngle/Hoek: ""
+*nb.Translation HPwmTextAngle/Vinkel: ""
+*pt.Translation HPwmTextAngle/Ângulo: ""
+*sv.Translation HPwmTextAngle/I vinkel: ""
+*zh_CN.Translation HPwmTextAngle/角度: ""
+*zh_TW.Translation HPwmTextAngle/角度: ""
+
+*HPwmTextAngle Deg90/90: ""
+*en.HPwmTextAngle Deg90/90°: ""
+*da.HPwmTextAngle Deg90/90°: ""
+*de.HPwmTextAngle Deg90/90°: ""
+*es.HPwmTextAngle Deg90/90°: ""
+*fi.HPwmTextAngle Deg90/90°: ""
+*fr.HPwmTextAngle Deg90/90°: ""
+*it.HPwmTextAngle Deg90/90°: ""
+*ja.HPwmTextAngle Deg90/90°: ""
+*ko.HPwmTextAngle Deg90/90°: ""
+*nl.HPwmTextAngle Deg90/90°: ""
+*nb.HPwmTextAngle Deg90/90°: ""
+*pt.HPwmTextAngle Deg90/90°: ""
+*sv.HPwmTextAngle Deg90/90°: ""
+*zh_CN.HPwmTextAngle Deg90/90°: ""
+*zh_TW.HPwmTextAngle Deg90/90°: ""
+
+*HPwmTextAngle Deg75/75: ""
+*en.HPwmTextAngle Deg75/75°: ""
+*da.HPwmTextAngle Deg75/75°: ""
+*de.HPwmTextAngle Deg75/75°: ""
+*es.HPwmTextAngle Deg75/75°: ""
+*fi.HPwmTextAngle Deg75/75°: ""
+*fr.HPwmTextAngle Deg75/75°: ""
+*it.HPwmTextAngle Deg75/75°: ""
+*ja.HPwmTextAngle Deg75/75°: ""
+*ko.HPwmTextAngle Deg75/75°: ""
+*nl.HPwmTextAngle Deg75/75°: ""
+*nb.HPwmTextAngle Deg75/75°: ""
+*pt.HPwmTextAngle Deg75/75°: ""
+*sv.HPwmTextAngle Deg75/75°: ""
+*zh_CN.HPwmTextAngle Deg75/75°: ""
+*zh_TW.HPwmTextAngle Deg75/75°: ""
+
+*HPwmTextAngle Deg60/60: ""
+*en.HPwmTextAngle Deg60/60°: ""
+*da.HPwmTextAngle Deg60/60°: ""
+*de.HPwmTextAngle Deg60/60°: ""
+*es.HPwmTextAngle Deg60/60°: ""
+*fi.HPwmTextAngle Deg60/60°: ""
+*fr.HPwmTextAngle Deg60/60°: ""
+*it.HPwmTextAngle Deg60/60°: ""
+*ja.HPwmTextAngle Deg60/60°: ""
+*ko.HPwmTextAngle Deg60/60°: ""
+*nl.HPwmTextAngle Deg60/60°: ""
+*nb.HPwmTextAngle Deg60/60°: ""
+*pt.HPwmTextAngle Deg60/60°: ""
+*sv.HPwmTextAngle Deg60/60°: ""
+*zh_CN.HPwmTextAngle Deg60/60°: ""
+*zh_TW.HPwmTextAngle Deg60/60°: ""
+
+*HPwmTextAngle Deg45/45: ""
+*en.HPwmTextAngle Deg45/45°: ""
+*da.HPwmTextAngle Deg45/45°: ""
+*de.HPwmTextAngle Deg45/45°: ""
+*es.HPwmTextAngle Deg45/45°: ""
+*fi.HPwmTextAngle Deg45/45°: ""
+*fr.HPwmTextAngle Deg45/45°: ""
+*it.HPwmTextAngle Deg45/45°: ""
+*ja.HPwmTextAngle Deg45/45°: ""
+*ko.HPwmTextAngle Deg45/45°: ""
+*nl.HPwmTextAngle Deg45/45°: ""
+*nb.HPwmTextAngle Deg45/45°: ""
+*pt.HPwmTextAngle Deg45/45°: ""
+*sv.HPwmTextAngle Deg45/45°: ""
+*zh_CN.HPwmTextAngle Deg45/45°: ""
+*zh_TW.HPwmTextAngle Deg45/45°: ""
+
+*HPwmTextAngle Deg30/30: ""
+*en.HPwmTextAngle Deg30/30°: ""
+*da.HPwmTextAngle Deg30/30°: ""
+*de.HPwmTextAngle Deg30/30°: ""
+*es.HPwmTextAngle Deg30/30°: ""
+*fi.HPwmTextAngle Deg30/30°: ""
+*fr.HPwmTextAngle Deg30/30°: ""
+*it.HPwmTextAngle Deg30/30°: ""
+*ja.HPwmTextAngle Deg30/30°: ""
+*ko.HPwmTextAngle Deg30/30°: ""
+*nl.HPwmTextAngle Deg30/30°: ""
+*nb.HPwmTextAngle Deg30/30°: ""
+*pt.HPwmTextAngle Deg30/30°: ""
+*sv.HPwmTextAngle Deg30/30°: ""
+*zh_CN.HPwmTextAngle Deg30/30°: ""
+*zh_TW.HPwmTextAngle Deg30/30°: ""
+
+*HPwmTextAngle Deg15/15: ""
+*en.HPwmTextAngle Deg15/15°: ""
+*da.HPwmTextAngle Deg15/15°: ""
+*de.HPwmTextAngle Deg15/15°: ""
+*es.HPwmTextAngle Deg15/15°: ""
+*fi.HPwmTextAngle Deg15/15°: ""
+*fr.HPwmTextAngle Deg15/15°: ""
+*it.HPwmTextAngle Deg15/15°: ""
+*ja.HPwmTextAngle Deg15/15°: ""
+*ko.HPwmTextAngle Deg15/15°: ""
+*nl.HPwmTextAngle Deg15/15°: ""
+*nb.HPwmTextAngle Deg15/15°: ""
+*pt.HPwmTextAngle Deg15/15°: ""
+*sv.HPwmTextAngle Deg15/15°: ""
+*zh_CN.HPwmTextAngle Deg15/15°: ""
+*zh_TW.HPwmTextAngle Deg15/15°: ""
+
+*HPwmTextAngle Deg0/0: ""
+*en.HPwmTextAngle Deg0/0°: ""
+*da.HPwmTextAngle Deg0/0°: ""
+*de.HPwmTextAngle Deg0/0°: ""
+*es.HPwmTextAngle Deg0/0°: ""
+*fi.HPwmTextAngle Deg0/0°: ""
+*fr.HPwmTextAngle Deg0/0°: ""
+*it.HPwmTextAngle Deg0/0°: ""
+*ja.HPwmTextAngle Deg0/0°: ""
+*ko.HPwmTextAngle Deg0/0°: ""
+*nl.HPwmTextAngle Deg0/0°: ""
+*nb.HPwmTextAngle Deg0/0°: ""
+*pt.HPwmTextAngle Deg0/0°: ""
+*sv.HPwmTextAngle Deg0/0°: ""
+*zh_CN.HPwmTextAngle Deg0/0°: ""
+*zh_TW.HPwmTextAngle Deg0/0°: ""
+
+*HPwmTextAngle DegN15/-15: ""
+*en.HPwmTextAngle DegN15/-15°: ""
+*da.HPwmTextAngle DegN15/-15°: ""
+*de.HPwmTextAngle DegN15/-15°: ""
+*es.HPwmTextAngle DegN15/-15°: ""
+*fi.HPwmTextAngle DegN15/-15°: ""
+*fr.HPwmTextAngle DegN15/- 15°: ""
+*it.HPwmTextAngle DegN15/-15°: ""
+*ja.HPwmTextAngle DegN15/-15°: ""
+*ko.HPwmTextAngle DegN15/-15°: ""
+*nl.HPwmTextAngle DegN15/-15°: ""
+*nb.HPwmTextAngle DegN15/-15°: ""
+*pt.HPwmTextAngle DegN15/-15°: ""
+*sv.HPwmTextAngle DegN15/-15°: ""
+*zh_CN.HPwmTextAngle DegN15/-15°: ""
+*zh_TW.HPwmTextAngle DegN15/-15°: ""
+
+*HPwmTextAngle DegN30/-30: ""
+*en.HPwmTextAngle DegN30/-30°: ""
+*da.HPwmTextAngle DegN30/-30°: ""
+*de.HPwmTextAngle DegN30/-30°: ""
+*es.HPwmTextAngle DegN30/-30°: ""
+*fi.HPwmTextAngle DegN30/-30°: ""
+*fr.HPwmTextAngle DegN30/- 30°: ""
+*it.HPwmTextAngle DegN30/-30°: ""
+*ja.HPwmTextAngle DegN30/-30°: ""
+*ko.HPwmTextAngle DegN30/-30°: ""
+*nl.HPwmTextAngle DegN30/-30°: ""
+*nb.HPwmTextAngle DegN30/-30°: ""
+*pt.HPwmTextAngle DegN30/-30°: ""
+*sv.HPwmTextAngle DegN30/-30°: ""
+*zh_CN.HPwmTextAngle DegN30/-30°: ""
+*zh_TW.HPwmTextAngle DegN30/-30°: ""
+
+*HPwmTextAngle DegN45/-45: ""
+*en.HPwmTextAngle DegN45/-45°: ""
+*da.HPwmTextAngle DegN45/-45°: ""
+*de.HPwmTextAngle DegN45/-45°: ""
+*es.HPwmTextAngle DegN45/-45°: ""
+*fi.HPwmTextAngle DegN45/-45°: ""
+*fr.HPwmTextAngle DegN45/- 45°: ""
+*it.HPwmTextAngle DegN45/-45°: ""
+*ja.HPwmTextAngle DegN45/-45°: ""
+*ko.HPwmTextAngle DegN45/-45°: ""
+*nl.HPwmTextAngle DegN45/-45°: ""
+*nb.HPwmTextAngle DegN45/-45°: ""
+*pt.HPwmTextAngle DegN45/-45°: ""
+*sv.HPwmTextAngle DegN45/-45°: ""
+*zh_CN.HPwmTextAngle DegN45/-45°: ""
+*zh_TW.HPwmTextAngle DegN45/-45°: ""
+
+*HPwmTextAngle DegN60/-60: ""
+*en.HPwmTextAngle DegN60/-60°: ""
+*da.HPwmTextAngle DegN60/-60°: ""
+*de.HPwmTextAngle DegN60/-60°: ""
+*es.HPwmTextAngle DegN60/-60°: ""
+*fi.HPwmTextAngle DegN60/-60°: ""
+*fr.HPwmTextAngle DegN60/- 60°: ""
+*it.HPwmTextAngle DegN60/-60°: ""
+*ja.HPwmTextAngle DegN60/-60°: ""
+*ko.HPwmTextAngle DegN60/-60°: ""
+*nl.HPwmTextAngle DegN60/-60°: ""
+*nb.HPwmTextAngle DegN60/-60°: ""
+*pt.HPwmTextAngle DegN60/-60°: ""
+*sv.HPwmTextAngle DegN60/-60°: ""
+*zh_CN.HPwmTextAngle DegN60/-60°: ""
+*zh_TW.HPwmTextAngle DegN60/-60°: ""
+
+*HPwmTextAngle DegN75/-75: ""
+*en.HPwmTextAngle DegN75/-75°: ""
+*da.HPwmTextAngle DegN75/-75°: ""
+*de.HPwmTextAngle DegN75/-75°: ""
+*es.HPwmTextAngle DegN75/-75°: ""
+*fi.HPwmTextAngle DegN75/-75°: ""
+*fr.HPwmTextAngle DegN75/- 75°: ""
+*it.HPwmTextAngle DegN75/-75°: ""
+*ja.HPwmTextAngle DegN75/-75°: ""
+*ko.HPwmTextAngle DegN75/-75°: ""
+*nl.HPwmTextAngle DegN75/-75°: ""
+*nb.HPwmTextAngle DegN75/-75°: ""
+*pt.HPwmTextAngle DegN75/-75°: ""
+*sv.HPwmTextAngle DegN75/-75°: ""
+*zh_CN.HPwmTextAngle DegN75/-75°: ""
+*zh_TW.HPwmTextAngle DegN75/-75°: ""
+
+*HPwmTextAngle DegN90/-90: ""
+*en.HPwmTextAngle DegN90/-90°: ""
+*da.HPwmTextAngle DegN90/-90°: ""
+*de.HPwmTextAngle DegN90/-90°: ""
+*es.HPwmTextAngle DegN90/-90°: ""
+*fi.HPwmTextAngle DegN90/-90°: ""
+*fr.HPwmTextAngle DegN90/- 90°: ""
+*it.HPwmTextAngle DegN90/-90°: ""
+*ja.HPwmTextAngle DegN90/-90°: ""
+*ko.HPwmTextAngle DegN90/-90°: ""
+*nl.HPwmTextAngle DegN90/-90°: ""
+*nb.HPwmTextAngle DegN90/-90°: ""
+*pt.HPwmTextAngle DegN90/-90°: ""
+*sv.HPwmTextAngle DegN90/-90°: ""
+*zh_CN.HPwmTextAngle DegN90/-90°: ""
+*zh_TW.HPwmTextAngle DegN90/-90°: ""
+
+*CloseUI: *HPwmTextAngle
+
+*% =================================
+*%  Watermark Style
+*% =================================
+*OpenUI *HPwmTextStyle/Style:  PickOne
+*OrderDependency: 65 AnySetup *HPwmTextStyle
+*DefaultHPwmTextStyle: Medium
+*da.Translation HPwmTextStyle/Stil: ""
+*de.Translation HPwmTextStyle/Schriftstil: ""
+*es.Translation HPwmTextStyle/Estilo: ""
+*fi.Translation HPwmTextStyle/Tyyli: ""
+*fr.Translation HPwmTextStyle/Style: ""
+*it.Translation HPwmTextStyle/Stile: ""
+*ja.Translation HPwmTextStyle/文字スタイル: ""
+*ko.Translation HPwmTextStyle/스타일: ""
+*nl.Translation HPwmTextStyle/Stijl: ""
+*nb.Translation HPwmTextStyle/Stil: ""
+*pt.Translation HPwmTextStyle/Estilo: ""
+*sv.Translation HPwmTextStyle/Stil: ""
+*zh_CN.Translation HPwmTextStyle/样式: ""
+*zh_TW.Translation HPwmTextStyle/樣式: ""
+
+*HPwmTextStyle Thin/Thin Outline: ""
+*da.HPwmTextStyle Thin/Tynd kontur: ""
+*de.HPwmTextStyle Thin/Umriss, schmal: ""
+*es.HPwmTextStyle Thin/Contorno fino: ""
+*fi.HPwmTextStyle Thin/Ohut ääriviiva: ""
+*fr.HPwmTextStyle Thin/Contour fin: ""
+*it.HPwmTextStyle Thin/Contorno sottile: ""
+*ja.HPwmTextStyle Thin/薄い輪郭: ""
+*ko.HPwmTextStyle Thin/얇은 외곽선: ""
+*nl.HPwmTextStyle Thin/Dunne omtrek: ""
+*nb.HPwmTextStyle Thin/Smal kontur: ""
+*pt.HPwmTextStyle Thin/Contorno fino: ""
+*sv.HPwmTextStyle Thin/Tunn kontur: ""
+*zh_CN.HPwmTextStyle Thin/细轮廓: ""
+*zh_TW.HPwmTextStyle Thin/細框: ""
+
+*HPwmTextStyle Medium/Medium Outline: ""
+*da.HPwmTextStyle Medium/Middel kontur: ""
+*de.HPwmTextStyle Medium/Umriss, mittel: ""
+*es.HPwmTextStyle Medium/Contorno medio: ""
+*fi.HPwmTextStyle Medium/Normaali ääriviiva: ""
+*fr.HPwmTextStyle Medium/Contour moyen: ""
+*it.HPwmTextStyle Medium/Contorno medio: ""
+*ja.HPwmTextStyle Medium/標準アウトライン: ""
+*ko.HPwmTextStyle Medium/중간 외곽선: ""
+*nl.HPwmTextStyle Medium/Normale omtrek: ""
+*nb.HPwmTextStyle Medium/Normal kontur: ""
+*pt.HPwmTextStyle Medium/Contorno médio: ""
+*sv.HPwmTextStyle Medium/Normal kontur: ""
+*zh_CN.HPwmTextStyle Medium/中轮廓: ""
+*zh_TW.HPwmTextStyle Medium/中等輪廓線: ""
+
+*HPwmTextStyle Thick/Thick Outline: ""
+*da.HPwmTextStyle Thick/Tyk kontur: ""
+*de.HPwmTextStyle Thick/Umriss, breit: ""
+*es.HPwmTextStyle Thick/Contorno grueso: ""
+*fi.HPwmTextStyle Thick/Paksu ääriviiva: ""
+*fr.HPwmTextStyle Thick/Contour épais: ""
+*it.HPwmTextStyle Thick/Contorno spesso: ""
+*ja.HPwmTextStyle Thick/濃い輪郭: ""
+*ko.HPwmTextStyle Thick/두꺼운 외곽선: ""
+*nl.HPwmTextStyle Thick/Dikke omtrek: ""
+*nb.HPwmTextStyle Thick/Bred kontur: ""
+*pt.HPwmTextStyle Thick/Contorno espesso: ""
+*sv.HPwmTextStyle Thick/Tjock kontur: ""
+*zh_CN.HPwmTextStyle Thick/粗轮廓: ""
+*zh_TW.HPwmTextStyle Thick/粗框: ""
+
+*HPwmTextStyle Halo/Thick Outline with Halo: ""
+*da.HPwmTextStyle Halo/Tyk kontur med glorie: ""
+*de.HPwmTextStyle Halo/Umriss, breit, mit Halo: ""
+*es.HPwmTextStyle Halo/Contorno grueso con halo: ""
+*fi.HPwmTextStyle Halo/Paksu ääriviiva ja valokehä: ""
+*fr.HPwmTextStyle Halo/Contour épais nimbé: ""
+*it.HPwmTextStyle Halo/Contorno spesso con alone: ""
+*ja.HPwmTextStyle Halo/ハロー付きの濃い輪郭: ""
+*ko.HPwmTextStyle Halo/무리가 있는 두꺼운 외곽선: ""
+*nl.HPwmTextStyle Halo/Dikke omtrek met halo: ""
+*nb.HPwmTextStyle Halo/Bred kontur med skygge: ""
+*pt.HPwmTextStyle Halo/Contorno espesso com Halo: ""
+*sv.HPwmTextStyle Halo/Tjock kontur med gloria: ""
+*zh_CN.HPwmTextStyle Halo/粗轮廓，带晕圈: ""
+*zh_TW.HPwmTextStyle Halo/粗框，並有光暈環繞效果: ""
+
+*HPwmTextStyle Fill/Filled: ""
+*da.HPwmTextStyle Fill/Udfyldt: ""
+*de.HPwmTextStyle Fill/Gefüllt: ""
+*es.HPwmTextStyle Fill/Relleno: ""
+*fi.HPwmTextStyle Fill/Täytetty: ""
+*fr.HPwmTextStyle Fill/Rempli: ""
+*it.HPwmTextStyle Fill/Pieno: ""
+*ja.HPwmTextStyle Fill/塗りつぶし: ""
+*ko.HPwmTextStyle Fill/채워짐: ""
+*nl.HPwmTextStyle Fill/Opgevuld: ""
+*nb.HPwmTextStyle Fill/Fylt: ""
+*pt.HPwmTextStyle Fill/Preenchido: ""
+*sv.HPwmTextStyle Fill/Fylld: ""
+*zh_CN.HPwmTextStyle Fill/填充: ""
+*zh_TW.HPwmTextStyle Fill/填滿: ""
+
+*CloseUI: *HPwmTextStyle
+
+*% =================================
+*%  WaterMark Brightness
+*% =================================
+*OpenUI *HPwmBrightness/Intensity:  PickOne
+*OrderDependency: 63 AnySetup *HPwmBrightness
+*DefaultHPwmBrightness: Medium
+*da.Translation HPwmBrightness/Intensitet: ""
+*de.Translation HPwmBrightness/Intensität: ""
+*es.Translation HPwmBrightness/Intensidad: ""
+*fi.Translation HPwmBrightness/Tummuus: ""
+*fr.Translation HPwmBrightness/Intensité: ""
+*it.Translation HPwmBrightness/Intensità: ""
+*ja.Translation HPwmBrightness/輝度: ""
+*ko.Translation HPwmBrightness/강도: ""
+*nl.Translation HPwmBrightness/Intensiteit: ""
+*nb.Translation HPwmBrightness/Intensitet: ""
+*pt.Translation HPwmBrightness/Intensidade: ""
+*sv.Translation HPwmBrightness/Intensitet: ""
+*zh_CN.Translation HPwmBrightness/浓度: ""
+*zh_TW.Translation HPwmBrightness/濃度: ""
+
+*HPwmBrightness Darkest/Darkest:          ""
+*da.HPwmBrightness Darkest/Mørkest: ""
+*de.HPwmBrightness Darkest/Am dunkelsten: ""
+*es.HPwmBrightness Darkest/Más oscuro: ""
+*fi.HPwmBrightness Darkest/Tummin: ""
+*fr.HPwmBrightness Darkest/Le + foncé: ""
+*it.HPwmBrightness Darkest/Scurissimo: ""
+*ja.HPwmBrightness Darkest/最も濃い: ""
+*ko.HPwmBrightness Darkest/가장 어두움: ""
+*nl.HPwmBrightness Darkest/Donkerst: ""
+*nb.HPwmBrightness Darkest/Mørkest: ""
+*pt.HPwmBrightness Darkest/Muito mais escuro: ""
+*sv.HPwmBrightness Darkest/Mörkast: ""
+*zh_CN.HPwmBrightness Darkest/最深: ""
+*zh_TW.HPwmBrightness Darkest/最深: ""
+
+*HPwmBrightness Darker/Darker:            ""
+*da.HPwmBrightness Darker/Mørkere: ""
+*de.HPwmBrightness Darker/Sehr dunkel: ""
+*es.HPwmBrightness Darker/Muy oscuro: ""
+*fi.HPwmBrightness Darker/Tummempi: ""
+*fr.HPwmBrightness Darker/Trés foncé: ""
+*it.HPwmBrightness Darker/Molto scuro: ""
+*ja.HPwmBrightness Darker/非常に濃い: ""
+*ko.HPwmBrightness Darker/아주 어두움: ""
+*nl.HPwmBrightness Darker/Donkerder: ""
+*nb.HPwmBrightness Darker/Mørkere: ""
+*pt.HPwmBrightness Darker/Muito escuro: ""
+*sv.HPwmBrightness Darker/Mörkare: ""
+*zh_CN.HPwmBrightness Darker/很深: ""
+*zh_TW.HPwmBrightness Darker/很深: ""
+
+*HPwmBrightness Dark/Dark:                ""
+*da.HPwmBrightness Dark/Mørk: ""
+*de.HPwmBrightness Dark/Dunkel: ""
+*es.HPwmBrightness Dark/Oscuro: ""
+*fi.HPwmBrightness Dark/Tumma: ""
+*fr.HPwmBrightness Dark/Foncé: ""
+*it.HPwmBrightness Dark/Scuro: ""
+*ja.HPwmBrightness Dark/濃い: ""
+*ko.HPwmBrightness Dark/어둡게: ""
+*nl.HPwmBrightness Dark/Donker: ""
+*nb.HPwmBrightness Dark/Mørk: ""
+*pt.HPwmBrightness Dark/Escuro: ""
+*sv.HPwmBrightness Dark/Mörk: ""
+*zh_CN.HPwmBrightness Dark/深: ""
+*zh_TW.HPwmBrightness Dark/深: ""
+
+*HPwmBrightness MediumDark/Medium Dark:   ""
+*da.HPwmBrightness MediumDark/Middel mørk: ""
+*de.HPwmBrightness MediumDark/Mitteldunkel: ""
+*es.HPwmBrightness MediumDark/Semioscuro: ""
+*fi.HPwmBrightness MediumDark/Keskitumma: ""
+*fr.HPwmBrightness MediumDark/Moyennement foncé: ""
+*it.HPwmBrightness MediumDark/Scuro medio: ""
+*ja.HPwmBrightness MediumDark/やや濃い: ""
+*ko.HPwmBrightness MediumDark/중간 어두음: ""
+*nl.HPwmBrightness MediumDark/Middeldonker: ""
+*nb.HPwmBrightness MediumDark/Middels mørk: ""
+*pt.HPwmBrightness MediumDark/Meio escuro: ""
+*sv.HPwmBrightness MediumDark/Mellanmörk: ""
+*zh_CN.HPwmBrightness MediumDark/中等深: ""
+*zh_TW.HPwmBrightness MediumDark/較淡的深色: ""
+
+*HPwmBrightness Medium/Medium:            ""
+*da.HPwmBrightness Medium/Middel: ""
+*de.HPwmBrightness Medium/Mittel: ""
+*es.HPwmBrightness Medium/Medio: ""
+*fi.HPwmBrightness Medium/Normaali: ""
+*fr.HPwmBrightness Medium/Moyen: ""
+*it.HPwmBrightness Medium/Medio: ""
+*ja.HPwmBrightness Medium/標準: ""
+*ko.HPwmBrightness Medium/중간: ""
+*nl.HPwmBrightness Medium/Middelinstelling: ""
+*nb.HPwmBrightness Medium/Normal: ""
+*pt.HPwmBrightness Medium/Médio: ""
+*sv.HPwmBrightness Medium/Normal: ""
+*zh_CN.HPwmBrightness Medium/中等: ""
+*zh_TW.HPwmBrightness Medium/中等: ""
+
+*HPwmBrightness MediumLight/Medium Light: ""
+*da.HPwmBrightness MediumLight/Middel lys: ""
+*de.HPwmBrightness MediumLight/Mittelhell: ""
+*es.HPwmBrightness MediumLight/Semiclaro: ""
+*fi.HPwmBrightness MediumLight/Keskivaalea: ""
+*fr.HPwmBrightness MediumLight/Moyennement clair: ""
+*it.HPwmBrightness MediumLight/Chiaro medio: ""
+*ja.HPwmBrightness MediumLight/やや薄い: ""
+*ko.HPwmBrightness MediumLight/중간 밝음: ""
+*nl.HPwmBrightness MediumLight/Middellicht: ""
+*nb.HPwmBrightness MediumLight/Middels lys: ""
+*pt.HPwmBrightness MediumLight/Meio claro: ""
+*sv.HPwmBrightness MediumLight/Mellanljus: ""
+*zh_CN.HPwmBrightness MediumLight/中等淡: ""
+*zh_TW.HPwmBrightness MediumLight/較深的淡色: ""
+
+*HPwmBrightness Light/Light:              ""
+*da.HPwmBrightness Light/Lys: ""
+*de.HPwmBrightness Light/Hell: ""
+*es.HPwmBrightness Light/Claro: ""
+*fi.HPwmBrightness Light/Vaalea: ""
+*fr.HPwmBrightness Light/Clair: ""
+*it.HPwmBrightness Light/Chiaro: ""
+*ja.HPwmBrightness Light/薄い: ""
+*ko.HPwmBrightness Light/밝게: ""
+*nl.HPwmBrightness Light/Licht: ""
+*nb.HPwmBrightness Light/Lys: ""
+*pt.HPwmBrightness Light/Claro: ""
+*sv.HPwmBrightness Light/Ljus: ""
+*zh_CN.HPwmBrightness Light/淡: ""
+*zh_TW.HPwmBrightness Light/淡: ""
+
+*HPwmBrightness Lighter/Lighter: ""
+*da.HPwmBrightness Lighter/Lysere: ""
+*de.HPwmBrightness Lighter/Sehr hell: ""
+*es.HPwmBrightness Lighter/Muy claro: ""
+*fi.HPwmBrightness Lighter/Vaaleampi: ""
+*fr.HPwmBrightness Lighter/Trés clair: ""
+*it.HPwmBrightness Lighter/Molto chiaro: ""
+*ja.HPwmBrightness Lighter/非常に薄い: ""
+*ko.HPwmBrightness Lighter/아주 밝음: ""
+*nl.HPwmBrightness Lighter/Lichter: ""
+*nb.HPwmBrightness Lighter/Lysere: ""
+*pt.HPwmBrightness Lighter/Muito claro: ""
+*sv.HPwmBrightness Lighter/Ljusare: ""
+*zh_CN.HPwmBrightness Lighter/很淡: ""
+*zh_TW.HPwmBrightness Lighter/很淡: ""
+
+*HPwmBrightness Lightest/Lightest: ""
+*da.HPwmBrightness Lightest/Lysest: ""
+*de.HPwmBrightness Lightest/Am hellsten: ""
+*es.HPwmBrightness Lightest/Más claro: ""
+*fi.HPwmBrightness Lightest/Vaalein: ""
+*fr.HPwmBrightness Lightest/Le + clair: ""
+*it.HPwmBrightness Lightest/Chiarissimo: ""
+*ja.HPwmBrightness Lightest/最も薄い: ""
+*ko.HPwmBrightness Lightest/가장 밝음: ""
+*nl.HPwmBrightness Lightest/Lichtst: ""
+*nb.HPwmBrightness Lightest/Lysest: ""
+*pt.HPwmBrightness Lightest/Muito mais claro: ""
+*sv.HPwmBrightness Lightest/Ljusast: ""
+*zh_CN.HPwmBrightness Lightest/最淡: ""
+*zh_TW.HPwmBrightness Lightest/最淡: ""
+
+*CloseUI: *HPwmBrightness
+
+*CloseGroup: HPWaterOverlayPanel
+
+*%================================
+*%    Media Output Destination
+*%================================
+*OpenGroup: HPFinishing/Finishing Panel
+*da.Translation HPFinishing/Finisher-indstillinger: ""
+*de.Translation HPFinishing/Optionen zum Fertigstellen: ""
+*es.Translation HPFinishing/Acabado: ""
+*fi.Translation HPFinishing/Viimeistelyasetukset: ""
+*fr.Translation HPFinishing/Finition: ""
+*it.Translation HPFinishing/Finitura: ""
+*ja.Translation HPFinishing/仕上げオプション: ""
+*ko.Translation HPFinishing/마감장치 옵션: ""
+*nl.Translation HPFinishing/Afwerkingsopties: ""
+*nb.Translation HPFinishing/Etterbehandlingsvalg: ""
+*pt.Translation HPFinishing/Acabamento: ""
+*sv.Translation HPFinishing/Efterbehandling: ""
+*zh_CN.Translation HPFinishing/完成选项: ""
+*zh_TW.Translation HPFinishing/外觀選項: ""
+*% ================================================
+*% Booklet
+*% ================================================
+*% Booklet printing is not allowed without Auto Duplex turned on
+*UIConstraints: *HPBookletFilter True *Duplex None
+*UIConstraints: *Duplex None *HPBookletFilter True
+*OpenUI *HPBookletFilter/Format Output As Booklet: Boolean
+*OrderDependency: 60 AnySetup *HPBookletFilter
+*DefaultHPBookletFilter: False
+*da.Translation HPBookletFilter/Formater Udskrift Som Brochure: ""
+*de.Translation HPBookletFilter/Ausgabeformat als Broschüre: ""
+*es.Translation HPBookletFilter/Formatear impr. como folleto: ""
+*fi.Translation HPBookletFilter/Tulostetaan kirjasena: ""
+*fr.Translation HPBookletFilter/Formate la sortie comme brochure: ""
+*it.Translation HPBookletFilter/Output in formato di opuscolo: ""
+*ja.Translation HPBookletFilter/ブックレット印刷用フォーマット: ""
+*ko.Translation HPBookletFilter/소책자 형식으로 출력: ""
+*nl.Translation HPBookletFilter/Opmaakuitvoer als brochure: ""
+*nb.Translation HPBookletFilter/Formater utskrift som hefte: ""
+*pt.Translation HPBookletFilter/Formatar saída como folheto: ""
+*sv.Translation HPBookletFilter/Broschyr som utskriftsformat: ""
+*zh_CN.Translation HPBookletFilter/以小册子格式输出: ""
+*zh_TW.Translation HPBookletFilter/輸出格式為手冊: ""
+
+*HPBookletFilter True/Yes: ""
+*da.HPBookletFilter True/På: ""
+*de.HPBookletFilter True/Ein: ""
+*es.HPBookletFilter True/Activado: ""
+*fi.HPBookletFilter True/käytössä: ""
+*fr.HPBookletFilter True/Activé: ""
+*it.HPBookletFilter True/Attiva: ""
+*ja.HPBookletFilter True/オン: ""
+*ko.HPBookletFilter True/켜짐: ""
+*nl.HPBookletFilter True/Aan: ""
+*nb.HPBookletFilter True/På: ""
+*pt.HPBookletFilter True/Ativado: ""
+*sv.HPBookletFilter True/På: ""
+*zh_CN.HPBookletFilter True/开: ""
+*zh_TW.HPBookletFilter True/開啟: ""
+
+*HPBookletFilter False/No: ""
+*da.HPBookletFilter False/Fra: ""
+*de.HPBookletFilter False/Aus: ""
+*es.HPBookletFilter False/Desactivado: ""
+*fi.HPBookletFilter False/Ei käytössä: ""
+*fr.HPBookletFilter False/Désactivé: ""
+*it.HPBookletFilter False/Disattivata: ""
+*ja.HPBookletFilter False/オフ: ""
+*ko.HPBookletFilter False/꺼짐: ""
+*nl.HPBookletFilter False/Uit: ""
+*nb.HPBookletFilter False/Av: ""
+*pt.HPBookletFilter False/Desativado: ""
+*sv.HPBookletFilter False/Av: ""
+*zh_CN.HPBookletFilter False/关: ""
+*zh_TW.HPBookletFilter False/關閉: ""
+
+*CloseUI: *HPBookletFilter
+
+*HPBookletFilterDS True: "HPBOOKLETFILTER_AUTO_DS"
+*HPBookletFilterDS False: "HPBOOKLETFILTER_AUTO_DS"
+
+*OpenUI *HPBookletBackCover/Last Page Is Back Cover: Boolean
+*OrderDependency: 61 AnySetup *HPBookletBackCover
+*DefaultHPBookletBackCover: False
+*da.Translation HPBookletBackCover/Sidste Side Er Bagomslag: ""
+*de.Translation HPBookletBackCover/Endseite = Broschürenrücken: ""
+*es.Translation HPBookletBackCover/La últ. pág. es la contraport.: ""
+*fi.Translation HPBookletBackCover/Viimeinen sivu on takakansi: ""
+*fr.Translation HPBookletBackCover/Dernière page page de garde: ""
+*it.Translation HPBookletBackCover/Ultima pag come retrocopertina: ""
+*ja.Translation HPBookletBackCover/最後のページを背表紙にする: ""
+*ko.Translation HPBookletBackCover/마지막 페이지는 뒤 표지입니다: ""
+*nl.Translation HPBookletBackCover/Laatste pagina is achterblad: ""
+*nb.Translation HPBookletBackCover/Siste side er bakside: ""
+*pt.Translation HPBookletBackCover/A última pág. é a quarta capa: ""
+*sv.Translation HPBookletBackCover/Sista sidan är bakre omslag: ""
+*zh_CN.Translation HPBookletBackCover/最后一页是封底: ""
+*zh_TW.Translation HPBookletBackCover/最後一頁為封底: ""
+
+*HPBookletBackCover True/Yes: ""
+*da.HPBookletBackCover True/På: ""
+*de.HPBookletBackCover True/Ein: ""
+*es.HPBookletBackCover True/Activado: ""
+*fi.HPBookletBackCover True/käytössä: ""
+*fr.HPBookletBackCover True/Activé: ""
+*it.HPBookletBackCover True/Attiva: ""
+*ja.HPBookletBackCover True/オン: ""
+*ko.HPBookletBackCover True/켜짐: ""
+*nl.HPBookletBackCover True/Aan: ""
+*nb.HPBookletBackCover True/På: ""
+*pt.HPBookletBackCover True/Ativado: ""
+*sv.HPBookletBackCover True/På: ""
+*zh_CN.HPBookletBackCover True/开: ""
+*zh_TW.HPBookletBackCover True/開啟: ""
+
+*HPBookletBackCover False/No: ""
+*da.HPBookletBackCover False/Fra: ""
+*de.HPBookletBackCover False/Aus: ""
+*es.HPBookletBackCover False/Desactivado: ""
+*fi.HPBookletBackCover False/Ei käytössä: ""
+*fr.HPBookletBackCover False/Désactivé: ""
+*it.HPBookletBackCover False/Disattivata: ""
+*ja.HPBookletBackCover False/オフ: ""
+*ko.HPBookletBackCover False/꺼짐: ""
+*nl.HPBookletBackCover False/Uit: ""
+*nb.HPBookletBackCover False/Av: ""
+*pt.HPBookletBackCover False/Desativado: ""
+*sv.HPBookletBackCover False/Av: ""
+*zh_CN.HPBookletBackCover False/关: ""
+*zh_TW.HPBookletBackCover False/關閉: ""
+
+*CloseUI: *HPBookletBackCover
+
+*OpenUI *HPBookletPageOrder/Page Order: PickOne
+*OrderDependency: 62 AnySetup *HPBookletPageOrder
+*DefaultHPBookletPageOrder: Normal
+*da.Translation HPBookletPageOrder/Siderækkefølge: ""
+*de.Translation HPBookletPageOrder/Seitenreihenfolge: ""
+*es.Translation HPBookletPageOrder/Orden de páginas: ""
+*fi.Translation HPBookletPageOrder/Sivujärjestys: ""
+*fr.Translation HPBookletPageOrder/Ordre des pages: ""
+*it.Translation HPBookletPageOrder/Ordine delle pagine: ""
+*ja.Translation HPBookletPageOrder/ページ方向: ""
+*ko.Translation HPBookletPageOrder/페이지 순서: ""
+*nl.Translation HPBookletPageOrder/Paginavolgorde: ""
+*nb.Translation HPBookletPageOrder/Siderekkefølge: ""
+*pt.Translation HPBookletPageOrder/Ordem das páginas: ""
+*sv.Translation HPBookletPageOrder/Sidföljd: ""
+*zh_CN.Translation HPBookletPageOrder/页面顺序: ""
+*zh_TW.Translation HPBookletPageOrder/頁序: ""
+
+*HPBookletPageOrder Normal/Pages Bound on the Left: ""
+*da.HPBookletPageOrder Normal/Sider bundet i venstre side: ""
+*de.HPBookletPageOrder Normal/Seiten links gebunden: ""
+*es.HPBookletPageOrder Normal/Encuadernación a la izquierda: ""
+*fi.HPBookletPageOrder Normal/Sivut sidottu vasemmalle: ""
+*fr.HPBookletPageOrder Normal/Pages reliées sur la gauche: ""
+*it.HPBookletPageOrder Normal/Pagine rilegate a sinistra: ""
+*ja.HPBookletPageOrder Normal/とじしろ左: ""
+*ko.HPBookletPageOrder Normal/왼쪽 제본 페이지: ""
+*nl.HPBookletPageOrder Normal/Links gebonden pagina’s: ""
+*nb.HPBookletPageOrder Normal/Sider bundet på venstre side: ""
+*pt.HPBookletPageOrder Normal/Páginas encadernadas à esquerda: ""
+*sv.HPBookletPageOrder Normal/Sidorna binds i vänsterkanten: ""
+*zh_CN.HPBookletPageOrder Normal/左侧装订: ""
+*zh_TW.HPBookletPageOrder Normal/左邊裝訂: ""
+
+*HPBookletPageOrder Asian/Pages Bound on the Right: ""
+*da.HPBookletPageOrder Asian/Sider bundet i højre side: ""
+*de.HPBookletPageOrder Asian/Seiten rechts gebunden: ""
+*es.HPBookletPageOrder Asian/Encuadernación a la derecha: ""
+*fi.HPBookletPageOrder Asian/Sivut sidottu oikealle: ""
+*fr.HPBookletPageOrder Asian/Pages reliées sur la droite: ""
+*it.HPBookletPageOrder Asian/Pagine rilegate a destra: ""
+*ja.HPBookletPageOrder Asian/とじしろ右: ""
+*ko.HPBookletPageOrder Asian/오른쪽 제본 페이지: ""
+*nl.HPBookletPageOrder Asian/Rechts gebonden pagina’s: ""
+*nb.HPBookletPageOrder Asian/Sider bundet på høyre side: ""
+*pt.HPBookletPageOrder Asian/Páginas encadernadas à direita: ""
+*sv.HPBookletPageOrder Asian/Sidorna binds i högerkanten: ""
+*zh_CN.HPBookletPageOrder Asian/右侧装订: ""
+*zh_TW.HPBookletPageOrder Asian/右邊裝訂: ""
+
+*CloseUI: *HPBookletPageOrder
+
+*OpenUI *HPBookletScaling/Scaling: PickOne
+*OrderDependency: 63 AnySetup *HPBookletScaling
+*DefaultHPBookletScaling: Proportional
+*da.Translation HPBookletScaling/Skalering: ""
+*de.Translation HPBookletScaling/Skalierung: ""
+*es.Translation HPBookletScaling/Cambio de escala: ""
+*fi.Translation HPBookletScaling/Skaalaus: ""
+*fr.Translation HPBookletScaling/Mise à l'échelle: ""
+*it.Translation HPBookletScaling/Scala: ""
+*ja.Translation HPBookletScaling/拡大縮小: ""
+*ko.Translation HPBookletScaling/스케일링: ""
+*nl.Translation HPBookletScaling/Schaal aanpassen: ""
+*nb.Translation HPBookletScaling/Skalering: ""
+*pt.Translation HPBookletScaling/Escalonando: ""
+*sv.Translation HPBookletScaling/Skalning: ""
+*zh_CN.Translation HPBookletScaling/缩放: ""
+*zh_TW.Translation HPBookletScaling/縮放: ""
+
+*HPBookletScaling Proportional/Proportional: ""
+*da.HPBookletScaling Proportional/Proportional: ""
+*de.HPBookletScaling Proportional/Proportional: ""
+*es.HPBookletScaling Proportional/Proporcional: ""
+*fi.HPBookletScaling Proportional/Suhteutettu: ""
+*fr.HPBookletScaling Proportional/Proportionnel: ""
+*it.HPBookletScaling Proportional/Proporzionale: ""
+*ja.HPBookletScaling Proportional/自動均等調整: ""
+*ko.HPBookletScaling Proportional/비례: ""
+*nl.HPBookletScaling Proportional/Proportioneel: ""
+*nb.HPBookletScaling Proportional/Proporsjonal: ""
+*pt.HPBookletScaling Proportional/Proporcional: ""
+*sv.HPBookletScaling Proportional/Proportionellt: ""
+*zh_CN.HPBookletScaling Proportional/按比例: ""
+*zh_TW.HPBookletScaling Proportional/比例: ""
+
+*HPBookletScaling FitPage/Fit To Page: ""
+*da.HPBookletScaling FitPage/Tilpas Til Side: ""
+*de.HPBookletScaling FitPage/Seite anpassen: ""
+*es.HPBookletScaling FitPage/Ajustar página: ""
+*fi.HPBookletScaling FitPage/Sovita sivu: ""
+*fr.HPBookletScaling FitPage/Ajuster la page: ""
+*it.HPBookletScaling FitPage/Adattamento pagina: ""
+*ja.HPBookletScaling FitPage/全体表示: ""
+*ko.HPBookletScaling FitPage/페이지에 맞춤: ""
+*nl.HPBookletScaling FitPage/Passend op pagina: ""
+*nb.HPBookletScaling FitPage/Tilpass til siden: ""
+*pt.HPBookletScaling FitPage/Ajuste a página: ""
+*sv.HPBookletScaling FitPage/Anpassa sida: ""
+*zh_CN.HPBookletScaling FitPage/适合页面: ""
+*zh_TW.HPBookletScaling FitPage/符合頁面: ""
+
+*CloseUI: *HPBookletScaling
+
+*% These values are set of PageSize settings so we need find
+*% the way to refer on to PageSize values
+
+
+*OpenUI *HPBookletPageSize/Paper For Booklet: PickOne
+*OrderDependency: 66 AnySetup *HPBookletPageSize
+*DefaultHPBookletPageSize: Letter
+*da.Translation HPBookletPageSize/Format På Brochure: ""
+*de.Translation HPBookletPageSize/Papier für Broschüre: ""
+*es.Translation HPBookletPageSize/Papel para folleto: ""
+*fi.Translation HPBookletPageSize/Kirjasen paperi: ""
+*fr.Translation HPBookletPageSize/Papier pour brochure: ""
+*it.Translation HPBookletPageSize/Carta per opuscolo: ""
+*ja.Translation HPBookletPageSize/ブックレットの用紙: ""
+*ko.Translation HPBookletPageSize/소책자용 용지: ""
+*nl.Translation HPBookletPageSize/Papier voor brochure: ""
+*nb.Translation HPBookletPageSize/Papir for hefte: ""
+*pt.Translation HPBookletPageSize/Papel para folheto: ""
+*sv.Translation HPBookletPageSize/Papper för broschyr: ""
+*zh_CN.Translation HPBookletPageSize/用于小册子的纸张: ""
+*zh_TW.Translation HPBookletPageSize/用於手冊的紙張: ""
+
+
+*HPBookletPageSize Letter/Letter: ""
+*da.HPBookletPageSize Letter/Letter: ""
+*de.HPBookletPageSize Letter/Letter: ""
+*es.HPBookletPageSize Letter/Letter: ""
+*fi.HPBookletPageSize Letter/Letter: ""
+*fr.HPBookletPageSize Letter/Lettre: ""
+*it.HPBookletPageSize Letter/Letter: ""
+*ja.HPBookletPageSize Letter/レター: ""
+*ko.HPBookletPageSize Letter/레터: ""
+*nl.HPBookletPageSize Letter/Letter: ""
+*nb.HPBookletPageSize Letter/Letter: ""
+*pt.HPBookletPageSize Letter/Carta: ""
+*sv.HPBookletPageSize Letter/Letter: ""
+*zh_CN.HPBookletPageSize Letter/信纸: ""
+*zh_TW.HPBookletPageSize Letter/Letter: ""
+
+*HPBookletPageSize LetterSmall/Letter (Small): ""
+*da.HPBookletPageSize LetterSmall/Letter (lille): ""
+*de.HPBookletPageSize LetterSmall/Letter (Klein): ""
+*es.HPBookletPageSize LetterSmall/Letter (pequeño): ""
+*fi.HPBookletPageSize LetterSmall/Letter (pieni): ""
+*fr.HPBookletPageSize LetterSmall/Lettre (petit): ""
+*it.HPBookletPageSize LetterSmall/Letter (ridotta): ""
+*ja.HPBookletPageSize LetterSmall/レター (小): ""
+*ko.HPBookletPageSize LetterSmall/레터 (소): ""
+*nl.HPBookletPageSize LetterSmall/Letter (klein): ""
+*nb.HPBookletPageSize LetterSmall/Letter (lite): ""
+*pt.HPBookletPageSize LetterSmall/Carta (pequeno): ""
+*sv.HPBookletPageSize LetterSmall/Letter (litet): ""
+*zh_CN.HPBookletPageSize LetterSmall/信纸 (小): ""
+*zh_TW.HPBookletPageSize LetterSmall/Letter (小): ""
+
+*HPBookletPageSize Legal/Legal: ""
+*da.HPBookletPageSize Legal/Legal: ""
+*de.HPBookletPageSize Legal/Legal: ""
+*es.HPBookletPageSize Legal/Legal: ""
+*fi.HPBookletPageSize Legal/Legal: ""
+*fr.HPBookletPageSize Legal/Légal: ""
+*it.HPBookletPageSize Legal/Legal: ""
+*ja.HPBookletPageSize Legal/リーガル: ""
+*ko.HPBookletPageSize Legal/리갈: ""
+*nl.HPBookletPageSize Legal/Legal: ""
+*nb.HPBookletPageSize Legal/Legal: ""
+*pt.HPBookletPageSize Legal/Legal: ""
+*sv.HPBookletPageSize Legal/Legal: ""
+*zh_CN.HPBookletPageSize Legal/Legal: ""
+*zh_TW.HPBookletPageSize Legal/Legal: ""
+
+*HPBookletPageSize LegalSmall/Legal (Small): ""
+*da.HPBookletPageSize LegalSmall/Legal (lille): ""
+*de.HPBookletPageSize LegalSmall/Legal (Klein): ""
+*es.HPBookletPageSize LegalSmall/Legal (pequeño): ""
+*fi.HPBookletPageSize LegalSmall/Legal (pieni): ""
+*fr.HPBookletPageSize LegalSmall/Légal (petit): ""
+*it.HPBookletPageSize LegalSmall/Legal (ridotto): ""
+*ja.HPBookletPageSize LegalSmall/リーガル (小): ""
+*ko.HPBookletPageSize LegalSmall/리갈 (소): ""
+*nl.HPBookletPageSize LegalSmall/Legal (klein): ""
+*nb.HPBookletPageSize LegalSmall/Legal (lite): ""
+*pt.HPBookletPageSize LegalSmall/Legal (pequeno): ""
+*sv.HPBookletPageSize LegalSmall/Legal (litet): ""
+*zh_CN.HPBookletPageSize LegalSmall/Legal (小): ""
+*zh_TW.HPBookletPageSize LegalSmall/Legal (小): ""
+
+*HPBookletPageSize Executive/Executive: ""
+*da.HPBookletPageSize Executive/Executive: ""
+*de.HPBookletPageSize Executive/Executive: ""
+*es.HPBookletPageSize Executive/Ejecutivo: ""
+*fi.HPBookletPageSize Executive/Executive: ""
+*fr.HPBookletPageSize Executive/Exécutif: ""
+*it.HPBookletPageSize Executive/Executive: ""
+*ja.HPBookletPageSize Executive/エグゼクティブ: ""
+*ko.HPBookletPageSize Executive/Executive: ""
+*nl.HPBookletPageSize Executive/Executive: ""
+*nb.HPBookletPageSize Executive/Executive: ""
+*pt.HPBookletPageSize Executive/Executivo: ""
+*sv.HPBookletPageSize Executive/Executive: ""
+*zh_CN.HPBookletPageSize Executive/Executive: ""
+*zh_TW.HPBookletPageSize Executive/Executive: ""
+
+*HPBookletPageSize HalfLetter/Statement: ""
+*da.HPBookletPageSize HalfLetter/Statement: ""
+*de.HPBookletPageSize HalfLetter/Statement: ""
+*es.HPBookletPageSize HalfLetter/Declaración: ""
+*fi.HPBookletPageSize HalfLetter/Statement: ""
+*fr.HPBookletPageSize HalfLetter/1/2 Lettre: ""
+*it.HPBookletPageSize HalfLetter/Dichiarazione: ""
+*ja.HPBookletPageSize HalfLetter/Statement: ""
+*ko.HPBookletPageSize HalfLetter/2절 레터: ""
+*nl.HPBookletPageSize HalfLetter/1/2 Letter : ""
+*nb.HPBookletPageSize HalfLetter/1/2 Letter: ""
+*pt.HPBookletPageSize HalfLetter/Statement: ""
+*sv.HPBookletPageSize HalfLetter/Statement: ""
+*zh_CN.HPBookletPageSize HalfLetter/结算单: ""
+*zh_TW.HPBookletPageSize HalfLetter/Statement: ""
+
+*HPBookletPageSize w612h935/8.5x13: ""
+*da.HPBookletPageSize w612h935/8.5x13: ""
+*de.HPBookletPageSize w612h935/8.5x13: ""
+*es.HPBookletPageSize w612h935/8.5x13: ""
+*fi.HPBookletPageSize w612h935/8.5x13: ""
+*fr.HPBookletPageSize w612h935/8.5x13: ""
+*it.HPBookletPageSize w612h935/8.5x13: ""
+*ja.HPBookletPageSize w612h935/8.5x13: ""
+*ko.HPBookletPageSize w612h935/8.5x13: ""
+*nl.HPBookletPageSize w612h935/8.5x13: ""
+*nb.HPBookletPageSize w612h935/8.5x13: ""
+*pt.HPBookletPageSize w612h935/8.5x13: ""
+*sv.HPBookletPageSize w612h935/8.5x13: ""
+*zh_CN.HPBookletPageSize w612h935/8.5x13: ""
+*zh_TW.HPBookletPageSize w612h935/8.5x13: ""
+
+*HPBookletPageSize Tabloid/11x17: ""
+*da.HPBookletPageSize Tabloid/11x17: ""
+*de.HPBookletPageSize Tabloid/11x17 Zoll: ""
+*es.HPBookletPageSize Tabloid/11x17: ""
+*fi.HPBookletPageSize Tabloid/11x17: ""
+*fr.HPBookletPageSize Tabloid/11 x 17 pouces: ""
+*it.HPBookletPageSize Tabloid/11x17: ""
+*ja.HPBookletPageSize Tabloid/11x17: ""
+*ko.HPBookletPageSize Tabloid/11x17: ""
+*nl.HPBookletPageSize Tabloid/11x17: ""
+*nb.HPBookletPageSize Tabloid/11x17: ""
+*pt.HPBookletPageSize Tabloid/11x17: ""
+*sv.HPBookletPageSize Tabloid/11x17: ""
+*zh_CN.HPBookletPageSize Tabloid/11x17: ""
+*zh_TW.HPBookletPageSize Tabloid/11x17 : ""
+
+*HPBookletPageSize 12X18/12x18: ""
+*da.HPBookletPageSize 12X18/12x18: ""
+*de.HPBookletPageSize 12X18/12x18: ""
+*es.HPBookletPageSize 12X18/12x18: ""
+*fi.HPBookletPageSize 12X18/12x18: ""
+*fr.HPBookletPageSize 12X18/12x18: ""
+*it.HPBookletPageSize 12X18/12x18: ""
+*ja.HPBookletPageSize 12X18/12x18: ""
+*ko.HPBookletPageSize 12X18/12x18: ""
+*nl.HPBookletPageSize 12X18/12x18: ""
+*nb.HPBookletPageSize 12X18/12x18: ""
+*pt.HPBookletPageSize 12X18/12x18: ""
+*sv.HPBookletPageSize 12X18/12x18: ""
+*zh_CN.HPBookletPageSize 12X18/12x18: ""
+*zh_TW.HPBookletPageSize 12X18/12x18: ""
+
+*HPBookletPageSize A3/A3: ""
+*da.HPBookletPageSize A3/A3: ""
+*de.HPBookletPageSize A3/A3: ""
+*es.HPBookletPageSize A3/A3: ""
+*fi.HPBookletPageSize A3/A3: ""
+*fr.HPBookletPageSize A3/A3: ""
+*it.HPBookletPageSize A3/A3: ""
+*ja.HPBookletPageSize A3/A3: ""
+*ko.HPBookletPageSize A3/A3: ""
+*nl.HPBookletPageSize A3/A3: ""
+*nb.HPBookletPageSize A3/A3: ""
+*pt.HPBookletPageSize A3/A3: ""
+*sv.HPBookletPageSize A3/A3: ""
+*zh_CN.HPBookletPageSize A3/A3: ""
+*zh_TW.HPBookletPageSize A3/A3: ""
+
+*HPBookletPageSize RA3/RA3: ""
+*da.HPBookletPageSize RA3/RA3: ""
+*de.HPBookletPageSize RA3/RA3: ""
+*es.HPBookletPageSize RA3/RA3: ""
+*fi.HPBookletPageSize RA3/RA3: ""
+*fr.HPBookletPageSize RA3/RA3: ""
+*it.HPBookletPageSize RA3/RA3: ""
+*ja.HPBookletPageSize RA3/RA3: ""
+*ko.HPBookletPageSize RA3/RA3: ""
+*nl.HPBookletPageSize RA3/RA3: ""
+*nb.HPBookletPageSize RA3/RA3: ""
+*pt.HPBookletPageSize RA3/RA3: ""
+*sv.HPBookletPageSize RA3/RA3: ""
+*zh_CN.HPBookletPageSize RA3/RA3: ""
+*zh_TW.HPBookletPageSize RA3/RA3: ""
+
+*HPBookletPageSize A4/A4: ""
+*da.HPBookletPageSize A4/A4: ""
+*de.HPBookletPageSize A4/A4: ""
+*es.HPBookletPageSize A4/A4: ""
+*fi.HPBookletPageSize A4/A4: ""
+*fr.HPBookletPageSize A4/A4: ""
+*it.HPBookletPageSize A4/A4: ""
+*ja.HPBookletPageSize A4/A4: ""
+*ko.HPBookletPageSize A4/A4: ""
+*nl.HPBookletPageSize A4/A4: ""
+*nb.HPBookletPageSize A4/A4: ""
+*pt.HPBookletPageSize A4/A4: ""
+*sv.HPBookletPageSize A4/A4: ""
+*zh_CN.HPBookletPageSize A4/A4: ""
+*zh_TW.HPBookletPageSize A4/A4: ""
+
+*HPBookletPageSize A4Small/A4 (Small): ""
+*da.HPBookletPageSize A4Small/A4 (lille): ""
+*de.HPBookletPageSize A4Small/A4 (Klein): ""
+*es.HPBookletPageSize A4Small/A4 (pequeño): ""
+*fi.HPBookletPageSize A4Small/A4 (pieni): ""
+*fr.HPBookletPageSize A4Small/A4 (petit): ""
+*it.HPBookletPageSize A4Small/A4 (ridotta): ""
+*ja.HPBookletPageSize A4Small/A4 (小): ""
+*ko.HPBookletPageSize A4Small/A4 (소): ""
+*nl.HPBookletPageSize A4Small/A4 (klein): ""
+*nb.HPBookletPageSize A4Small/A4 (lite): ""
+*pt.HPBookletPageSize A4Small/A4 (pequeno): ""
+*sv.HPBookletPageSize A4Small/A4 (litet): ""
+*zh_CN.HPBookletPageSize A4Small/A4 (小): ""
+*zh_TW.HPBookletPageSize A4Small/A4 (小): ""
+
+*HPBookletPageSize A5/A5: ""
+*da.HPBookletPageSize A5/A5: ""
+*de.HPBookletPageSize A5/A5: ""
+*es.HPBookletPageSize A5/A5: ""
+*fi.HPBookletPageSize A5/A5: ""
+*fr.HPBookletPageSize A5/A5: ""
+*it.HPBookletPageSize A5/A5: ""
+*ja.HPBookletPageSize A5/A5: ""
+*ko.HPBookletPageSize A5/A5: ""
+*nl.HPBookletPageSize A5/A5: ""
+*nb.HPBookletPageSize A5/A5: ""
+*pt.HPBookletPageSize A5/A5: ""
+*sv.HPBookletPageSize A5/A5: ""
+*zh_CN.HPBookletPageSize A5/A5: ""
+*zh_TW.HPBookletPageSize A5/A5: ""
+
+*HPBookletPageSize B5/B5 (JIS): ""
+*da.HPBookletPageSize B5/JIS B5: ""
+*de.HPBookletPageSize B5/B5 (JIS): ""
+*es.HPBookletPageSize B5/JIS B5: ""
+*fi.HPBookletPageSize B5/JIS B5: ""
+*fr.HPBookletPageSize B5/JIS B5: ""
+*it.HPBookletPageSize B5/JIS B5: ""
+*ja.HPBookletPageSize B5/B5 (JIS): ""
+*ko.HPBookletPageSize B5/JIS B5: ""
+*nl.HPBookletPageSize B5/JIS B5: ""
+*nb.HPBookletPageSize B5/JIS B5: ""
+*pt.HPBookletPageSize B5/B5 JIS: ""
+*sv.HPBookletPageSize B5/JIS B5: ""
+*zh_CN.HPBookletPageSize B5/JIS B5: ""
+*zh_TW.HPBookletPageSize B5/JIS B5: ""
+
+*HPBookletPageSize B4/B4 (JIS): ""
+*da.HPBookletPageSize B4/JIS B4: ""
+*de.HPBookletPageSize B4/B4 (JIS): ""
+*es.HPBookletPageSize B4/JIS B4: ""
+*fi.HPBookletPageSize B4/JIS B4: ""
+*fr.HPBookletPageSize B4/JIS B4: ""
+*it.HPBookletPageSize B4/JIS B4: ""
+*ja.HPBookletPageSize B4/B4 (JIS): ""
+*ko.HPBookletPageSize B4/JIS B4: ""
+*nl.HPBookletPageSize B4/JIS B4: ""
+*nb.HPBookletPageSize B4/JIS B4: ""
+*pt.HPBookletPageSize B4/B4 JIS: ""
+*sv.HPBookletPageSize B4/JIS B4: ""
+*zh_CN.HPBookletPageSize B4/JIS B4: ""
+*zh_TW.HPBookletPageSize B4/JIS B4: ""
+
+*HPBookletPageSize w612h936/Executive (JIS): ""
+*da.HPBookletPageSize w612h936/Executive (JIS): ""
+*de.HPBookletPageSize w612h936/Executive (JIS): ""
+*es.HPBookletPageSize w612h936/Ejecutivo (JIS): ""
+*fi.HPBookletPageSize w612h936/Executive (JIS): ""
+*fr.HPBookletPageSize w612h936/Exécutif (JIS): ""
+*it.HPBookletPageSize w612h936/Executive (JIS): ""
+*ja.HPBookletPageSize w612h936/エグゼクティブ (JIS): ""
+*ko.HPBookletPageSize w612h936/Executive(JIS): ""
+*nl.HPBookletPageSize w612h936/Executive (JIS): ""
+*nb.HPBookletPageSize w612h936/Executive (JIS): ""
+*pt.HPBookletPageSize w612h936/Executivo (JIS): ""
+*sv.HPBookletPageSize w612h936/Executive (JIS): ""
+*zh_CN.HPBookletPageSize w612h936/Executive (JIS): ""
+*zh_TW.HPBookletPageSize w612h936/Executive (JIS): ""
+
+*HPBookletPageSize w774h1116/8K: ""
+*da.HPBookletPageSize w774h1116/8K: ""
+*de.HPBookletPageSize w774h1116/8K: ""
+*es.HPBookletPageSize w774h1116/8K: ""
+*fi.HPBookletPageSize w774h1116/8K: ""
+*fr.HPBookletPageSize w774h1116/8K: ""
+*it.HPBookletPageSize w774h1116/8K: ""
+*ja.HPBookletPageSize w774h1116/8K: ""
+*ko.HPBookletPageSize w774h1116/8K: ""
+*nl.HPBookletPageSize w774h1116/8K: ""
+*nb.HPBookletPageSize w774h1116/8K: ""
+*pt.HPBookletPageSize w774h1116/8K: ""
+*sv.HPBookletPageSize w774h1116/8K: ""
+*zh_CN.HPBookletPageSize w774h1116/8K: ""
+*zh_TW.HPBookletPageSize w774h1116/8K: ""
+
+*HPBookletPageSize w558h774/16K: ""
+*da.HPBookletPageSize w558h774/16K: ""
+*de.HPBookletPageSize w558h774/16K: ""
+*es.HPBookletPageSize w558h774/16K: ""
+*fi.HPBookletPageSize w558h774/16K: ""
+*fr.HPBookletPageSize w558h774/16K: ""
+*it.HPBookletPageSize w558h774/16K: ""
+*ja.HPBookletPageSize w558h774/16K: ""
+*ko.HPBookletPageSize w558h774/16K: ""
+*nl.HPBookletPageSize w558h774/16K: ""
+*nb.HPBookletPageSize w558h774/16K: ""
+*pt.HPBookletPageSize w558h774/16K: ""
+*sv.HPBookletPageSize w558h774/16K: ""
+*zh_CN.HPBookletPageSize w558h774/16K: ""
+*zh_TW.HPBookletPageSize w558h774/16K: ""
+
+*CloseUI: *HPBookletPageSize
+
+*%Constraints on HPBookletPageSize
+*%=============================================
+*UIConstraints: *HPBookletPageSize 12X18       *InputSlot Tray2
+*UIConstraints: *HPBookletPageSize 12X18       *InputSlot Tray3
+*UIConstraints: *HPBookletPageSize RA3       *InputSlot Tray2
+*UIConstraints: *HPBookletPageSize RA3       *InputSlot Tray3
+*UIConstraints: *InputSlot Tray2	  *HPBookletPageSize 12X18
+*UIConstraints: *InputSlot Tray3	  *HPBookletPageSize 12X18
+*UIConstraints: *InputSlot Tray2	  *HPBookletPageSize RA3
+*UIConstraints: *InputSlot Tray3	  *HPBookletPageSize RA3
+*UIConstraints: *HPBookletPageSize HalfLetter      *InputSlot Tray4Optional
+*UIConstraints: *HPBookletPageSize 12X18        	*InputSlot Tray4Optional
+*UIConstraints: *HPBookletPageSize RA3        	*InputSlot Tray4Optional
+*UIConstraints: *HPBookletPageSize A5        	*InputSlot Tray4Optional
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize HalfLetter
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize 12X18
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize A3
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize RA3
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize A5
+*UIConstraints: *HPBookletPageSize Executive   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize HalfLetter   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w612h935   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize 12X18   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize A5   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize RA3   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize B5   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w612h936   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w558h774   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w774h1116   *OutputBin HPBooklet
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize Executive
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize HalfLetter
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w612h935
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize 12X18
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize A5
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize RA3
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize B5
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w612h936
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w558h774
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w774h1116
+
+*OpenUI *OutputBin/Output Bin: PickOne
+*OrderDependency: 100 AnySetup *OutputBin
+*DefaultOutputBin: PrinterDefault
+*da.Translation OutputBin/Udskriftsbakke: ""
+*de.Translation OutputBin/Ausgabefach: ""
+*es.Translation OutputBin/Bandeja de salida: ""
+*fi.Translation OutputBin/Tulostelokero: ""
+*fr.Translation OutputBin/Bac de sortie: ""
+*it.Translation OutputBin/Scomparto di uscita: ""
+*ja.Translation OutputBin/排紙トレイ: ""
+*ko.Translation OutputBin/출력 용지함: ""
+*nl.Translation OutputBin/Uitvoerbak: ""
+*nb.Translation OutputBin/Utskuff: ""
+*pt.Translation OutputBin/Compartimento de saída: ""
+*sv.Translation OutputBin/Utmatningsfack: ""
+*zh_CN.Translation OutputBin/出纸槽: ""
+*zh_TW.Translation OutputBin/出紙槽: ""
+
+*OutputBin PrinterDefault/Printer's Current Setting: ""
+*da.OutputBin PrinterDefault/Printerens aktuelle indstilling: ""
+*de.OutputBin PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.OutputBin PrinterDefault/Configuración actual de la impresora: ""
+*fi.OutputBin PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.OutputBin PrinterDefault/Paramétrage actuel de l’imprimante: ""
+*it.OutputBin PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.OutputBin PrinterDefault/プリンタの現在の設定: ""
+*ko.OutputBin PrinterDefault/프린터의 현재 설정: ""
+*nl.OutputBin PrinterDefault/Huidige instelling van de printer: ""
+*nb.OutputBin PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.OutputBin PrinterDefault/Configuração atual da impressora: ""
+*sv.OutputBin PrinterDefault/Skrivarens inställning: ""
+*zh_CN.OutputBin PrinterDefault/打印机的当前设置: ""
+*zh_TW.OutputBin PrinterDefault/印表機目前的設定值: ""
+
+*OutputBin Upper/Top Bin: "<</Staple 0 /OutputType (TOP OUTPUT BIN)>> setpagedevice"
+*da.OutputBin Upper/ÿverste (forside nedad): ""
+*de.OutputBin Upper/Linkes (unten): ""
+*es.OutputBin Upper/Superior (boca abajo): ""
+*fi.OutputBin Upper/Ylälokero (tulostuspuoli lokero): ""
+*fr.OutputBin Upper/Bac supérieur (Verso): ""
+*it.OutputBin Upper/Vassoio superiore (verso il basso): ""
+*ja.OutputBin Upper/上部トレイ (下向き): ""
+*ko.OutputBin Upper/위쪽 용지함 (페이스다운): ""
+*nl.OutputBin Upper/Bovenbak (afdrukzijde naar beneden): ""
+*nb.OutputBin Upper/Øvre skuff (fors ned): ""
+*pt.OutputBin Upper/Bandeja superior (Voltado para baixo): ""
+*sv.OutputBin Upper/Övre (texten nedåt): ""
+*zh_CN.OutputBin Upper/上层纸盒 (下）): ""
+*zh_TW.OutputBin Upper/上層紙匣 (列印面向下): ""
+
+*OutputBin Left/Left Output Bin (Face Up): "
+   currentpagedevice /MediaProcessingDetails known
+   {   currentpagedevice /MediaProcessingDetails get /DeviceID known
+       {   currentpagedevice /MediaProcessingDetails get /DeviceID get (multifunction) search
+           { currentpagedevice /OutputAttributes get
+                {
+                pop pop pop
+                <</MediaProcessing (FACE_UP) /MediaProcessingDetails
+                <</MediaProcessingOption (FACE_UP) /MediaProcessingBoundary 0 /Type 8>> >> setpagedevice
+           		}
+           	}
+       } <</MediaProcessing (FACE_UP) /MediaProcessingDetails
+                <</MediaProcessingOption (FACE_UP) /MediaProcessingBoundary 0 /Type 8>> >> setpagedevice
+   }
+   {<</Staple 0 /OutputType (FACE UP BIN)>> setpagedevice} ifelse
+"
+*End
+*da.OutputBin Left/Venstre (forside opad): ""
+*de.OutputBin Left/Oberes (oben): ""
+*es.OutputBin Left/Izquierda (boca arriba): ""
+*fi.OutputBin Left/Vasen (tulostuspuoli ylös): ""
+*fr.OutputBin Left/Bac gauche (Recto): ""
+*it.OutputBin Left/Scomparto di uscita sinistro (verso l’alto): ""
+*ja.OutputBin Left/左排紙トレイ (上向き): ""
+*ko.OutputBin Left/왼쪽 용지함 (페이스업): ""
+*nl.OutputBin Left/Linker uitvoerbak (afdrukzijde naar boven): ""
+*nb.OutputBin Left/Øvre venstre skuff (fors opp): ""
+*pt.OutputBin Left/Compartimento esquerdo (Voltado para cima): ""
+*sv.OutputBin Left/Vänster fack (texten uppåt): ""
+*zh_CN.OutputBin Left/左侧出纸槽 (上）): ""
+*zh_TW.OutputBin Left/左出紙槽 (列印面向上): ""
+
+*OutputBin StackerFaceUp/Stacker (Face-UP): "
+currentpagedevice /MediaProcessing known
+  { << /MediaProcessing (FACE_UP) /MediaProcessingDetails<<
+						  /MediaProcessingOption (FACE_UP)
+						  /MedaiProcessingBoundary 0 /ImageOrientation 0 /Type 8 >> >> setpagedevice
+  }
+  {
+  currentpagedevice /OutputAttributes get
+   4 known
+         {<</Staple 0 /OutputType (FACE UP BIN)>> setpagedevice}
+         {<</Staple 0 /OutputType (LEFT OUTPUT BIN)>> setpagedevice}
+       ifelse
+} ifelse"
+*End
+*da.OutputBin StackerFaceUp/Stabler (forside opad): ""
+*de.OutputBin StackerFaceUp/Stapel (Druckseite oben): ""
+*es.OutputBin StackerFaceUp/Apilador (boca arriba): ""
+*fi.OutputBin StackerFaceUp/Pinoaja (tulostuspuoli ylös): ""
+*fr.OutputBin StackerFaceUp/Récepteur (Recto): ""
+*it.OutputBin StackerFaceUp/Accumulatore (verso l’alto): ""
+*ja.OutputBin StackerFaceUp/スタッカ (上向き): ""
+*ko.OutputBin StackerFaceUp/스태커(페이스업): ""
+*nl.OutputBin StackerFaceUp/Stapelaar (afdrukzijde naar boven): ""
+*nb.OutputBin StackerFaceUp/Magasin (fors opp): ""
+*pt.OutputBin StackerFaceUp/Empilhador (Voltado para cima): ""
+*sv.OutputBin StackerFaceUp/Stapling (texten uppåt): ""
+*zh_CN.OutputBin StackerFaceUp/堆栈器（面朝上）: ""
+*zh_TW.OutputBin StackerFaceUp/堆疊器（列印面向上）: ""
+
+*OutputBin Stacker/Stacker (Face-Down): "
+  currentpagedevice /MediaProcessingDetails known{
+	currentpagedevice /MediaProcessingDetails get /ModelID get
+	(C8088B) search {<< /MediaProcessing (FACE_DOWN) /MediaProcessingDetails
+	<</MediaProcessingOption (FACE_DOWN)/MedaiProcessingBoundary 0
+	/ImageOrientation 0 /Type 8 >> >> setpagedevice put }
+            {<</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice} ifelse }
+  {<</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice} ifelse "
+*End
+*da.OutputBin Stacker/Stabler (forside nedad): ""
+*de.OutputBin Stacker/Stapel (Druckseite unten): ""
+*es.OutputBin Stacker/Apilador (boca abajo): ""
+*fi.OutputBin Stacker/Pinoaja (tulostuspuoli alas): ""
+*fr.OutputBin Stacker/Récepteur (Verso): ""
+*it.OutputBin Stacker/Accumulatore (verso il basso): ""
+*ja.OutputBin Stacker/スタッカ (下向き): ""
+*ko.OutputBin Stacker/스태커(페이스다운): ""
+*nl.OutputBin Stacker/Stapelaar (afdrukzijde naar beneden): ""
+*nb.OutputBin Stacker/Magasin (fors ned): ""
+*pt.OutputBin Stacker/Empilhador (Voltado para baixo): ""
+*sv.OutputBin Stacker/Stapling (texten nedåt): ""
+*zh_CN.OutputBin Stacker/堆栈器（面朝下）: ""
+*zh_TW.OutputBin Stacker/堆疊器（列印面向下）: ""
+
+*OutputBin HP8BinMB/8-Bin Mailbox: ""
+*da.OutputBin HP8BinMB/Postkasse med 8 bakker: ""
+*de.OutputBin HP8BinMB/Mailbox mit 8 Fächern: ""
+*es.OutputBin HP8BinMB/Buzón de 8 bandejas: ""
+*fi.OutputBin HP8BinMB/8 lokeron postilaatikko: ""
+*fr.OutputBin HP8BinMB/Trieuse à 8 bacs: ""
+*it.OutputBin HP8BinMB/Casella a 8 scomparti: ""
+*ja.OutputBin HP8BinMB/8 トレイメールボックス: ""
+*ko.OutputBin HP8BinMB/8단 우편함: ""
+*nl.OutputBin HP8BinMB/Postbus met 8 bakken: ""
+*nb.OutputBin HP8BinMB/Postkasse med 8 lommer: ""
+*pt.OutputBin HP8BinMB/Caixa de correio com oito compartimentos: ""
+*sv.OutputBin HP8BinMB/Sorterare med 8 fack: ""
+*zh_CN.OutputBin HP8BinMB/8 槽信箱: ""
+*zh_TW.OutputBin HP8BinMB/8 槽式信箱: ""
+
+*OutputBin UStapler/Stapler: ""
+*da.OutputBin UStapler/Hæfter: ""
+*de.OutputBin UStapler/Hefter: ""
+*es.OutputBin UStapler/Grapadora: ""
+*fi.OutputBin UStapler/Nitoja: ""
+*fr.OutputBin UStapler/Agrafeuse: ""
+*it.OutputBin UStapler/Cucitrice: ""
+*ja.OutputBin UStapler/ホチキス: ""
+*ko.OutputBin UStapler/스테이플러: ""
+*nl.OutputBin UStapler/Nietmachine: ""
+*nb.OutputBin UStapler/Stifteenhet : ""
+*pt.OutputBin UStapler/Grampeador: ""
+*sv.OutputBin UStapler/Häftning: ""
+*zh_CN.OutputBin UStapler/装订器: ""
+*zh_TW.OutputBin UStapler/裝訂機: ""
+
+*OutputBin HPBooklet/Booklet Bin: "
+  << /MediaProcessing (BOOKLET_MAKER) /MediaProcessingDetails <<
+  /MediaProcessingOption (BOOKLET_MAKER) /MedaiProcessingBoundary 0
+  /ImageOrientation 0 /Type 8 >> >> setpagedevice
+  << /Staple 0 /OutputType (OPTIONAL OUTBIN 2) >> setpagedevice
+"
+*End
+*da.OutputBin HPBooklet/Brochurebakke: ""
+*de.OutputBin HPBooklet/Broschürenfach: ""
+*es.OutputBin HPBooklet/Apiladora de folletos: ""
+*fi.OutputBin HPBooklet/Vihkon lokero: ""
+*fr.OutputBin HPBooklet/Bac à brochures: ""
+*it.OutputBin HPBooklet/Scomparto opuscoli: ""
+*ja.OutputBin HPBooklet/ブックレット ビン: ""
+*ko.OutputBin HPBooklet/소책자 용지함: ""
+*nl.OutputBin HPBooklet/Brochurebak: ""
+*nb.OutputBin HPBooklet/Hefteutskuff: ""
+*pt.OutputBin HPBooklet/Compartimento de folheto: ""
+*sv.OutputBin HPBooklet/Fack för broschyr: ""
+*zh_CN.OutputBin HPBooklet/小册子纸槽: ""
+*zh_TW.OutputBin HPBooklet/書冊出紙槽: ""
+
+*?OutputBin: "save
+ currentpagedevice /OutputAttributes get dup
+ 5 known
+ {/Priority get 0 get
+    [(Upper) (Left) (Reserved1) (Reserved2) (OutputBin1)
+     (OutputBin2) (OutputBin3) (OutputBin4) (OutputBin5) (OutputBin6) (OutputBin7) (OutputBin8)] exch get = flush}
+ {/Priority get 0 get
+    [(Upper) (Left)  (Reserved1) (Reserved2) (Stacker)] exch get = flush} ifelse
+restore
+"
+*End
+*CloseUI: *OutputBin
+
+*%=== 3000 Sheet Stacker/Stapler Stapler Options =========================
+*OpenUI *HPStaplerOptions/Finishing Options: PickOne
+*OrderDependency: 45 AnySetup *HPStaplerOptions
+*DefaultHPStaplerOptions: PrintersDefault
+*da.Translation HPStaplerOptions/Hæftningsvalg/Foldning: ""
+*de.Translation HPStaplerOptions/Heftoptionen: ""
+*es.Translation HPStaplerOptions/Opción Grapadora: ""
+*fi.Translation HPStaplerOptions/Nitoja-asetus: ""
+*fr.Translation HPStaplerOptions/Option de l’agrafeuse: ""
+*it.Translation HPStaplerOptions/Opzione di cucitura: ""
+*ja.Translation HPStaplerOptions/ステイプル留め/折り畳み: ""
+*ko.Translation HPStaplerOptions/스테이플러 선택사항: ""
+*nl.Translation HPStaplerOptions/Nietmethode: ""
+*nb.Translation HPStaplerOptions/Stiftealternativ: ""
+*pt.Translation HPStaplerOptions/Opção de Grampeador: ""
+*sv.Translation HPStaplerOptions/Häftningsalternativ: ""
+*zh_CN.Translation HPStaplerOptions/装订器选项: ""
+*zh_TW.Translation HPStaplerOptions/裝訂機選項: ""
+
+*HPStaplerOptions PrintersDefault/Printer's Current Setting: "
+  <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (NONE) /MediaProcessingBoundary 0
+    /ImageOrientation 1 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions PrintersDefault/Ingen: ""
+*de.HPStaplerOptions PrintersDefault/Aktuelle Einstellung des Druckers: ""
+*es.HPStaplerOptions PrintersDefault/Configuración actual de la impresora: ""
+*fi.HPStaplerOptions PrintersDefault/Kirjoittimen nykyinen asetus: ""
+*fr.HPStaplerOptions PrintersDefault/Paramétrage actuel de l’imprimante: ""
+*it.HPStaplerOptions PrintersDefault/Impostazione corrente stampante: ""
+*ja.HPStaplerOptions PrintersDefault/なし: ""
+*ko.HPStaplerOptions PrintersDefault/프린터의 현재 설정: ""
+*nl.HPStaplerOptions PrintersDefault/Huidige printerinstellingen: ""
+*nb.HPStaplerOptions PrintersDefault/Skriverens gjeldende innstilling: ""
+*pt.HPStaplerOptions PrintersDefault/Configuração atual da Impressora: ""
+*sv.HPStaplerOptions PrintersDefault/Skrivarens inställning: ""
+*zh_CN.HPStaplerOptions PrintersDefault/打印机当前设定值: ""
+*zh_TW.HPStaplerOptions PrintersDefault/印表機目前設定值: ""
+
+*HPStaplerOptions 1diagonal/1 Staple, diagonal: "
+  <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (ANGLED_STAPLE) /MediaProcessingBoundary 0
+    /ImageOrientation 0 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 1diagonal/En hæfteklamme, diagonal: ""
+*de.HPStaplerOptions 1diagonal/Eine Heftklammer, diagonal: ""
+*es.HPStaplerOptions 1diagonal/Una grapa, diagonal: ""
+*fi.HPStaplerOptions 1diagonal/Yksi niitti, vino: ""
+*fr.HPStaplerOptions 1diagonal/Une agrafe, diagonal: ""
+*it.HPStaplerOptions 1diagonal/Un punto, diagonale: ""
+*ja.HPStaplerOptions 1diagonal/ステイプル, 斜め: ""
+*ko.HPStaplerOptions 1diagonal/스테이플러 1개, 대각선: ""
+*nl.HPStaplerOptions 1diagonal/Eén nietje diagonal: ""
+*nb.HPStaplerOptions 1diagonal/Én stift, diagonalt: ""
+*pt.HPStaplerOptions 1diagonal/Um grampo á diagonal: ""
+*sv.HPStaplerOptions 1diagonal/1 häftklammer, diagonal: ""
+*zh_CN.HPStaplerOptions 1diagonal/一个订书钉, 对角: ""
+*zh_TW.HPStaplerOptions 1diagonal/1個訂書釘: ""
+
+*HPStaplerOptions 1parallel/1 Staple, parallel: "
+   <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (ONE_STAPLE) /MediaProcessingBoundary 0
+    /ImageOrientation 0 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 1parallel/En hæfteklamme, parallel: ""
+*de.HPStaplerOptions 1parallel/Eine Heftklammer, parallel: ""
+*es.HPStaplerOptions 1parallel/Una grapa, paralelo: ""
+*fi.HPStaplerOptions 1parallel/Yksi niitti, rinnakkainen: ""
+*fr.HPStaplerOptions 1parallel/Une agrafe, paralléle: ""
+*it.HPStaplerOptions 1parallel/Un punto, parallela: ""
+*ja.HPStaplerOptions 1parallel/1 箇所, パラレル: ""
+*ko.HPStaplerOptions 1parallel/스테이플러 1개, 병렬: ""
+*nl.HPStaplerOptions 1parallel/Eén nietje parallel: ""
+*nb.HPStaplerOptions 1parallel/Én stift, parallell: ""
+*pt.HPStaplerOptions 1parallel/Um grampo á paralela: ""
+*sv.HPStaplerOptions 1parallel/1 häftklammer, parallel: ""
+*zh_CN.HPStaplerOptions 1parallel/一个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 1parallel/1枚釘書針: ""
+
+*HPStaplerOptions 2parallel/2 Staples, parallel: "
+  <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (TWO_STAPLES) /MediaProcessingBoundary 0
+    /ImageOrientation 1 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 2parallel/To hæfteklammer, parallel: ""
+*de.HPStaplerOptions 2parallel/Zwei Heftklammern, parallel: ""
+*es.HPStaplerOptions 2parallel/Dos grapas, paralelo: ""
+*fi.HPStaplerOptions 2parallel/Kaksi niittiä, rinnakkainen: ""
+*fr.HPStaplerOptions 2parallel/Deux agrafes, paralléle: ""
+*it.HPStaplerOptions 2parallel/Due punti, parallela: ""
+*ja.HPStaplerOptions 2parallel/2 箇所, パラレル: ""
+*ko.HPStaplerOptions 2parallel/스테이플러 2개, 병렬: ""
+*nl.HPStaplerOptions 2parallel/Twee nietjes parallel: ""
+*nb.HPStaplerOptions 2parallel/To stifter, parallell: ""
+*pt.HPStaplerOptions 2parallel/Dois grampos á paralela: ""
+*sv.HPStaplerOptions 2parallel/2 häftklamrar, parallel: ""
+*zh_CN.HPStaplerOptions 2parallel/2个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 2parallel/2枚釘書針: ""
+
+*HPStaplerOptions 3parallel/3 Staples, parallel: "
+ <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (THREE_STAPLES) /MediaProcessingBoundary 0
+    /ImageOrientation 0 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 3parallel/Tre hæfteklammer, parallel: ""
+*de.HPStaplerOptions 3parallel/Drei Heftklammern, parallel: ""
+*es.HPStaplerOptions 3parallel/Tres grapas, paralelo: ""
+*fi.HPStaplerOptions 3parallel/Kolme niittiä, rinnakkainen: ""
+*fr.HPStaplerOptions 3parallel/Trois agrafes, paralléle: ""
+*it.HPStaplerOptions 3parallel/Tre punti, parallela: ""
+*ja.HPStaplerOptions 3parallel/3 箇所, パラレル: ""
+*ko.HPStaplerOptions 3parallel/스테이플러 3개, 병렬: ""
+*nl.HPStaplerOptions 3parallel/Drie nietjes parallel: ""
+*nb.HPStaplerOptions 3parallel/Tre stifter, parallell: ""
+*pt.HPStaplerOptions 3parallel/TrÍs grampos do paralela: ""
+*sv.HPStaplerOptions 3parallel/3 häftklamrar, parallel: ""
+*zh_CN.HPStaplerOptions 3parallel/三个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 3parallel/三枚釘書針, 平行: ""
+
+*HPStaplerOptions 6parallel/6 Staples, parallel: "
+   <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (SIX_STAPLES) /MediaProcessingBoundary 0
+    /ImageOrientation 1 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 6parallel/Seks hæfteklammer, parallel: ""
+*de.HPStaplerOptions 6parallel/Sechs Heftklammern, parallel: ""
+*es.HPStaplerOptions 6parallel/Seis grapas, paralelo: ""
+*fi.HPStaplerOptions 6parallel/Kuusi niittiä, rinnakkainen: ""
+*fr.HPStaplerOptions 6parallel/Six agrafes, paralléle: ""
+*it.HPStaplerOptions 6parallel/Sei punti, parallela: ""
+*ja.HPStaplerOptions 6parallel/6 箇所, パラレル: ""
+*ko.HPStaplerOptions 6parallel/스테이플러 6개, 병렬: ""
+*nl.HPStaplerOptions 6parallel/Zes nietjes parallel: ""
+*nb.HPStaplerOptions 6parallel/Seks stifter, parallell: ""
+*pt.HPStaplerOptions 6parallel/Seis grampos do paralela: ""
+*sv.HPStaplerOptions 6parallel/6 häftklamrar, parallel: ""
+*zh_CN.HPStaplerOptions 6parallel/六个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 6parallel/六枚釘書針, 平行: ""
+
+*%*HPStaplerOptions HPBooklet/Fold & Saddle Stitch: "
+*%  << /MediaProcessing (BOOKLET_MAKER) /MediaProcessingDetails <<
+*%  /MediaProcessingOption (BOOKLET_MAKER) /MedaiProcessingBoundary 0
+*%  /ImageOrientation 0 /Type 8 >> >> setpagedevice
+*%  << /Staple 0 /OutputType (OPTIONAL OUTBIN 2) >> setpagedevice"
+*%*End
+*CloseUI: *HPStaplerOptions
+
+*%=== 8 Bin MultiBin MailBox Options =========================
+*OpenUI *HPMailboxOptions/Mailbox Options: PickOne
+*OrderDependency: 46 AnySetup *HPMailboxOptions
+*DefaultHPMailboxOptions: PrintersDefault
+*da.Translation HPMailboxOptions/Finisher-indstillinger: ""
+*de.Translation HPMailboxOptions/Fertigstellung: ""
+*es.Translation HPMailboxOptions/Acabado: ""
+*fi.Translation HPMailboxOptions/Viimeistelyasetukset: ""
+*fr.Translation HPMailboxOptions/Options de finition: ""
+*it.Translation HPMailboxOptions/Opzioni di finitura: ""
+*ja.Translation HPMailboxOptions/仕上げオプション: ""
+*ko.Translation HPMailboxOptions/마감장치 옵션: ""
+*nl.Translation HPMailboxOptions/Afwerkingsopties: ""
+*nb.Translation HPMailboxOptions/Etterbehandling: ""
+*pt.Translation HPMailboxOptions/Acabamento: ""
+*sv.Translation HPMailboxOptions/Efterbehandling: ""
+*zh_CN.Translation HPMailboxOptions/完成选项: ""
+*zh_TW.Translation HPMailboxOptions/外觀選項: ""
+
+*HPMailboxOptions PrintersDefault/Printer's Current Setting: ""
+*da.HPMailboxOptions PrintersDefault/Ingen: ""
+*de.HPMailboxOptions PrintersDefault/Aktuelle Einstellung: ""
+*es.HPMailboxOptions PrintersDefault/Valor actual: ""
+*fi.HPMailboxOptions PrintersDefault/Nykyinen asetus: ""
+*fr.HPMailboxOptions PrintersDefault/Paramétrage actuel de l’imprimante: ""
+*it.HPMailboxOptions PrintersDefault/Impostazione corrente: ""
+*ja.HPMailboxOptions PrintersDefault/現在の設定: ""
+*ko.HPMailboxOptions PrintersDefault/현재 설정: ""
+*nl.HPMailboxOptions PrintersDefault/Huidige instelling: ""
+*nb.HPMailboxOptions PrintersDefault/Ingen: ""
+*pt.HPMailboxOptions PrintersDefault/Configuração atual: ""
+*sv.HPMailboxOptions PrintersDefault/Aktuell inställning: ""
+*zh_CN.HPMailboxOptions PrintersDefault/当前设置: ""
+*zh_TW.HPMailboxOptions PrintersDefault/目前設定值: ""
+
+*HPMailboxOptions Bin1/Output Bin 1: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin1/Postkasse 1: ""
+*de.HPMailboxOptions Bin1/Ausgabefach 1: ""
+*es.HPMailboxOptions Bin1/Buzón 1: ""
+*fi.HPMailboxOptions Bin1/Lokero 1: ""
+*fr.HPMailboxOptions Bin1/Trieuse 1: ""
+*it.HPMailboxOptions Bin1/Casella 1: ""
+*ja.HPMailboxOptions Bin1/メールボックス 1: ""
+*ko.HPMailboxOptions Bin1/용지함 1: ""
+*nl.HPMailboxOptions Bin1/Bak 1: ""
+*nb.HPMailboxOptions Bin1/Utskuff 1: ""
+*pt.HPMailboxOptions Bin1/Caixa de correio 1: ""
+*sv.HPMailboxOptions Bin1/Fack 1: ""
+*zh_CN.HPMailboxOptions Bin1/信箱 1: ""
+*zh_TW.HPMailboxOptions Bin1/1 號信箱: ""
+
+*HPMailboxOptions Bin2/Output Bin 2: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 3)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin2/Postkasse 2: ""
+*de.HPMailboxOptions Bin2/Ausgabefach 2: ""
+*es.HPMailboxOptions Bin2/Buzón 2: ""
+*fi.HPMailboxOptions Bin2/Lokero 2: ""
+*fr.HPMailboxOptions Bin2/Trieuse 2: ""
+*it.HPMailboxOptions Bin2/Casella 2: ""
+*ja.HPMailboxOptions Bin2/メールボックス 2: ""
+*ko.HPMailboxOptions Bin2/용지함 2: ""
+*nl.HPMailboxOptions Bin2/Bak 2: ""
+*nb.HPMailboxOptions Bin2/Utskuff 2: ""
+*pt.HPMailboxOptions Bin2/Caixa de correio 2: ""
+*sv.HPMailboxOptions Bin2/Fack 2: ""
+*zh_CN.HPMailboxOptions Bin2/信箱 2: ""
+*zh_TW.HPMailboxOptions Bin2/2 號信箱: ""
+
+*HPMailboxOptions Bin3/Output Bin 3: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 4)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin3/Postkasse 3: ""
+*de.HPMailboxOptions Bin3/Ausgabefach 3: ""
+*es.HPMailboxOptions Bin3/Buzón 3: ""
+*fi.HPMailboxOptions Bin3/Lokero 3: ""
+*fr.HPMailboxOptions Bin3/Trieuse 3: ""
+*it.HPMailboxOptions Bin3/Casella 3: ""
+*ja.HPMailboxOptions Bin3/メールボックス 3: ""
+*ko.HPMailboxOptions Bin3/용지함 3: ""
+*nl.HPMailboxOptions Bin3/Bak 3: ""
+*nb.HPMailboxOptions Bin3/Utskuff 3: ""
+*pt.HPMailboxOptions Bin3/Caixa de correio 3: ""
+*sv.HPMailboxOptions Bin3/Fack 3: ""
+*zh_CN.HPMailboxOptions Bin3/信箱 3: ""
+*zh_TW.HPMailboxOptions Bin3/3 號信箱: ""
+
+*HPMailboxOptions Bin4/Output Bin 4: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 5)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin4/Postkasse 4: ""
+*de.HPMailboxOptions Bin4/Ausgabefach 4: ""
+*es.HPMailboxOptions Bin4/Buzón 4: ""
+*fi.HPMailboxOptions Bin4/Lokero 4: ""
+*fr.HPMailboxOptions Bin4/Trieuse 4: ""
+*it.HPMailboxOptions Bin4/Casella 4: ""
+*ja.HPMailboxOptions Bin4/メールボックス 4: ""
+*ko.HPMailboxOptions Bin4/용지함 4: ""
+*nl.HPMailboxOptions Bin4/Bak 4: ""
+*nb.HPMailboxOptions Bin4/Utskuff 4: ""
+*pt.HPMailboxOptions Bin4/Caixa de correio 4: ""
+*sv.HPMailboxOptions Bin4/Fack 4: ""
+*zh_CN.HPMailboxOptions Bin4/信箱 4: ""
+*zh_TW.HPMailboxOptions Bin4/4 號信箱: ""
+
+*HPMailboxOptions Bin5/Output Bin 5: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 6)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin5/Postkasse 5: ""
+*de.HPMailboxOptions Bin5/Ausgabefach 5: ""
+*es.HPMailboxOptions Bin5/Buzón 5: ""
+*fi.HPMailboxOptions Bin5/Lokero 5: ""
+*fr.HPMailboxOptions Bin5/Trieuse 5: ""
+*it.HPMailboxOptions Bin5/Casella 5: ""
+*ja.HPMailboxOptions Bin5/メールボックス 5: ""
+*ko.HPMailboxOptions Bin5/용지함 5: ""
+*nl.HPMailboxOptions Bin5/Bak 5: ""
+*nb.HPMailboxOptions Bin5/Utskuff 5: ""
+*pt.HPMailboxOptions Bin5/Caixa de correio 5: ""
+*sv.HPMailboxOptions Bin5/Fack 5: ""
+*zh_CN.HPMailboxOptions Bin5/信箱 5: ""
+*zh_TW.HPMailboxOptions Bin5/5 號信箱: ""
+
+*HPMailboxOptions Bin6/Output Bin 6: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 7)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin6/Postkasse 6: ""
+*de.HPMailboxOptions Bin6/Ausgabefach 6: ""
+*es.HPMailboxOptions Bin6/Buzón 6: ""
+*fi.HPMailboxOptions Bin6/Lokero 6: ""
+*fr.HPMailboxOptions Bin6/Trieuse 6: ""
+*it.HPMailboxOptions Bin6/Casella 6: ""
+*ja.HPMailboxOptions Bin6/メールボックス 6: ""
+*ko.HPMailboxOptions Bin6/용지함 6: ""
+*nl.HPMailboxOptions Bin6/Bak 6: ""
+*nb.HPMailboxOptions Bin6/Utskuff 6: ""
+*pt.HPMailboxOptions Bin6/Caixa de correio 6: ""
+*sv.HPMailboxOptions Bin6/Fack 6: ""
+*zh_CN.HPMailboxOptions Bin6/信箱 6: ""
+*zh_TW.HPMailboxOptions Bin6/6 號信箱: ""
+
+*HPMailboxOptions Bin7/Output Bin 7: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 8)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin7/Postkasse 7: ""
+*de.HPMailboxOptions Bin7/Ausgabefach 7: ""
+*es.HPMailboxOptions Bin7/Buzón 7: ""
+*fi.HPMailboxOptions Bin7/Lokero 7: ""
+*fr.HPMailboxOptions Bin7/Trieuse 7: ""
+*it.HPMailboxOptions Bin7/Casella 7: ""
+*ja.HPMailboxOptions Bin7/メールボックス 7: ""
+*ko.HPMailboxOptions Bin7/용지함 7: ""
+*nl.HPMailboxOptions Bin7/Bak 7: ""
+*nb.HPMailboxOptions Bin7/Utskuff 7: ""
+*pt.HPMailboxOptions Bin7/Caixa de correio 7: ""
+*sv.HPMailboxOptions Bin7/Fack 7: ""
+*zh_CN.HPMailboxOptions Bin7/信箱 7: ""
+*zh_TW.HPMailboxOptions Bin7/7 號信箱: ""
+
+*HPMailboxOptions Bin8/Output Bin 8: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 9)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin8/Postkasse 8: ""
+*de.HPMailboxOptions Bin8/Ausgabefach 8: ""
+*es.HPMailboxOptions Bin8/Buzón 8: ""
+*fi.HPMailboxOptions Bin8/Lokero 8: ""
+*fr.HPMailboxOptions Bin8/Trieuse 8: ""
+*it.HPMailboxOptions Bin8/Casella 8: ""
+*ja.HPMailboxOptions Bin8/メールボックス 8: ""
+*ko.HPMailboxOptions Bin8/용지함 8: ""
+*nl.HPMailboxOptions Bin8/Bak 8: ""
+*nb.HPMailboxOptions Bin8/Utskuff 8: ""
+*pt.HPMailboxOptions Bin8/Caixa de correio 8: ""
+*sv.HPMailboxOptions Bin8/Fack 8: ""
+*zh_CN.HPMailboxOptions Bin8/信箱 8: ""
+*zh_TW.HPMailboxOptions Bin8/8 號信箱: ""
+
+*HPMailboxOptions Bin1_8/Output Bins 1-8: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin1_8/Postkasse 1-8: ""
+*de.HPMailboxOptions Bin1_8/Ausgabefachs 1-8: ""
+*es.HPMailboxOptions Bin1_8/Buzón 1-8: ""
+*fi.HPMailboxOptions Bin1_8/Lokeros 1-8: ""
+*fr.HPMailboxOptions Bin1_8/Trieuse 1-8: ""
+*it.HPMailboxOptions Bin1_8/Casella 1-8: ""
+*ja.HPMailboxOptions Bin1_8/メールボックス 1-8: ""
+*ko.HPMailboxOptions Bin1_8/용지함 1-8: ""
+*nl.HPMailboxOptions Bin1_8/Bak 1-8: ""
+*nb.HPMailboxOptions Bin1_8/Utskuff 1-8: ""
+*pt.HPMailboxOptions Bin1_8/Caixa de correio 1-8: ""
+*sv.HPMailboxOptions Bin1_8/Fack 1-8: ""
+*zh_CN.HPMailboxOptions Bin1_8/信箱 1-8: ""
+*zh_TW.HPMailboxOptions Bin1_8/1-8 號信箱: ""
+
+*CloseUI: *HPMailboxOptions
+
+*%=================================================
+*%		 Edge-to-Edge Printing
+*%=================================================
+*OpenUI *HPEdgeToEdge/Edge-To-Edge Printing: Boolean
+*OrderDependency: 10 AnySetup *HPEdgeToEdge
+*DefaultHPEdgeToEdge: False
+*da.Translation HPEdgeToEdge/Kant-til-kant: ""
+*de.Translation HPEdgeToEdge/Randlos: ""
+*es.Translation HPEdgeToEdge/De borde a borde: ""
+*fi.Translation HPEdgeToEdge/Reunasta reunaan: ""
+*fr.Translation HPEdgeToEdge/Bord à bord: ""
+*it.Translation HPEdgeToEdge/Bordo a bordo: ""
+*ja.Translation HPEdgeToEdge/最小マージン: ""
+*ko.Translation HPEdgeToEdge/가장자리까지 인쇄: ""
+*nl.Translation HPEdgeToEdge/Aflopend: ""
+*nb.Translation HPEdgeToEdge/Kant til kant: ""
+*pt.Translation HPEdgeToEdge/Margem a margem: ""
+*sv.Translation HPEdgeToEdge/Kant till kant: ""
+*zh_CN.Translation HPEdgeToEdge/边到边: ""
+*zh_TW.Translation HPEdgeToEdge/邊到邊: ""
+
+*HPEdgeToEdge False/Off: "<</EdgeToEdge false>> setpagedevice"
+*da.HPEdgeToEdge False/Aus: ""
+*de.HPEdgeToEdge False/Aus: ""
+*es.HPEdgeToEdge False/Desactivado: ""
+*fi.HPEdgeToEdge False/Ei: ""
+*fr.HPEdgeToEdge False/Désactivé: ""
+*it.HPEdgeToEdge False/Disattivata: ""
+*ja.HPEdgeToEdge False/オフ: ""
+*ko.HPEdgeToEdge False/끔: ""
+*nl.HPEdgeToEdge False/Uit: ""
+*nb.HPEdgeToEdge False/Av: ""
+*pt.HPEdgeToEdge False/Desativado: ""
+*sv.HPEdgeToEdge False/Av: ""
+*zh_CN.HPEdgeToEdge False/关: ""
+*zh_TW.HPEdgeToEdge False/關閉: ""
+
+*HPEdgeToEdge True/On: "<</EdgeToEdge true>> setpagedevice"
+*da.HPEdgeToEdge True/Ein: ""
+*de.HPEdgeToEdge True/Ein: ""
+*es.HPEdgeToEdge True/Activado: ""
+*fi.HPEdgeToEdge True/Kyllä: ""
+*fr.HPEdgeToEdge True/Activé: ""
+*it.HPEdgeToEdge True/Attivata: ""
+*ja.HPEdgeToEdge True/オン: ""
+*ko.HPEdgeToEdge True/켜짐: ""
+*nl.HPEdgeToEdge True/Aan: ""
+*nb.HPEdgeToEdge True/På: ""
+*pt.HPEdgeToEdge True/Ativado: ""
+*sv.HPEdgeToEdge True/På: ""
+*zh_CN.HPEdgeToEdge True/开: ""
+*zh_TW.HPEdgeToEdge True/開啟: ""
+
+*?HPEdgeToEdge: "
+  save
+    currentpagedevice /EdgeToEdge get
+      {(True)}{(False)}ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPEdgeToEdge
+
+*CloseGroup: HPFinishing
+
+*%=================================================
+*%		 Enable/Disable Collate via PostScript
+*%=================================================
+*OpenUI *Collate/Collate:  Boolean
+*OrderDependency: 12 AnySetup *Collate
+*DefaultCollate: False
+*da.Translation Collate/Sætvis: ""
+*de.Translation Collate/Sortieren: ""
+*es.Translation Collate/Clasificar: ""
+*fi.Translation Collate/Lajittele: ""
+*fr.Translation Collate/Assembler: ""
+*it.Translation Collate/Fascicola: ""
+*ja.Translation Collate/照合: ""
+*ko.Translation Collate/한 부씩 인쇄: ""
+*nl.Translation Collate/Sorteren: ""
+*nb.Translation Collate/Sorter: ""
+*pt.Translation Collate/Intercalar: ""
+*sv.Translation Collate/Sortera: ""
+*zh_CN.Translation Collate/分页: ""
+*zh_TW.Translation Collate/自動分頁: ""
+
+*Collate True/On (turn off in application): "<</Collate true>> setpagedevice"
+*da.Collate True/Til (deaktiver i programmet): ""
+*de.Collate True/Ein (in der Anwendung deaktivieren): ""
+*es.Collate True/Activado (desactivar en la aplicación): ""
+*fi.Collate True/Kyllä (poista valinta sovelluksesta): ""
+*fr.Collate True/Activé (désactiver dans l’applic.): ""
+*it.Collate True/Attivata (disattivare in applicazione): ""
+*ja.Collate True/オン (アプリケーションではオフに): ""
+*ko.Collate True/켬(응용 프로그램에서 마치기): ""
+*nl.Collate True/Aan (uitzetten in toepassingsprogramma): ""
+*nb.Collate True/På (slå av i programmet): ""
+*pt.Collate True/Ligado (desligar no aplicativo): ""
+*sv.Collate True/På (stäng av i programmet): ""
+*zh_CN.Collate True/开 (在应用程序关闭): ""
+*zh_TW.Collate True/開 (從應用程式關閉): ""
+
+*Collate False/Off: "<</Collate false>> setpagedevice"
+*da.Collate False/Fra: ""
+*de.Collate False/Aus: ""
+*es.Collate False/Desactivado: ""
+*fi.Collate False/Ei: ""
+*fr.Collate False/Désactivé: ""
+*it.Collate False/Disattivata: ""
+*ja.Collate False/オフ: ""
+*ko.Collate False/끔: ""
+*nl.Collate False/Uit: ""
+*nb.Collate False/Av: ""
+*pt.Collate False/Desligado: ""
+*sv.Collate False/Av: ""
+*zh_CN.Collate False/关: ""
+*zh_TW.Collate False/關: ""
+
+*?Collate: "
+   save
+      currentpagedevice /Collate get
+      {(True)}{(False)}ifelse = flush
+   restore
+"
+*End
+*CloseUI: *Collate
+
+*OpenGroup: HPImagingOptions/Image Quality
+*da.Translation HPImagingOptions/Billedindstillinger: ""
+*de.Translation HPImagingOptions/Abbildungsoptionen: ""
+*es.Translation HPImagingOptions/Opciones de imagen: ""
+*fi.Translation HPImagingOptions/Kuvanmuodostusasetukset: ""
+*fr.Translation HPImagingOptions/Options d'image: ""
+*it.Translation HPImagingOptions/Opzioni di immagine: ""
+*ja.Translation HPImagingOptions/画質オプション: ""
+*ko.Translation HPImagingOptions/이미지 옵션: ""
+*nl.Translation HPImagingOptions/Afbeeldingen-opties: ""
+*nb.Translation HPImagingOptions/Valg for bildebehandling: ""
+*pt.Translation HPImagingOptions/Opções de imagem: ""
+*sv.Translation HPImagingOptions/Alternativ för kvalitet: ""
+*zh_CN.Translation HPImagingOptions/图象选项: ""
+*zh_TW.Translation HPImagingOptions/影像選項: ""
+
+
+*%=================================================
+*%		 Halftone Information
+*%=================================================
+*ScreenFreq:  "106.0"
+*ScreenAngle: "45.0"
+
+*ResScreenFreq 300dpi/300 dpi:  "60.0"
+*da.ResScreenFreq 300dpi/300 dpi: ""
+*de.ResScreenFreq 300dpi/300 dpi: ""
+*es.ResScreenFreq 300dpi/300 dpi: ""
+*fi.ResScreenFreq 300dpi/300 dpi: ""
+*fr.ResScreenFreq 300dpi/300 dpi: ""
+*it.ResScreenFreq 300dpi/300 dpi: ""
+*ja.ResScreenFreq 300dpi/300 dpi: ""
+*ko.ResScreenFreq 300dpi/300 dpi: ""
+*nl.ResScreenFreq 300dpi/300 dpi: ""
+*nb.ResScreenFreq 300dpi/300 dpi: ""
+*pt.ResScreenFreq 300dpi/300 dpi: ""
+*sv.ResScreenFreq 300dpi/300 dpi: ""
+*zh_CN.ResScreenFreq 300dpi/300 dpi: ""
+*zh_TW.ResScreenFreq 300dpi/300 dpi: ""
+
+*ResScreenAngle 300dpi/300 dpi: "45.0"
+*da.ResScreenAngle 300dpi/300 dpi: ""
+*de.ResScreenAngle 300dpi/300 dpi: ""
+*es.ResScreenAngle 300dpi/300 dpi: ""
+*fi.ResScreenAngle 300dpi/300 dpi: ""
+*fr.ResScreenAngle 300dpi/300 dpi: ""
+*it.ResScreenAngle 300dpi/300 dpi: ""
+*ja.ResScreenAngle 300dpi/300 dpi: ""
+*ko.ResScreenAngle 300dpi/300 dpi: ""
+*nl.ResScreenAngle 300dpi/300 dpi: ""
+*nb.ResScreenAngle 300dpi/300 dpi: ""
+*pt.ResScreenAngle 300dpi/300 dpi: ""
+*sv.ResScreenAngle 300dpi/300 dpi: ""
+*zh_CN.ResScreenAngle 300dpi/300 dpi: ""
+*zh_TW.ResScreenAngle 300dpi/300 dpi: ""
+
+*ResScreenFreq 600dpi/600 dpi:  "106.0"
+*da.ResScreenFreq 600dpi/600 dpi: ""
+*de.ResScreenFreq 600dpi/600 dpi: ""
+*es.ResScreenFreq 600dpi/600 dpi: ""
+*fi.ResScreenFreq 600dpi/600 dpi: ""
+*fr.ResScreenFreq 600dpi/600 dpi: ""
+*it.ResScreenFreq 600dpi/600 dpi: ""
+*ja.ResScreenFreq 600dpi/600 dpi: ""
+*ko.ResScreenFreq 600dpi/600 dpi: ""
+*nl.ResScreenFreq 600dpi/600 dpi: ""
+*nb.ResScreenFreq 600dpi/600 dpi: ""
+*pt.ResScreenFreq 600dpi/600 dpi: ""
+*sv.ResScreenFreq 600dpi/600 dpi: ""
+*zh_CN.ResScreenFreq 600dpi/600 dpi: ""
+*zh_TW.ResScreenFreq 600dpi/600 dpi: ""
+
+*ResScreenAngle 600dpi/600 dpi: "45.0"
+*da.ResScreenAngle 600dpi/600 dpi: ""
+*de.ResScreenAngle 600dpi/600 dpi: ""
+*es.ResScreenAngle 600dpi/600 dpi: ""
+*fi.ResScreenAngle 600dpi/600 dpi: ""
+*fr.ResScreenAngle 600dpi/600 dpi: ""
+*it.ResScreenAngle 600dpi/600 dpi: ""
+*ja.ResScreenAngle 600dpi/600 dpi: ""
+*ko.ResScreenAngle 600dpi/600 dpi: ""
+*nl.ResScreenAngle 600dpi/600 dpi: ""
+*nb.ResScreenAngle 600dpi/600 dpi: ""
+*pt.ResScreenAngle 600dpi/600 dpi: ""
+*sv.ResScreenAngle 600dpi/600 dpi: ""
+*zh_CN.ResScreenAngle 600dpi/600 dpi: ""
+*zh_TW.ResScreenAngle 600dpi/600 dpi: ""
+
+
+*DefaultScreenProc: Dot
+*ScreenProc HPEnhanced: "
+	{ /EnhancedHalftone /Halftone findresource }"
+*End
+*ScreenProc Dot: "
+        {abs exch abs 2 copy add 1 gt {1 sub dup mul exch 1 sub dup mul add 1
+        sub }{dup mul exch dup mul add 1 exch sub }ifelse }
+"
+*End
+*ScreenProc Line: "{ pop }"
+*ScreenProc Ellipse: "{ dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub }"
+
+*DefaultTransfer: Null
+*Transfer Null: "{ }"
+*Transfer Null.Inverse: "{ 1 exch sub }"
+
+*DefaultHalftoneType:    9
+*AccurateScreensSupport: False
+
+*OpenUI *HPHalftone/Levels of Gray: PickOne
+*OrderDependency: 10 DocumentSetup *HPHalftone
+*DefaultHPHalftone: PrinterDefault
+*da.Translation HPHalftone/Halvtone: ""
+*de.Translation HPHalftone/Halbton: ""
+*es.Translation HPHalftone/Medios tonos: ""
+*fi.Translation HPHalftone/Puolisävy: ""
+*fr.Translation HPHalftone/Demi-teinte: ""
+*it.Translation HPHalftone/Mezzitoni: ""
+*ja.Translation HPHalftone/ハーフトーン: ""
+*ko.Translation HPHalftone/중간 색조: ""
+*nl.Translation HPHalftone/Halftonen: ""
+*nb.Translation HPHalftone/Halvtone: ""
+*pt.Translation HPHalftone/Meio-tom: ""
+*sv.Translation HPHalftone/Halvton: ""
+*zh_CN.Translation HPHalftone/半色调: ""
+*zh_TW.Translation HPHalftone/半色調: ""
+
+*HPHalftone PrinterDefault/Printer's Current Setting: ""
+*da.HPHalftone PrinterDefault/Aktuelle Druckereinstellung: ""
+*de.HPHalftone PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.HPHalftone PrinterDefault/Configuración actual de la impresora: ""
+*fi.HPHalftone PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.HPHalftone PrinterDefault/Paramétrage actuel de l'imprimante: ""
+*it.HPHalftone PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.HPHalftone PrinterDefault/プリンタの現在の設定: ""
+*ko.HPHalftone PrinterDefault/프린터 기본값: ""
+*nl.HPHalftone PrinterDefault/Huidige instelling van de printer: ""
+*nb.HPHalftone PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.HPHalftone PrinterDefault/Configuração atual da impressora: ""
+*sv.HPHalftone PrinterDefault/Skrivarens inställning: ""
+*zh_CN.HPHalftone PrinterDefault/打印机的当前设置: ""
+*zh_TW.HPHalftone PrinterDefault/印表機目前的設定值: ""
+
+*HPHalftone Enhanced/Enhanced: "
+   << /Install {
+     currentpagedevice /HWResolution get
+     dup 0 get 600 eq exch 1 get 600 eq and
+     { /EnhancedColorRendering600 } { /EnhancedColorRendering } ifelse
+     /ColorRendering findresource setcolorrendering
+     /EnhancedHalftone /Halftone findresource sethalftone
+     { } settransfer false setstrokeadjust
+   }
+   >> setpagedevice
+   currentpagedevice /HWResolution get dup 0 get 600 eq exch 1 get 600 eq and
+   {
+       << /PostRenderingEnhance true
+            /PostRenderingEnhanceDetails << /REValue 0 /Type 8 >>
+       >> setpagedevice
+   } if
+   /setscreen { pop pop pop } def
+   /setcolorscreen { pop pop pop pop pop pop pop pop pop pop pop pop } def
+   /sethalftone { pop } def
+"
+*End
+*da.HPHalftone Enhanced/Forbedret: ""
+*de.HPHalftone Enhanced/Erhöhen: ""
+*es.HPHalftone Enhanced/Mejorada: ""
+*fi.HPHalftone Enhanced/Parantaminen: ""
+*fr.HPHalftone Enhanced/Rehausser: ""
+*it.HPHalftone Enhanced/Valorizzare: ""
+*ja.HPHalftone Enhanced/拡張: ""
+*ko.HPHalftone Enhanced/해상도 향상: ""
+*nl.HPHalftone Enhanced/Gecombineerd: ""
+*nb.HPHalftone Enhanced/Sammenslått: ""
+*pt.HPHalftone Enhanced/Melhoria: ""
+*sv.HPHalftone Enhanced/Höja: ""
+*zh_CN.HPHalftone Enhanced/分辨率增强: ""
+*zh_TW.HPHalftone Enhanced/解析度增強: ""
+
+*HPHalftone Standard/Standard: "
+   << /Install {
+     currentpagedevice /HWResolution get
+     dup 0 get 600 eq exch 1 get 600 eq and dup
+     currentpagedevice /PostRenderingEnhance get
+     currentpagedevice /PostRenderingEnhanceDetails get /REValue get 0 ne and
+     { {/DefaultColorRenderingRE600} {/DefaultColorRenderingRE} ifelse}
+     { {/DefaultColorRendering600} {/DefaultColorRendering} ifelse} ifelse
+     /ColorRendering findresource setcolorrendering
+     { /DefaultHalftone600 } {/DefaultHalftone} ifelse
+     /Halftone findresource sethalftone
+     {} settransfer false setstrokeadjust
+   } >> setpagedevice
+   currentpagedevice /HWResolution get dup 0 get 600 eq exch 1 get 600 eq and
+   {
+     << /PostRenderingEnhance true /PostRenderingEnhanceDetails
+     << /REValue 0 /Type 8 >> >> setpagedevice
+   } if
+"
+*End
+*da.HPHalftone Standard/Standard: ""
+*de.HPHalftone Standard/Standard: ""
+*es.HPHalftone Standard/Estandarte: ""
+*fi.HPHalftone Standard/Normaali: ""
+*fr.HPHalftone Standard/Standard: ""
+*it.HPHalftone Standard/Standard: ""
+*ja.HPHalftone Standard/標準: ""
+*ko.HPHalftone Standard/역호환성: ""
+*nl.HPHalftone Standard/Standaard: ""
+*nb.HPHalftone Standard/Bakoverkompatibilitet: ""
+*pt.HPHalftone Standard/Padrão: ""
+*sv.HPHalftone Standard/Standard: ""
+*zh_CN.HPHalftone Standard/标准: ""
+*zh_TW.HPHalftone Standard/標準: ""
+
+*?HPHalftone: "
+   save
+      currenthalftone /HalftoneType get 9 eq
+     {(Enhanced)} {(Standard)} ifelse = flush
+   restore
+"
+*End
+*CloseUI: *HPHalftone
+
+*%=================================================
+*%		Resolution
+*%=================================================
+*% Select Printer Resolution
+*OpenUI *Resolution/Printer Resolution: PickOne
+*DefaultResolution: 600x601dpi
+*da.Translation Resolution/Opløsning: ""
+*de.Translation Resolution/Druckerauflösung: ""
+*es.Translation Resolution/Resol. de la impresora: ""
+*fi.Translation Resolution/Kirjoittimen tarkkuus: ""
+*fr.Translation Resolution/Résolution d’imprimante: ""
+*it.Translation Resolution/Risoluzione: ""
+*ja.Translation Resolution/プリンタの解像度: ""
+*ko.Translation Resolution/프린터 해상도: ""
+*nl.Translation Resolution/Printer-resolutie: ""
+*nb.Translation Resolution/Skriveroppløsning: ""
+*pt.Translation Resolution/Resolução da impressora: ""
+*sv.Translation Resolution/Skrivarupplösning: ""
+*zh_CN.Translation Resolution/打印机分辨率: ""
+*zh_TW.Translation Resolution/印表機解析度: ""
+
+*OrderDependency: 5 DocumentSetup  *Resolution
+*Resolution 600x600dpi/600 dpi: "
+    <</HWResolution [600 600] /PreRenderingEnhance false>> setpagedevice"
+*End
+*da.Resolution 600x600dpi/600 dpi: ""
+*de.Resolution 600x600dpi/600 dpi: ""
+*es.Resolution 600x600dpi/600 dpi: ""
+*fi.Resolution 600x600dpi/600 dpi: ""
+*fr.Resolution 600x600dpi/600 dpi: ""
+*it.Resolution 600x600dpi/600 dpi: ""
+*ja.Resolution 600x600dpi/600 dpi: ""
+*ko.Resolution 600x600dpi/600 dpi: ""
+*nl.Resolution 600x600dpi/600 dpi: ""
+*nb.Resolution 600x600dpi/600 dpi: ""
+*pt.Resolution 600x600dpi/600 dpi: ""
+*sv.Resolution 600x600dpi/600 dpi: ""
+*zh_CN.Resolution 600x600dpi/600 dpi: ""
+*zh_TW.Resolution 600x600dpi/600 dpi: ""
+
+*Resolution 600x601dpi/FastRes 1200: "
+	<</HWResolution [600 600] /PreRenderingEnhance true>> setpagedevice"
+*End
+*da.Resolution 600x601dpi/FastRes 1200: ""
+*de.Resolution 600x601dpi/FastRes 1200: ""
+*es.Resolution 600x601dpi/FastRes 1200: ""
+*fi.Resolution 600x601dpi/FastRes 1200: ""
+*fr.Resolution 600x601dpi/FastRes 1200: ""
+*it.Resolution 600x601dpi/FastRes 1200: ""
+*ja.Resolution 600x601dpi/FastRes 1200: ""
+*ko.Resolution 600x601dpi/FastRes 1200: ""
+*nl.Resolution 600x601dpi/FastRes 1200: ""
+*nb.Resolution 600x601dpi/FastRes 1200: ""
+*pt.Resolution 600x601dpi/FastRes 1200: ""
+*sv.Resolution 600x601dpi/FastRes 1200: ""
+*zh_CN.Resolution 600x601dpi/FastRes 1200: ""
+*zh_TW.Resolution 600x601dpi/FastRes 1200: ""
+
+*?Resolution: "
+  save
+    currentpagedevice /HWResolution get
+    0 get
+    (          ) cvs print
+    (dpi)
+    = flush
+  restore
+"
+*End
+*CloseUI: *Resolution
+
+*%=================================================
+*%          HPEconoMode
+*%=================================================
+*OpenUI *HPEconoMode/EconoMode: PickOne
+*DefaultHPEconoMode: PrinterDefault
+*da.Translation HPEconoMode/EconoMode: ""
+*de.Translation HPEconoMode/EconoMode: ""
+*es.Translation HPEconoMode/EconoMode: ""
+*fi.Translation HPEconoMode/EconoMode: ""
+*fr.Translation HPEconoMode/EconoMode: ""
+*it.Translation HPEconoMode/EconoMode: ""
+*ja.Translation HPEconoMode/EconoMode: ""
+*ko.Translation HPEconoMode/EconoMode: ""
+*nl.Translation HPEconoMode/EconoMode: ""
+*nb.Translation HPEconoMode/EconoMode: ""
+*pt.Translation HPEconoMode/EconoMode: ""
+*sv.Translation HPEconoMode/EconoMode: ""
+*zh_CN.Translation HPEconoMode/EconoMode: ""
+*zh_TW.Translation HPEconoMode/EconoMode: ""
+
+*OrderDependency: 10 AnySetup *HPEconoMode
+*HPEconoMode PrinterDefault/Printer's Current Setting: ""
+*da.HPEconoMode PrinterDefault/Printerens aktuelle indstilling: ""
+*de.HPEconoMode PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.HPEconoMode PrinterDefault/Configuración actual de la impresora: ""
+*fi.HPEconoMode PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.HPEconoMode PrinterDefault/Paramétrage actuel de l’imprimante: ""
+*it.HPEconoMode PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.HPEconoMode PrinterDefault/プリンタの現在の設定: ""
+*ko.HPEconoMode PrinterDefault/프린터의 현재 설정: ""
+*nl.HPEconoMode PrinterDefault/Huidige instelling van de printer: ""
+*nb.HPEconoMode PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.HPEconoMode PrinterDefault/Configuração atual da impressora: ""
+*sv.HPEconoMode PrinterDefault/Skrivarens inställning: ""
+*zh_CN.HPEconoMode PrinterDefault/打印机的当前设置: ""
+*zh_TW.HPEconoMode PrinterDefault/印表機目前的設定值: ""
+
+*HPEconoMode True/Save Toner: "
+    <</EconoMode true>> setpagedevice"
+*End
+*da.HPEconoMode True/Spar toner: ""
+*de.HPEconoMode True/Toner sparen: ""
+*es.HPEconoMode True/Ahorrar tóner: ""
+*fi.HPEconoMode True/Säästä väriainetta: ""
+*fr.HPEconoMode True/Economiser l’encre: ""
+*it.HPEconoMode True/Salva toner: ""
+*ja.HPEconoMode True/トナー節約: ""
+*ko.HPEconoMode True/토너 절약: ""
+*nl.HPEconoMode True/Toner besparen: ""
+*nb.HPEconoMode True/Spar toner: ""
+*pt.HPEconoMode True/Economizar toner: ""
+*sv.HPEconoMode True/Spara toner: ""
+*zh_CN.HPEconoMode True/节省碳粉: ""
+*zh_TW.HPEconoMode True/節約碳粉: ""
+
+*HPEconoMode False/Highest Quality: "
+    <</EconoMode false>> setpagedevice"
+*End
+*da.HPEconoMode False/Højeste kvalitet: ""
+*de.HPEconoMode False/Beste Qualität: ""
+*es.HPEconoMode False/Calidad óptima: ""
+*fi.HPEconoMode False/Korkein laatu: ""
+*fr.HPEconoMode False/Meilleure qualité: ""
+*it.HPEconoMode False/Qualità superiore: ""
+*ja.HPEconoMode False/最品位: ""
+*ko.HPEconoMode False/최고품질: ""
+*nl.HPEconoMode False/Beste kwaliteit: ""
+*nb.HPEconoMode False/Høyeste kvalitet: ""
+*pt.HPEconoMode False/Melhor qualidade: ""
+*sv.HPEconoMode False/Högsta kvalitet: ""
+*zh_CN.HPEconoMode False/最高质量: ""
+*zh_TW.HPEconoMode False/最高品質: ""
+
+*?HPEconoMode: "
+  save
+    currentpagedevice /EconoMode get
+    {(True)}{(False)}ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPEconoMode
+
+*%=================================================
+*%        Resolution Enhancement
+*%=================================================
+*OpenUI *Smoothing/Resolution Enhancement:  PickOne
+*OrderDependency: 20 DocumentSetup *Smoothing
+*DefaultSmoothing: PrinterDefault
+*da.Translation Smoothing/Opløsningsforbedring: ""
+*de.Translation Smoothing/Auflösungsoptimierung: ""
+*es.Translation Smoothing/Resolución Enhancement: ""
+*fi.Translation Smoothing/Tarkkuuden parannus: ""
+*fr.Translation Smoothing/Amélioration résolution: ""
+*it.Translation Smoothing/Miglioramento risoluzione: ""
+*ja.Translation Smoothing/解像度エンハンスメント: ""
+*ko.Translation Smoothing/해상도 향상: ""
+*nl.Translation Smoothing/Resolutieverbetering: ""
+*nb.Translation Smoothing/Oppløsningsfremheving: ""
+*pt.Translation Smoothing/Resolução avançada: ""
+*sv.Translation Smoothing/Förbättring av upplösning: ""
+*zh_CN.Translation Smoothing/分辨率增强: ""
+*zh_TW.Translation Smoothing/解析度增強: ""
+
+*Smoothing PrinterDefault/Printer's Current Setting: ""
+*da.Smoothing PrinterDefault/Aktuelle Druckereinstellung: ""
+*de.Smoothing PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.Smoothing PrinterDefault/Configuración actual de la impresora: ""
+*fi.Smoothing PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.Smoothing PrinterDefault/Paramétrage actuel de l'imprimante: ""
+*it.Smoothing PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.Smoothing PrinterDefault/プリンタの現在の設定: ""
+*ko.Smoothing PrinterDefault/프린터 기본값: ""
+*nl.Smoothing PrinterDefault/Huidige instelling van de printer: ""
+*nb.Smoothing PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.Smoothing PrinterDefault/Configuração atual da impressora: ""
+*sv.Smoothing PrinterDefault/Skrivarens inställning: ""
+*zh_CN.Smoothing PrinterDefault/打印机的当前设置: ""
+*zh_TW.Smoothing PrinterDefault/印表機目前的設定值: ""
+
+*Smoothing None/Off: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 0 /Type 8 >>
+>>  setpagedevice"
+*End
+*da.Smoothing None/Ingen: ""
+*de.Smoothing None/Aus: ""
+*es.Smoothing None/Desactivado: ""
+*fi.Smoothing None/Ei: ""
+*fr.Smoothing None/Désactivé: ""
+*it.Smoothing None/Disattivata: ""
+*ja.Smoothing None/オフ: ""
+*ko.Smoothing None/꺼짐: ""
+*nl.Smoothing None/Uit: ""
+*nb.Smoothing None/Av: ""
+*pt.Smoothing None/Desativado: ""
+*sv.Smoothing None/Av: ""
+*zh_CN.Smoothing None/关: ""
+*zh_TW.Smoothing None/關閉: ""
+
+*Smoothing Light/Light: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 1 /Type 8 >>
+>>  setpagedevice"
+*End
+*da.Smoothing Light/Lys: ""
+*de.Smoothing Light/Hell: ""
+*es.Smoothing Light/Claro: ""
+*fi.Smoothing Light/Vaalea: ""
+*fr.Smoothing Light/Clair: ""
+*it.Smoothing Light/Chiaro: ""
+*ja.Smoothing Light/薄い: ""
+*ko.Smoothing Light/밝게: ""
+*nl.Smoothing Light/Licht: ""
+*nb.Smoothing Light/Lys: ""
+*pt.Smoothing Light/Claro: ""
+*sv.Smoothing Light/Ljus: ""
+*zh_CN.Smoothing Light/淡: ""
+*zh_TW.Smoothing Light/淡: ""
+
+*Smoothing Medium/Medium: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 2 /Type 8 >>
+>>  setpagedevice"
+*End
+*da.Smoothing Medium/Middel: ""
+*de.Smoothing Medium/Mittel: ""
+*es.Smoothing Medium/Medio: ""
+*fi.Smoothing Medium/Keskitaso: ""
+*fr.Smoothing Medium/Moyen: ""
+*it.Smoothing Medium/Medio: ""
+*ja.Smoothing Medium/標準: ""
+*ko.Smoothing Medium/중간: ""
+*nl.Smoothing Medium/Middel: ""
+*nb.Smoothing Medium/Middels: ""
+*pt.Smoothing Medium/Médio: ""
+*sv.Smoothing Medium/Medium: ""
+*zh_CN.Smoothing Medium/中等: ""
+*zh_TW.Smoothing Medium/中等: ""
+
+*Smoothing Dark/Dark: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 3 /Type 8 >>
+>> setpagedevice"
+*End
+*da.Smoothing Dark/Mørk: ""
+*de.Smoothing Dark/Dunkel: ""
+*es.Smoothing Dark/Oscuro: ""
+*fi.Smoothing Dark/Tumma: ""
+*fr.Smoothing Dark/Foncé: ""
+*it.Smoothing Dark/Scuro: ""
+*ja.Smoothing Dark/濃い: ""
+*ko.Smoothing Dark/어둡게: ""
+*nl.Smoothing Dark/Donker: ""
+*nb.Smoothing Dark/Mørk: ""
+*pt.Smoothing Dark/Escuro: ""
+*sv.Smoothing Dark/Mörk: ""
+*zh_CN.Smoothing Dark/深: ""
+*zh_TW.Smoothing Dark/深: ""
+
+*?Smoothing: "
+  save
+    currentpagedevice /PostRenderingEnhanceDetails get /REValue get
+    [(Off) (Light) (Medium) (Dark)]  exch get print
+  restore
+"
+*End
+*CloseUI: *Smoothing
+
+*CloseGroup: HPImagingOptions
+
+*FreeVM: "6291456"
+*VMOption 64-127MB/64 - 127 MB: "6291456"
+*da.VMOption 64-127MB/64 - 127 MB: ""
+*de.VMOption 64-127MB/64 - 127 MB: ""
+*es.VMOption 64-127MB/64 - 127 MB: ""
+*fi.VMOption 64-127MB/64 - 127 MB: ""
+*fr.VMOption 64-127MB/64 - 127 MB: ""
+*it.VMOption 64-127MB/64 - 127 MB: ""
+*ja.VMOption 64-127MB/64 - 127 MB: ""
+*ko.VMOption 64-127MB/64 - 127 MB: ""
+*nl.VMOption 64-127MB/64 - 127 MB: ""
+*nb.VMOption 64-127MB/64 - 127 MB: ""
+*pt.VMOption 64-127MB/64 - 127 MB: ""
+*sv.VMOption 64-127MB/64 - 127 MB: ""
+*zh_CN.VMOption 64-127MB/64 - 127 MB: ""
+*zh_TW.VMOption 64-127MB/64 - 127 MB: ""
+
+*VMOption 128-255MB/128 - 255 MB: "56623104"
+*da.VMOption 128-255MB/128 - 255 MB: ""
+*de.VMOption 128-255MB/128 - 255 MB: ""
+*es.VMOption 128-255MB/128 - 255 MB: ""
+*fi.VMOption 128-255MB/128 - 255 MB: ""
+*fr.VMOption 128-255MB/128 - 255 MB: ""
+*it.VMOption 128-255MB/128 - 255 MB: ""
+*ja.VMOption 128-255MB/128 - 255 MB: ""
+*ko.VMOption 128-255MB/128 - 255 MB: ""
+*nl.VMOption 128-255MB/128 - 255 MB: ""
+*nb.VMOption 128-255MB/128 - 255 MB: ""
+*pt.VMOption 128-255MB/128 - 255 MB: ""
+*sv.VMOption 128-255MB/128 - 255 MB: ""
+*zh_CN.VMOption 128-255MB/128 - 255 MB: ""
+*zh_TW.VMOption 128-255MB/128 - 255 MB: ""
+
+*VMOption 256-383MB/256 - 383 MB: "123731968"
+*da.VMOption 256-383MB/256 - 383 MB: ""
+*de.VMOption 256-383MB/256 - 383 MB: ""
+*es.VMOption 256-383MB/256 - 383 MB: ""
+*fi.VMOption 256-383MB/256 - 383 MB: ""
+*fr.VMOption 256-383MB/256 - 383 MB: ""
+*it.VMOption 256-383MB/256 - 383 MB: ""
+*ja.VMOption 256-383MB/256 - 383 MB: ""
+*ko.VMOption 256-383MB/256 - 383 MB: ""
+*nl.VMOption 256-383MB/256 - 383 MB: ""
+*nb.VMOption 256-383MB/256 - 383 MB: ""
+*pt.VMOption 256-383MB/256 - 383 MB: ""
+*sv.VMOption 256-383MB/256 - 383 MB: ""
+*zh_CN.VMOption 256-383MB/256 - 383 MB: ""
+*zh_TW.VMOption 256-383MB/256 - 383 MB: ""
+
+*VMOption 384-512MB/384 - 512 MB: "123731968"
+*da.VMOption 384-512MB/384 - 512 MB: ""
+*de.VMOption 384-512MB/384 - 512 MB: ""
+*es.VMOption 384-512MB/384 - 512 MB: ""
+*fi.VMOption 384-512MB/384 - 512 MB: ""
+*fr.VMOption 384-512MB/384 - 512 MB: ""
+*it.VMOption 384-512MB/384 - 512 MB: ""
+*ja.VMOption 384-512MB/384 - 512 MB: ""
+*ko.VMOption 384-512MB/384 - 512 MB: ""
+*nl.VMOption 384-512MB/384 - 512 MB: ""
+*nb.VMOption 384-512MB/384 - 512 MB: ""
+*pt.VMOption 384-512MB/384 - 512 MB: ""
+*sv.VMOption 384-512MB/384 - 512 MB: ""
+*zh_CN.VMOption 384-512MB/384 - 512 MB: ""
+*zh_TW.VMOption 384-512MB/384 - 512 MB: ""
+
+
+*% =================================
+*% Paper Sizes
+*% =================================
+
+*LandscapeOrientation: Plus90
+*VariablePaperSize: False
+*OpenUI *PageSize/Page Size: PickOne
+*OrderDependency: 30 AnySetup *PageSize
+*DefaultPageSize: Letter
+*da.Translation PageSize/Page Size: ""
+*de.Translation PageSize/Papierformat: ""
+*es.Translation PageSize/Tamaño del papel: ""
+*fi.Translation PageSize/Sivukoko: ""
+*fr.Translation PageSize/Format de page: ""
+*it.Translation PageSize/Dimensioni pagina: ""
+*ja.Translation PageSize/ページサイズ: ""
+*ko.Translation PageSize/용지 크기: ""
+*nl.Translation PageSize/Papierformaat: ""
+*nb.Translation PageSize/Papirformat: ""
+*pt.Translation PageSize/Tamanho do papel: ""
+*sv.Translation PageSize/Sidstorlek: ""
+*zh_CN.Translation PageSize/页面大小: ""
+*zh_TW.Translation PageSize/頁面尺寸: ""
+
+*PageSize Letter/Letter: "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Letter/Letter: ""
+*de.PageSize Letter/Letter: ""
+*es.PageSize Letter/Letter: ""
+*fi.PageSize Letter/Letter: ""
+*fr.PageSize Letter/Lettre: ""
+*it.PageSize Letter/Letter: ""
+*ja.PageSize Letter/レター: ""
+*ko.PageSize Letter/레터: ""
+*nl.PageSize Letter/Letter: ""
+*nb.PageSize Letter/Letter: ""
+*pt.PageSize Letter/Carta: ""
+*sv.PageSize Letter/Letter: ""
+*zh_CN.PageSize Letter/信纸: ""
+*zh_TW.PageSize Letter/Letter: ""
+
+*PageSize LetterSmall/Letter (Small): "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize LetterSmall/Letter (lille): ""
+*de.PageSize LetterSmall/Letter (Klein): ""
+*es.PageSize LetterSmall/Letter (pequeño): ""
+*fi.PageSize LetterSmall/Letter (pieni): ""
+*fr.PageSize LetterSmall/Lettre (petit): ""
+*it.PageSize LetterSmall/Letter (ridotta): ""
+*ja.PageSize LetterSmall/レター (小): ""
+*ko.PageSize LetterSmall/레터 (소): ""
+*nl.PageSize LetterSmall/Letter (klein): ""
+*nb.PageSize LetterSmall/Letter (lite): ""
+*pt.PageSize LetterSmall/Carta (pequeno): ""
+*sv.PageSize LetterSmall/Letter (litet): ""
+*zh_CN.PageSize LetterSmall/信纸 (小): ""
+*zh_TW.PageSize LetterSmall/Letter (小): ""
+
+*PageSize Legal/Legal: "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Legal/Legal: ""
+*de.PageSize Legal/Legal: ""
+*es.PageSize Legal/Legal: ""
+*fi.PageSize Legal/Legal: ""
+*fr.PageSize Legal/Légal: ""
+*it.PageSize Legal/Legal: ""
+*ja.PageSize Legal/リーガル: ""
+*ko.PageSize Legal/리갈: ""
+*nl.PageSize Legal/Legal: ""
+*nb.PageSize Legal/Legal: ""
+*pt.PageSize Legal/Legal: ""
+*sv.PageSize Legal/Legal: ""
+*zh_CN.PageSize Legal/Legal: ""
+*zh_TW.PageSize Legal/Legal: ""
+
+*PageSize LegalSmall/Legal (Small): "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize LegalSmall/Legal (lille): ""
+*de.PageSize LegalSmall/Legal (Klein): ""
+*es.PageSize LegalSmall/Legal (pequeño): ""
+*fi.PageSize LegalSmall/Legal (pieni): ""
+*fr.PageSize LegalSmall/Légal (petit): ""
+*it.PageSize LegalSmall/Legal (ridotto): ""
+*ja.PageSize LegalSmall/リーガル (小): ""
+*ko.PageSize LegalSmall/리갈 (소): ""
+*nl.PageSize LegalSmall/Legal (klein): ""
+*nb.PageSize LegalSmall/Legal (lite): ""
+*pt.PageSize LegalSmall/Legal (pequeno): ""
+*sv.PageSize LegalSmall/Legal (litet): ""
+*zh_CN.PageSize LegalSmall/Legal (小): ""
+*zh_TW.PageSize LegalSmall/Legal (小): ""
+
+*PageSize Executive/Executive: "
+	<</DeferredMediaSelection true /PageSize [522 756] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Executive/Executive: ""
+*de.PageSize Executive/Executive: ""
+*es.PageSize Executive/Ejecutivo: ""
+*fi.PageSize Executive/Executive: ""
+*fr.PageSize Executive/Exécutif: ""
+*it.PageSize Executive/Executive: ""
+*ja.PageSize Executive/エグゼクティブ: ""
+*ko.PageSize Executive/Executive: ""
+*nl.PageSize Executive/Executive: ""
+*nb.PageSize Executive/Executive: ""
+*pt.PageSize Executive/Executivo: ""
+*sv.PageSize Executive/Executive: ""
+*zh_CN.PageSize Executive/Executive: ""
+*zh_TW.PageSize Executive/Executive: ""
+
+*PageSize HalfLetter/Statement: "
+    <</DeferredMediaSelection true /PageSize [396 612] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize HalfLetter/Statement: ""
+*de.PageSize HalfLetter/Statement: ""
+*es.PageSize HalfLetter/Declaración: ""
+*fi.PageSize HalfLetter/Statement: ""
+*fr.PageSize HalfLetter/1/2 Lettre: ""
+*it.PageSize HalfLetter/Dichiarazione: ""
+*ja.PageSize HalfLetter/Statement: ""
+*ko.PageSize HalfLetter/2절 레터: ""
+*nl.PageSize HalfLetter/1/2 Letter : ""
+*nb.PageSize HalfLetter/1/2 Letter: ""
+*pt.PageSize HalfLetter/Statement: ""
+*sv.PageSize HalfLetter/Statement: ""
+*zh_CN.PageSize HalfLetter/结算单: ""
+*zh_TW.PageSize HalfLetter/Statement: ""
+
+*PageSize w612h935/8.5x13: "
+  	<</DeferredMediaSelection true /PageSize [612 935] /ImagingBBox null /MediaClass (8.5X13)>> setpagedevice"
+*End
+*da.PageSize w612h935/8.5x13: ""
+*de.PageSize w612h935/8.5x13: ""
+*es.PageSize w612h935/8.5x13: ""
+*fi.PageSize w612h935/8.5x13: ""
+*fr.PageSize w612h935/8.5x13: ""
+*it.PageSize w612h935/8.5x13: ""
+*ja.PageSize w612h935/8.5x13: ""
+*ko.PageSize w612h935/8.5x13: ""
+*nl.PageSize w612h935/8.5x13: ""
+*nb.PageSize w612h935/8.5x13: ""
+*pt.PageSize w612h935/8.5x13: ""
+*sv.PageSize w612h935/8.5x13: ""
+*zh_CN.PageSize w612h935/8.5x13: ""
+*zh_TW.PageSize w612h935/8.5x13: ""
+
+*PageSize Tabloid/11x17: "
+    <</DeferredMediaSelection true /PageSize [792 1224] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Tabloid/11x17: ""
+*de.PageSize Tabloid/11x17 Zoll: ""
+*es.PageSize Tabloid/11x17: ""
+*fi.PageSize Tabloid/11x17: ""
+*fr.PageSize Tabloid/11 x 17 pouces: ""
+*it.PageSize Tabloid/11x17: ""
+*ja.PageSize Tabloid/11x17: ""
+*ko.PageSize Tabloid/11x17: ""
+*nl.PageSize Tabloid/11x17: ""
+*nb.PageSize Tabloid/11x17: ""
+*pt.PageSize Tabloid/11x17: ""
+*sv.PageSize Tabloid/11x17: ""
+*zh_CN.PageSize Tabloid/11x17: ""
+*zh_TW.PageSize Tabloid/11x17 : ""
+
+*PageSize 12X18/12x18: "
+    <</DeferredMediaSelection true /PageSize [864 1296] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize 12X18/12x18: ""
+*de.PageSize 12X18/12x18: ""
+*es.PageSize 12X18/12x18: ""
+*fi.PageSize 12X18/12x18: ""
+*fr.PageSize 12X18/12x18: ""
+*it.PageSize 12X18/12x18: ""
+*ja.PageSize 12X18/12x18: ""
+*ko.PageSize 12X18/12x18: ""
+*nl.PageSize 12X18/12x18: ""
+*nb.PageSize 12X18/12x18: ""
+*pt.PageSize 12X18/12x18: ""
+*sv.PageSize 12X18/12x18: ""
+*zh_CN.PageSize 12X18/12x18: ""
+*zh_TW.PageSize 12X18/12x18: ""
+
+*PageSize A3/A3: "
+    <</DeferredMediaSelection true /PageSize [842 1191] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A3/A3: ""
+*de.PageSize A3/A3: ""
+*es.PageSize A3/A3: ""
+*fi.PageSize A3/A3: ""
+*fr.PageSize A3/A3: ""
+*it.PageSize A3/A3: ""
+*ja.PageSize A3/A3: ""
+*ko.PageSize A3/A3: ""
+*nl.PageSize A3/A3: ""
+*nb.PageSize A3/A3: ""
+*pt.PageSize A3/A3: ""
+*sv.PageSize A3/A3: ""
+*zh_CN.PageSize A3/A3: ""
+*zh_TW.PageSize A3/A3: ""
+
+*PageSize RA3/RA3: "
+    <</DeferredMediaSelection true /PageSize [865 1219] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize RA3/RA3: ""
+*de.PageSize RA3/RA3: ""
+*es.PageSize RA3/RA3: ""
+*fi.PageSize RA3/RA3: ""
+*fr.PageSize RA3/RA3: ""
+*it.PageSize RA3/RA3: ""
+*ja.PageSize RA3/RA3: ""
+*ko.PageSize RA3/RA3: ""
+*nl.PageSize RA3/RA3: ""
+*nb.PageSize RA3/RA3: ""
+*pt.PageSize RA3/RA3: ""
+*sv.PageSize RA3/RA3: ""
+*zh_CN.PageSize RA3/RA3: ""
+*zh_TW.PageSize RA3/RA3: ""
+
+*PageSize A4/A4: "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A4/A4: ""
+*de.PageSize A4/A4: ""
+*es.PageSize A4/A4: ""
+*fi.PageSize A4/A4: ""
+*fr.PageSize A4/A4: ""
+*it.PageSize A4/A4: ""
+*ja.PageSize A4/A4: ""
+*ko.PageSize A4/A4: ""
+*nl.PageSize A4/A4: ""
+*nb.PageSize A4/A4: ""
+*pt.PageSize A4/A4: ""
+*sv.PageSize A4/A4: ""
+*zh_CN.PageSize A4/A4: ""
+*zh_TW.PageSize A4/A4: ""
+
+*PageSize A4Small/A4 (Small): "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A4Small/A4 (lille): ""
+*de.PageSize A4Small/A4 (Klein): ""
+*es.PageSize A4Small/A4 (pequeño): ""
+*fi.PageSize A4Small/A4 (pieni): ""
+*fr.PageSize A4Small/A4 (petit): ""
+*it.PageSize A4Small/A4 (ridotta): ""
+*ja.PageSize A4Small/A4 (小): ""
+*ko.PageSize A4Small/A4 (소): ""
+*nl.PageSize A4Small/A4 (klein): ""
+*nb.PageSize A4Small/A4 (lite): ""
+*pt.PageSize A4Small/A4 (pequeno): ""
+*sv.PageSize A4Small/A4 (litet): ""
+*zh_CN.PageSize A4Small/A4 (小): ""
+*zh_TW.PageSize A4Small/A4 (小): ""
+
+*PageSize A5/A5: "
+	<</DeferredMediaSelection true /PageSize [420 595] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A5/A5: ""
+*de.PageSize A5/A5: ""
+*es.PageSize A5/A5: ""
+*fi.PageSize A5/A5: ""
+*fr.PageSize A5/A5: ""
+*it.PageSize A5/A5: ""
+*ja.PageSize A5/A5: ""
+*ko.PageSize A5/A5: ""
+*nl.PageSize A5/A5: ""
+*nb.PageSize A5/A5: ""
+*pt.PageSize A5/A5: ""
+*sv.PageSize A5/A5: ""
+*zh_CN.PageSize A5/A5: ""
+*zh_TW.PageSize A5/A5: ""
+
+*PageSize B5/B5 (JIS): "
+	<</DeferredMediaSelection true /PageSize [516 729] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize B5/JIS B5: ""
+*de.PageSize B5/B5 (JIS): ""
+*es.PageSize B5/JIS B5: ""
+*fi.PageSize B5/JIS B5: ""
+*fr.PageSize B5/JIS B5: ""
+*it.PageSize B5/JIS B5: ""
+*ja.PageSize B5/B5 (JIS): ""
+*ko.PageSize B5/JIS B5: ""
+*nl.PageSize B5/JIS B5: ""
+*nb.PageSize B5/JIS B5: ""
+*pt.PageSize B5/B5 JIS: ""
+*sv.PageSize B5/JIS B5: ""
+*zh_CN.PageSize B5/JIS B5: ""
+*zh_TW.PageSize B5/JIS B5: ""
+
+*PageSize B4/B4 (JIS): "
+    <</DeferredMediaSelection true /PageSize [729 1032] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize B4/JIS B4: ""
+*de.PageSize B4/B4 (JIS): ""
+*es.PageSize B4/JIS B4: ""
+*fi.PageSize B4/JIS B4: ""
+*fr.PageSize B4/JIS B4: ""
+*it.PageSize B4/JIS B4: ""
+*ja.PageSize B4/B4 (JIS): ""
+*ko.PageSize B4/JIS B4: ""
+*nl.PageSize B4/JIS B4: ""
+*nb.PageSize B4/JIS B4: ""
+*pt.PageSize B4/B4 JIS: ""
+*sv.PageSize B4/JIS B4: ""
+*zh_CN.PageSize B4/JIS B4: ""
+*zh_TW.PageSize B4/JIS B4: ""
+
+*PageSize w612h936/Executive (JIS): "
+    <</DeferredMediaSelection true /PageSize [612 936] /ImagingBBox null /MediaClass (JISEXEC)>> setpagedevice"
+*End
+*da.PageSize w612h936/Executive (JIS): ""
+*de.PageSize w612h936/Executive (JIS): ""
+*es.PageSize w612h936/Ejecutivo (JIS): ""
+*fi.PageSize w612h936/Executive (JIS): ""
+*fr.PageSize w612h936/Exécutif (JIS): ""
+*it.PageSize w612h936/Executive (JIS): ""
+*ja.PageSize w612h936/エグゼクティブ (JIS): ""
+*ko.PageSize w612h936/Executive(JIS): ""
+*nl.PageSize w612h936/Executive (JIS): ""
+*nb.PageSize w612h936/Executive (JIS): ""
+*pt.PageSize w612h936/Executivo (JIS): ""
+*sv.PageSize w612h936/Executive (JIS): ""
+*zh_CN.PageSize w612h936/Executive (JIS): ""
+*zh_TW.PageSize w612h936/Executive (JIS): ""
+
+*PageSize DoublePostcard/Double Postcard (JIS): "
+    <</DeferredMediaSelection true /PageSize [419.5 567] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize DoublePostcard/Dobbelt postkort (JIS): ""
+*de.PageSize DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.PageSize DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.PageSize DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.PageSize DoublePostcard/Carte postale double (JIS): ""
+*it.PageSize DoublePostcard/Cartolina doppia (JIS): ""
+*ja.PageSize DoublePostcard/往復はがき (JIS): ""
+*ko.PageSize DoublePostcard/양면 엽서 (JIS): ""
+*nl.PageSize DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.PageSize DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.PageSize DoublePostcard/Postal duplo (JIS): ""
+*sv.PageSize DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.PageSize DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.PageSize DoublePostcard/雙面明信片 (JIS): ""
+
+*PageSize w774h1116/8K: "
+    <</DeferredMediaSelection true /PageSize [774 1116] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize w774h1116/8K: ""
+*de.PageSize w774h1116/8K: ""
+*es.PageSize w774h1116/8K: ""
+*fi.PageSize w774h1116/8K: ""
+*fr.PageSize w774h1116/8K: ""
+*it.PageSize w774h1116/8K: ""
+*ja.PageSize w774h1116/8K: ""
+*ko.PageSize w774h1116/8K: ""
+*nl.PageSize w774h1116/8K: ""
+*nb.PageSize w774h1116/8K: ""
+*pt.PageSize w774h1116/8K: ""
+*sv.PageSize w774h1116/8K: ""
+*zh_CN.PageSize w774h1116/8K: ""
+*zh_TW.PageSize w774h1116/8K: ""
+
+*PageSize w558h774/16K: "
+    <</DeferredMediaSelection true /PageSize [558 774] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize w558h774/16K: ""
+*de.PageSize w558h774/16K: ""
+*es.PageSize w558h774/16K: ""
+*fi.PageSize w558h774/16K: ""
+*fr.PageSize w558h774/16K: ""
+*it.PageSize w558h774/16K: ""
+*ja.PageSize w558h774/16K: ""
+*ko.PageSize w558h774/16K: ""
+*nl.PageSize w558h774/16K: ""
+*nb.PageSize w558h774/16K: ""
+*pt.PageSize w558h774/16K: ""
+*sv.PageSize w558h774/16K: ""
+*zh_CN.PageSize w558h774/16K: ""
+*zh_TW.PageSize w558h774/16K: ""
+
+*PageSize EnvISOB5/Env B5: "
+	<</DeferredMediaSelection true /PageSize [499 709] /ImagingBBox null /MediaClass (Envelope)>> setpagedevice"
+*End
+*da.PageSize EnvISOB5/Konv ISO B5: ""
+*de.PageSize EnvISOB5/Umschlag ISO B5: ""
+*es.PageSize EnvISOB5/Sobre ISO B5: ""
+*fi.PageSize EnvISOB5/Kirjekuori ISO B5: ""
+*fr.PageSize EnvISOB5/Enveloppe ISO B5: ""
+*it.PageSize EnvISOB5/Busta B5: ""
+*ja.PageSize EnvISOB5/封筒 ISO B5: ""
+*ko.PageSize EnvISOB5/ISO B5 봉투: ""
+*nl.PageSize EnvISOB5/ISO B5-envelop: ""
+*nb.PageSize EnvISOB5/B5-konvolutt: ""
+*pt.PageSize EnvISOB5/Envelope B5: ""
+*sv.PageSize EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.PageSize EnvISOB5/信封 ISO B5: ""
+*zh_TW.PageSize EnvISOB5/ISO B5 信封: ""
+
+*PageSize Env10/Env Comm10: "
+	<</DeferredMediaSelection true /PageSize [297 684] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Env10/Konv Comm10: ""
+*de.PageSize Env10/Umschlag Comm10: ""
+*es.PageSize Env10/Sobre Comm10: ""
+*fi.PageSize Env10/Kirjekuori Comm10: ""
+*fr.PageSize Env10/Enveloppe Comm10: ""
+*it.PageSize Env10/Busta Comm10: ""
+*ja.PageSize Env10/封筒 Comm10: ""
+*ko.PageSize Env10/Comm10 봉투: ""
+*nl.PageSize Env10/Comm10-envelop: ""
+*nb.PageSize Env10/Comm10-konvolutt: ""
+*pt.PageSize Env10/Envelope Comm10: ""
+*sv.PageSize Env10/Comm10-kuvert: ""
+*zh_CN.PageSize Env10/信封 Comm10: ""
+*zh_TW.PageSize Env10/Comm10 信封: ""
+
+*PageSize EnvC5/Env C5: "
+	<</DeferredMediaSelection true /PageSize [459 649] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize EnvC5/Konv C5: ""
+*de.PageSize EnvC5/Umschlag C5: ""
+*es.PageSize EnvC5/Sobre C5: ""
+*fi.PageSize EnvC5/Kirjekuori C5: ""
+*fr.PageSize EnvC5/Enveloppe C5: ""
+*it.PageSize EnvC5/Busta C5: ""
+*ja.PageSize EnvC5/封筒 C5: ""
+*ko.PageSize EnvC5/C5 봉투: ""
+*nl.PageSize EnvC5/C5-envelop: ""
+*nb.PageSize EnvC5/C5-konvolutt: ""
+*pt.PageSize EnvC5/Envelope C5: ""
+*sv.PageSize EnvC5/C5-kuvert: ""
+*zh_CN.PageSize EnvC5/信封 C5: ""
+*zh_TW.PageSize EnvC5/C5 信封: ""
+
+*PageSize EnvDL/Env DL: "
+	<</DeferredMediaSelection true /PageSize [312 624] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize EnvDL/Konv DL: ""
+*de.PageSize EnvDL/Umschlag DL: ""
+*es.PageSize EnvDL/Sobre DL: ""
+*fi.PageSize EnvDL/Kirjekuori DL: ""
+*fr.PageSize EnvDL/Enveloppe DL: ""
+*it.PageSize EnvDL/Busta DL: ""
+*ja.PageSize EnvDL/封筒 DL: ""
+*ko.PageSize EnvDL/DL 봉투: ""
+*nl.PageSize EnvDL/DL-envelop: ""
+*nb.PageSize EnvDL/DL-konvolutt: ""
+*pt.PageSize EnvDL/Envelope DL: ""
+*sv.PageSize EnvDL/DL-kuvert: ""
+*zh_CN.PageSize EnvDL/信封 DL: ""
+*zh_TW.PageSize EnvDL/DL 信封: ""
+
+*PageSize EnvMonarch/Env Monarch: "
+	<</DeferredMediaSelection true /PageSize [279 540] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize EnvMonarch/Konv Monarch: ""
+*de.PageSize EnvMonarch/Umschlag Monarch: ""
+*es.PageSize EnvMonarch/Sobre Monarch: ""
+*fi.PageSize EnvMonarch/Kirjekuori Monarch: ""
+*fr.PageSize EnvMonarch/Enveloppe Monarch: ""
+*it.PageSize EnvMonarch/Busta Monarch: ""
+*ja.PageSize EnvMonarch/封筒 Monarch: ""
+*ko.PageSize EnvMonarch/Monarch 봉투: ""
+*nl.PageSize EnvMonarch/Monarch-envelop: ""
+*nb.PageSize EnvMonarch/Monarch-konvolutt: ""
+*pt.PageSize EnvMonarch/Envelope Monarch: ""
+*sv.PageSize EnvMonarch/Monarch-kuvert: ""
+*zh_CN.PageSize EnvMonarch/信封 Monarch: ""
+*zh_TW.PageSize EnvMonarch/Monarch 信封: ""
+
+*?PageSize: "
+ save
+   currentpagedevice /PageSize get aload pop
+   2 copy gt {exch} if
+   (Unknown)
+  22 dict
+   dup [612 792] (Letter) put
+   dup [612 1008] (Legal) put
+   dup [522 756] (Executive) put
+   dup [396 612] (HalfLetter) put
+   dup [612 936]  (w612h935) put
+   dup [792 1224] (Tabloid) put
+   dup [864 1296] (12X18) put
+   dup [842 1191] (A3) put
+   dup [865 1219] (RA3) put
+   dup [595 842] (A4) put
+   dup [420 595] (A5) put
+   dup [516 728] (B5) put
+   dup [728 1032] (B4) put
+   dup [612 936]  (w612h936) put
+   dup [419.5 567](DoublePostcard) put
+   dup [774 1116] (w774h1116) put
+   dup [558 774]  (w558h774) put
+   dup [499 709] (EnvISOB5) put
+   dup [297 684] (Env10) put
+   dup [459 649] (EnvC5) put
+   dup [312 624] (EnvDL) put
+   dup [279 540] (EnvMonarch) put
+ { exch aload pop 4 index sub abs 5 le exch
+   5 index sub abs 5 le and
+      {exch pop exit} {pop} ifelse
+   } bind forall
+   = flush pop pop
+restore
+"
+*End
+*CloseUI: *PageSize
+*OpenUI *PageRegion/Page Region:  PickOne
+*OrderDependency: 30 AnySetup *PageRegion
+*DefaultPageRegion: Letter
+*da.Translation PageRegion/Page Region: ""
+*de.Translation PageRegion/Seitenbereich: ""
+*es.Translation PageRegion/Dimensión de papel: ""
+*fi.Translation PageRegion/Sivuseutu: ""
+*fr.Translation PageRegion/Région de page: ""
+*it.Translation PageRegion/Dimensioni regione: ""
+*ja.Translation PageRegion/Page Region: ""
+*ko.Translation PageRegion/Page Region: ""
+*nl.Translation PageRegion/Page Region: ""
+*nb.Translation PageRegion/Page Region: ""
+*pt.Translation PageRegion/Região do papel: ""
+*sv.Translation PageRegion/Page Region: ""
+*zh_CN.Translation PageRegion/Page Region: ""
+*zh_TW.Translation PageRegion/Page Region: ""
+
+*PageRegion Letter/Letter: "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Letter/Letter: ""
+*de.PageRegion Letter/Letter: ""
+*es.PageRegion Letter/Letter: ""
+*fi.PageRegion Letter/Letter: ""
+*fr.PageRegion Letter/Lettre: ""
+*it.PageRegion Letter/Letter: ""
+*ja.PageRegion Letter/レター: ""
+*ko.PageRegion Letter/레터: ""
+*nl.PageRegion Letter/Letter: ""
+*nb.PageRegion Letter/Letter: ""
+*pt.PageRegion Letter/Carta: ""
+*sv.PageRegion Letter/Letter: ""
+*zh_CN.PageRegion Letter/信纸: ""
+*zh_TW.PageRegion Letter/Letter: ""
+
+*PageRegion LetterSmall/Letter (Small): "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion LetterSmall/Letter (lille): ""
+*de.PageRegion LetterSmall/Letter (Klein): ""
+*es.PageRegion LetterSmall/Letter (pequeño): ""
+*fi.PageRegion LetterSmall/Letter (pieni): ""
+*fr.PageRegion LetterSmall/Lettre (petit): ""
+*it.PageRegion LetterSmall/Letter (ridotta): ""
+*ja.PageRegion LetterSmall/レター (小): ""
+*ko.PageRegion LetterSmall/레터 (소): ""
+*nl.PageRegion LetterSmall/Letter (klein): ""
+*nb.PageRegion LetterSmall/Letter (lite): ""
+*pt.PageRegion LetterSmall/Carta (pequeno): ""
+*sv.PageRegion LetterSmall/Letter (litet): ""
+*zh_CN.PageRegion LetterSmall/信纸 (小): ""
+*zh_TW.PageRegion LetterSmall/Letter (小): ""
+
+*PageRegion Legal/Legal: "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Legal/Legal: ""
+*de.PageRegion Legal/Legal: ""
+*es.PageRegion Legal/Legal: ""
+*fi.PageRegion Legal/Legal: ""
+*fr.PageRegion Legal/Légal: ""
+*it.PageRegion Legal/Legal: ""
+*ja.PageRegion Legal/リーガル: ""
+*ko.PageRegion Legal/리갈: ""
+*nl.PageRegion Legal/Legal: ""
+*nb.PageRegion Legal/Legal: ""
+*pt.PageRegion Legal/Legal: ""
+*sv.PageRegion Legal/Legal: ""
+*zh_CN.PageRegion Legal/Legal: ""
+*zh_TW.PageRegion Legal/Legal: ""
+
+*PageRegion LegalSmall/Legal (Small): "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion LegalSmall/Legal (lille): ""
+*de.PageRegion LegalSmall/Legal (Klein): ""
+*es.PageRegion LegalSmall/Legal (pequeño): ""
+*fi.PageRegion LegalSmall/Legal (pieni): ""
+*fr.PageRegion LegalSmall/Légal (petit): ""
+*it.PageRegion LegalSmall/Legal (ridotto): ""
+*ja.PageRegion LegalSmall/リーガル (小): ""
+*ko.PageRegion LegalSmall/리갈 (소): ""
+*nl.PageRegion LegalSmall/Legal (klein): ""
+*nb.PageRegion LegalSmall/Legal (lite): ""
+*pt.PageRegion LegalSmall/Legal (pequeno): ""
+*sv.PageRegion LegalSmall/Legal (litet): ""
+*zh_CN.PageRegion LegalSmall/Legal (小): ""
+*zh_TW.PageRegion LegalSmall/Legal (小): ""
+
+*PageRegion Executive/Executive: "
+	<</DeferredMediaSelection true /PageSize [522 756] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Executive/Executive: ""
+*de.PageRegion Executive/Executive: ""
+*es.PageRegion Executive/Ejecutivo: ""
+*fi.PageRegion Executive/Executive: ""
+*fr.PageRegion Executive/Exécutif: ""
+*it.PageRegion Executive/Executive: ""
+*ja.PageRegion Executive/エグゼクティブ: ""
+*ko.PageRegion Executive/Executive: ""
+*nl.PageRegion Executive/Executive: ""
+*nb.PageRegion Executive/Executive: ""
+*pt.PageRegion Executive/Executivo: ""
+*sv.PageRegion Executive/Executive: ""
+*zh_CN.PageRegion Executive/Executive: ""
+*zh_TW.PageRegion Executive/Executive: ""
+
+*PageRegion HalfLetter/Statement: "
+    <</DeferredMediaSelection true /PageSize [396 612] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion HalfLetter/Statement: ""
+*de.PageRegion HalfLetter/Statement: ""
+*es.PageRegion HalfLetter/Declaración: ""
+*fi.PageRegion HalfLetter/Statement: ""
+*fr.PageRegion HalfLetter/1/2 Lettre: ""
+*it.PageRegion HalfLetter/Dichiarazione: ""
+*ja.PageRegion HalfLetter/Statement: ""
+*ko.PageRegion HalfLetter/2절 레터: ""
+*nl.PageRegion HalfLetter/1/2 Letter : ""
+*nb.PageRegion HalfLetter/1/2 Letter: ""
+*pt.PageRegion HalfLetter/Statement: ""
+*sv.PageRegion HalfLetter/Statement: ""
+*zh_CN.PageRegion HalfLetter/结算单: ""
+*zh_TW.PageRegion HalfLetter/Statement: ""
+
+*PageRegion w612h935/8.5x13: "
+  	<</DeferredMediaSelection true /PageSize [612 935] /ImagingBBox null /MediaClass (8.5X13)>> setpagedevice"
+*End
+*da.PageRegion w612h935/8.5x13: ""
+*de.PageRegion w612h935/8.5x13: ""
+*es.PageRegion w612h935/8.5x13: ""
+*fi.PageRegion w612h935/8.5x13: ""
+*fr.PageRegion w612h935/8.5x13: ""
+*it.PageRegion w612h935/8.5x13: ""
+*ja.PageRegion w612h935/8.5x13: ""
+*ko.PageRegion w612h935/8.5x13: ""
+*nl.PageRegion w612h935/8.5x13: ""
+*nb.PageRegion w612h935/8.5x13: ""
+*pt.PageRegion w612h935/8.5x13: ""
+*sv.PageRegion w612h935/8.5x13: ""
+*zh_CN.PageRegion w612h935/8.5x13: ""
+*zh_TW.PageRegion w612h935/8.5x13: ""
+
+*PageRegion Tabloid/11x17: "
+    <</DeferredMediaSelection true /PageSize [792 1224] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Tabloid/11x17: ""
+*de.PageRegion Tabloid/11x17 Zoll: ""
+*es.PageRegion Tabloid/11x17: ""
+*fi.PageRegion Tabloid/11x17: ""
+*fr.PageRegion Tabloid/11 x 17 pouces: ""
+*it.PageRegion Tabloid/11x17: ""
+*ja.PageRegion Tabloid/11x17: ""
+*ko.PageRegion Tabloid/11x17: ""
+*nl.PageRegion Tabloid/11x17: ""
+*nb.PageRegion Tabloid/11x17: ""
+*pt.PageRegion Tabloid/11x17: ""
+*sv.PageRegion Tabloid/11x17: ""
+*zh_CN.PageRegion Tabloid/11x17: ""
+*zh_TW.PageRegion Tabloid/11x17 : ""
+
+*PageRegion 12X18/12x18: "
+    <</DeferredMediaSelection true /PageSize [864 1296] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion 12X18/12x18: ""
+*de.PageRegion 12X18/12x18: ""
+*es.PageRegion 12X18/12x18: ""
+*fi.PageRegion 12X18/12x18: ""
+*fr.PageRegion 12X18/12x18: ""
+*it.PageRegion 12X18/12x18: ""
+*ja.PageRegion 12X18/12x18: ""
+*ko.PageRegion 12X18/12x18: ""
+*nl.PageRegion 12X18/12x18: ""
+*nb.PageRegion 12X18/12x18: ""
+*pt.PageRegion 12X18/12x18: ""
+*sv.PageRegion 12X18/12x18: ""
+*zh_CN.PageRegion 12X18/12x18: ""
+*zh_TW.PageRegion 12X18/12x18: ""
+
+*PageRegion A3/A3: "
+    <</DeferredMediaSelection true /PageSize [842 1191] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A3/A3: ""
+*de.PageRegion A3/A3: ""
+*es.PageRegion A3/A3: ""
+*fi.PageRegion A3/A3: ""
+*fr.PageRegion A3/A3: ""
+*it.PageRegion A3/A3: ""
+*ja.PageRegion A3/A3: ""
+*ko.PageRegion A3/A3: ""
+*nl.PageRegion A3/A3: ""
+*nb.PageRegion A3/A3: ""
+*pt.PageRegion A3/A3: ""
+*sv.PageRegion A3/A3: ""
+*zh_CN.PageRegion A3/A3: ""
+*zh_TW.PageRegion A3/A3: ""
+
+*PageRegion RA3/RA3: "
+    <</DeferredMediaSelection true /PageSize [865 1219] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion RA3/RA3: ""
+*de.PageRegion RA3/RA3: ""
+*es.PageRegion RA3/RA3: ""
+*fi.PageRegion RA3/RA3: ""
+*fr.PageRegion RA3/RA3: ""
+*it.PageRegion RA3/RA3: ""
+*ja.PageRegion RA3/RA3: ""
+*ko.PageRegion RA3/RA3: ""
+*nl.PageRegion RA3/RA3: ""
+*nb.PageRegion RA3/RA3: ""
+*pt.PageRegion RA3/RA3: ""
+*sv.PageRegion RA3/RA3: ""
+*zh_CN.PageRegion RA3/RA3: ""
+*zh_TW.PageRegion RA3/RA3: ""
+
+*PageRegion A4/A4: "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A4/A4: ""
+*de.PageRegion A4/A4: ""
+*es.PageRegion A4/A4: ""
+*fi.PageRegion A4/A4: ""
+*fr.PageRegion A4/A4: ""
+*it.PageRegion A4/A4: ""
+*ja.PageRegion A4/A4: ""
+*ko.PageRegion A4/A4: ""
+*nl.PageRegion A4/A4: ""
+*nb.PageRegion A4/A4: ""
+*pt.PageRegion A4/A4: ""
+*sv.PageRegion A4/A4: ""
+*zh_CN.PageRegion A4/A4: ""
+*zh_TW.PageRegion A4/A4: ""
+
+*PageRegion A4Small/A4 (Small): "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A4Small/A4 (lille): ""
+*de.PageRegion A4Small/A4 (Klein): ""
+*es.PageRegion A4Small/A4 (pequeño): ""
+*fi.PageRegion A4Small/A4 (pieni): ""
+*fr.PageRegion A4Small/A4 (petit): ""
+*it.PageRegion A4Small/A4 (ridotta): ""
+*ja.PageRegion A4Small/A4 (小): ""
+*ko.PageRegion A4Small/A4 (소): ""
+*nl.PageRegion A4Small/A4 (klein): ""
+*nb.PageRegion A4Small/A4 (lite): ""
+*pt.PageRegion A4Small/A4 (pequeno): ""
+*sv.PageRegion A4Small/A4 (litet): ""
+*zh_CN.PageRegion A4Small/A4 (小): ""
+*zh_TW.PageRegion A4Small/A4 (小): ""
+
+*PageRegion A5/A5: "
+	<</DeferredMediaSelection true /PageSize [420 595] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A5/A5: ""
+*de.PageRegion A5/A5: ""
+*es.PageRegion A5/A5: ""
+*fi.PageRegion A5/A5: ""
+*fr.PageRegion A5/A5: ""
+*it.PageRegion A5/A5: ""
+*ja.PageRegion A5/A5: ""
+*ko.PageRegion A5/A5: ""
+*nl.PageRegion A5/A5: ""
+*nb.PageRegion A5/A5: ""
+*pt.PageRegion A5/A5: ""
+*sv.PageRegion A5/A5: ""
+*zh_CN.PageRegion A5/A5: ""
+*zh_TW.PageRegion A5/A5: ""
+
+*PageRegion B5/B5 (JIS): "
+	<</DeferredMediaSelection true /PageSize [516 729] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion B5/JIS B5: ""
+*de.PageRegion B5/B5 (JIS): ""
+*es.PageRegion B5/JIS B5: ""
+*fi.PageRegion B5/JIS B5: ""
+*fr.PageRegion B5/JIS B5: ""
+*it.PageRegion B5/JIS B5: ""
+*ja.PageRegion B5/B5 (JIS): ""
+*ko.PageRegion B5/JIS B5: ""
+*nl.PageRegion B5/JIS B5: ""
+*nb.PageRegion B5/JIS B5: ""
+*pt.PageRegion B5/B5 JIS: ""
+*sv.PageRegion B5/JIS B5: ""
+*zh_CN.PageRegion B5/JIS B5: ""
+*zh_TW.PageRegion B5/JIS B5: ""
+
+*PageRegion B4/B4 (JIS): "
+    <</DeferredMediaSelection true /PageSize [729 1032] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion B4/JIS B4: ""
+*de.PageRegion B4/B4 (JIS): ""
+*es.PageRegion B4/JIS B4: ""
+*fi.PageRegion B4/JIS B4: ""
+*fr.PageRegion B4/JIS B4: ""
+*it.PageRegion B4/JIS B4: ""
+*ja.PageRegion B4/B4 (JIS): ""
+*ko.PageRegion B4/JIS B4: ""
+*nl.PageRegion B4/JIS B4: ""
+*nb.PageRegion B4/JIS B4: ""
+*pt.PageRegion B4/B4 JIS: ""
+*sv.PageRegion B4/JIS B4: ""
+*zh_CN.PageRegion B4/JIS B4: ""
+*zh_TW.PageRegion B4/JIS B4: ""
+
+*PageRegion w612h936/Executive (JIS): "
+    <</DeferredMediaSelection true /PageSize [612 936] /ImagingBBox null /MediaClass (JISEXEC)>> setpagedevice"
+*End
+*da.PageRegion w612h936/Executive (JIS): ""
+*de.PageRegion w612h936/Executive (JIS): ""
+*es.PageRegion w612h936/Ejecutivo (JIS): ""
+*fi.PageRegion w612h936/Executive (JIS): ""
+*fr.PageRegion w612h936/Exécutif (JIS): ""
+*it.PageRegion w612h936/Executive (JIS): ""
+*ja.PageRegion w612h936/エグゼクティブ (JIS): ""
+*ko.PageRegion w612h936/Executive(JIS): ""
+*nl.PageRegion w612h936/Executive (JIS): ""
+*nb.PageRegion w612h936/Executive (JIS): ""
+*pt.PageRegion w612h936/Executivo (JIS): ""
+*sv.PageRegion w612h936/Executive (JIS): ""
+*zh_CN.PageRegion w612h936/Executive (JIS): ""
+*zh_TW.PageRegion w612h936/Executive (JIS): ""
+
+*PageRegion DoublePostcard/Double Postcard (JIS): "
+    <</DeferredMediaSelection true /PageSize [419.5 567] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion DoublePostcard/Dobbelt postkort (JIS): ""
+*de.PageRegion DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.PageRegion DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.PageRegion DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.PageRegion DoublePostcard/Carte postale double (JIS): ""
+*it.PageRegion DoublePostcard/Cartolina doppia (JIS): ""
+*ja.PageRegion DoublePostcard/往復はがき (JIS): ""
+*ko.PageRegion DoublePostcard/양면 엽서 (JIS): ""
+*nl.PageRegion DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.PageRegion DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.PageRegion DoublePostcard/Postal duplo (JIS): ""
+*sv.PageRegion DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.PageRegion DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.PageRegion DoublePostcard/雙面明信片 (JIS): ""
+
+*PageRegion w774h1116/8K: "
+    <</DeferredMediaSelection true /PageSize [774 1116] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion w774h1116/8K: ""
+*de.PageRegion w774h1116/8K: ""
+*es.PageRegion w774h1116/8K: ""
+*fi.PageRegion w774h1116/8K: ""
+*fr.PageRegion w774h1116/8K: ""
+*it.PageRegion w774h1116/8K: ""
+*ja.PageRegion w774h1116/8K: ""
+*ko.PageRegion w774h1116/8K: ""
+*nl.PageRegion w774h1116/8K: ""
+*nb.PageRegion w774h1116/8K: ""
+*pt.PageRegion w774h1116/8K: ""
+*sv.PageRegion w774h1116/8K: ""
+*zh_CN.PageRegion w774h1116/8K: ""
+*zh_TW.PageRegion w774h1116/8K: ""
+
+*PageRegion w558h774/16K: "
+    <</DeferredMediaSelection true /PageSize [558 774] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion w558h774/16K: ""
+*de.PageRegion w558h774/16K: ""
+*es.PageRegion w558h774/16K: ""
+*fi.PageRegion w558h774/16K: ""
+*fr.PageRegion w558h774/16K: ""
+*it.PageRegion w558h774/16K: ""
+*ja.PageRegion w558h774/16K: ""
+*ko.PageRegion w558h774/16K: ""
+*nl.PageRegion w558h774/16K: ""
+*nb.PageRegion w558h774/16K: ""
+*pt.PageRegion w558h774/16K: ""
+*sv.PageRegion w558h774/16K: ""
+*zh_CN.PageRegion w558h774/16K: ""
+*zh_TW.PageRegion w558h774/16K: ""
+
+*PageRegion EnvISOB5/Env B5: "
+	<</DeferredMediaSelection true /PageSize [499 709] /ImagingBBox null /MediaClass (Envelope)>> setpagedevice"
+*End
+*da.PageRegion EnvISOB5/Konv ISO B5: ""
+*de.PageRegion EnvISOB5/Umschlag ISO B5: ""
+*es.PageRegion EnvISOB5/Sobre ISO B5: ""
+*fi.PageRegion EnvISOB5/Kirjekuori ISO B5: ""
+*fr.PageRegion EnvISOB5/Enveloppe ISO B5: ""
+*it.PageRegion EnvISOB5/Busta ISO B5: ""
+*ja.PageRegion EnvISOB5/封筒 B5 (ISO): ""
+*ko.PageRegion EnvISOB5/ISO B5 봉투: ""
+*nl.PageRegion EnvISOB5/ISO B5-envelop: ""
+*nb.PageRegion EnvISOB5/B5-konvolutt: ""
+*pt.PageRegion EnvISOB5/Envelope B5: ""
+*sv.PageRegion EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.PageRegion EnvISOB5/信封 ISO B5: ""
+*zh_TW.PageRegion EnvISOB5/ISO B5 信封: ""
+
+*PageRegion Env10/Env Comm10: "
+	<</DeferredMediaSelection true /PageSize [297 684] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Env10/Konv Comm10: ""
+*de.PageRegion Env10/Umschlag Comm10: ""
+*es.PageRegion Env10/Sobre Comm10: ""
+*fi.PageRegion Env10/Kirjekuori Comm10: ""
+*fr.PageRegion Env10/Enveloppe Comm10: ""
+*it.PageRegion Env10/Busta Comm10: ""
+*ja.PageRegion Env10/封筒 Comm10: ""
+*ko.PageRegion Env10/Comm10 봉투: ""
+*nl.PageRegion Env10/Comm10-envelop: ""
+*nb.PageRegion Env10/Comm10-konvolutt: ""
+*pt.PageRegion Env10/Envelope Comm10: ""
+*sv.PageRegion Env10/Comm10-kuvert: ""
+*zh_CN.PageRegion Env10/信封 Comm10: ""
+*zh_TW.PageRegion Env10/Comm10 信封: ""
+
+*PageRegion EnvC5/Env C5: "
+	<</DeferredMediaSelection true /PageSize [459 649] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion EnvC5/Konv C5: ""
+*de.PageRegion EnvC5/Umschlag C5: ""
+*es.PageRegion EnvC5/Sobre C5: ""
+*fi.PageRegion EnvC5/Kirjekuori C5: ""
+*fr.PageRegion EnvC5/Enveloppe C5: ""
+*it.PageRegion EnvC5/Busta C5: ""
+*ja.PageRegion EnvC5/封筒 C5: ""
+*ko.PageRegion EnvC5/C5 봉투: ""
+*nl.PageRegion EnvC5/C5-envelop: ""
+*nb.PageRegion EnvC5/C5-konvolutt: ""
+*pt.PageRegion EnvC5/Envelope C5: ""
+*sv.PageRegion EnvC5/C5-kuvert: ""
+*zh_CN.PageRegion EnvC5/信封 C5: ""
+*zh_TW.PageRegion EnvC5/C5 信封: ""
+
+*PageRegion EnvDL/Env DL: "
+	<</DeferredMediaSelection true /PageSize [312 624] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion EnvDL/Konv DL: ""
+*de.PageRegion EnvDL/Umschlag DL: ""
+*es.PageRegion EnvDL/Sobre DL: ""
+*fi.PageRegion EnvDL/Kirjekuori DL: ""
+*fr.PageRegion EnvDL/Enveloppe DL: ""
+*it.PageRegion EnvDL/Busta DL: ""
+*ja.PageRegion EnvDL/封筒 DL: ""
+*ko.PageRegion EnvDL/DL 봉투: ""
+*nl.PageRegion EnvDL/DL-envelop: ""
+*nb.PageRegion EnvDL/DL-konvolutt: ""
+*pt.PageRegion EnvDL/Envelope DL: ""
+*sv.PageRegion EnvDL/DL-kuvert: ""
+*zh_CN.PageRegion EnvDL/信封 DL: ""
+*zh_TW.PageRegion EnvDL/DL 信封: ""
+
+*PageRegion EnvMonarch/Env Monarch: "
+	<</DeferredMediaSelection true /PageSize [279 540] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion EnvMonarch/Konv Monarch: ""
+*de.PageRegion EnvMonarch/Umschlag Monarch: ""
+*es.PageRegion EnvMonarch/Sobre Monarch: ""
+*fi.PageRegion EnvMonarch/Kirjekuori Monarch: ""
+*fr.PageRegion EnvMonarch/Enveloppe Monarch: ""
+*it.PageRegion EnvMonarch/Busta Monarch: ""
+*ja.PageRegion EnvMonarch/封筒 Monarch: ""
+*ko.PageRegion EnvMonarch/Monarch 봉투: ""
+*nl.PageRegion EnvMonarch/Monarch-envelop: ""
+*nb.PageRegion EnvMonarch/Monarch-konvolutt: ""
+*pt.PageRegion EnvMonarch/Envelope Monarch: ""
+*sv.PageRegion EnvMonarch/Monarch-kuvert: ""
+*zh_CN.PageRegion EnvMonarch/信封 Monarch: ""
+*zh_TW.PageRegion EnvMonarch/Monarch 信封: ""
+
+*CloseUI: *PageRegion
+
+*% The following entries provide information about specific paper keywords.
+*DefaultImageableArea: Letter
+*ImageableArea Letter/Letter: 					"12.00 12.12 599.88 780.00"
+*da.ImageableArea Letter/Letter: ""
+*de.ImageableArea Letter/Letter: ""
+*es.ImageableArea Letter/Letter: ""
+*fi.ImageableArea Letter/Letter: ""
+*fr.ImageableArea Letter/Lettre: ""
+*it.ImageableArea Letter/Letter: ""
+*ja.ImageableArea Letter/レター: ""
+*ko.ImageableArea Letter/레터: ""
+*nl.ImageableArea Letter/Letter: ""
+*nb.ImageableArea Letter/Letter: ""
+*pt.ImageableArea Letter/Carta: ""
+*sv.ImageableArea Letter/Letter: ""
+*zh_CN.ImageableArea Letter/信纸: ""
+*zh_TW.ImageableArea Letter/Letter: ""
+
+*ImageableArea LetterSmall/Letter (Small):		"30.00 31.00 582.00 761.00"
+*da.ImageableArea LetterSmall/Letter (lille): ""
+*de.ImageableArea LetterSmall/Letter (Klein): ""
+*es.ImageableArea LetterSmall/Letter (pequeño): ""
+*fi.ImageableArea LetterSmall/Letter (pieni): ""
+*fr.ImageableArea LetterSmall/Lettre (petit): ""
+*it.ImageableArea LetterSmall/Letter (ridotta): ""
+*ja.ImageableArea LetterSmall/レター (小): ""
+*ko.ImageableArea LetterSmall/레터 (소): ""
+*nl.ImageableArea LetterSmall/Letter (klein): ""
+*nb.ImageableArea LetterSmall/Letter (lite): ""
+*pt.ImageableArea LetterSmall/Carta (pequeno): ""
+*sv.ImageableArea LetterSmall/Letter (litet): ""
+*zh_CN.ImageableArea LetterSmall/信纸 (小): ""
+*zh_TW.ImageableArea LetterSmall/Letter (小): ""
+
+*ImageableArea Legal/Legal: 					"12.00 12.12 599.88 996.00"
+*da.ImageableArea Legal/Legal: ""
+*de.ImageableArea Legal/Legal: ""
+*es.ImageableArea Legal/Legal: ""
+*fi.ImageableArea Legal/Legal: ""
+*fr.ImageableArea Legal/Légal: ""
+*it.ImageableArea Legal/Legal: ""
+*ja.ImageableArea Legal/リーガル: ""
+*ko.ImageableArea Legal/리갈: ""
+*nl.ImageableArea Legal/Legal: ""
+*nb.ImageableArea Legal/Legal: ""
+*pt.ImageableArea Legal/Legal: ""
+*sv.ImageableArea Legal/Legal: ""
+*zh_CN.ImageableArea Legal/Legal: ""
+*zh_TW.ImageableArea Legal/Legal: ""
+
+*ImageableArea LegalSmall/Legal (Small):		"64.00 54.00 548.00 954.00"
+*da.ImageableArea LegalSmall/Legal (lille): ""
+*de.ImageableArea LegalSmall/Legal (Klein): ""
+*es.ImageableArea LegalSmall/Legal (pequeño): ""
+*fi.ImageableArea LegalSmall/Legal (pieni): ""
+*fr.ImageableArea LegalSmall/Légal (petit): ""
+*it.ImageableArea LegalSmall/Legal (ridotto): ""
+*ja.ImageableArea LegalSmall/リーガル (小): ""
+*ko.ImageableArea LegalSmall/리갈 (소): ""
+*nl.ImageableArea LegalSmall/Legal (klein): ""
+*nb.ImageableArea LegalSmall/Legal (lite): ""
+*pt.ImageableArea LegalSmall/Legal (pequeno): ""
+*sv.ImageableArea LegalSmall/Legal (litet): ""
+*zh_CN.ImageableArea LegalSmall/Legal (小): ""
+*zh_TW.ImageableArea LegalSmall/Legal (小): ""
+
+*ImageableArea Executive/Executive: 			"12.00 12.00 509.88 744.00"
+*da.ImageableArea Executive/Executive: ""
+*de.ImageableArea Executive/Executive: ""
+*es.ImageableArea Executive/Ejecutivo: ""
+*fi.ImageableArea Executive/Executive: ""
+*fr.ImageableArea Executive/Exécutif: ""
+*it.ImageableArea Executive/Executive: ""
+*ja.ImageableArea Executive/エグゼクティブ: ""
+*ko.ImageableArea Executive/Executive: ""
+*nl.ImageableArea Executive/Executive: ""
+*nb.ImageableArea Executive/Executive: ""
+*pt.ImageableArea Executive/Executivo: ""
+*sv.ImageableArea Executive/Executive: ""
+*zh_CN.ImageableArea Executive/Executive: ""
+*zh_TW.ImageableArea Executive/Executive: ""
+
+*ImageableArea HalfLetter/Statement:			"12.00 12.00 384.00 599.88"
+*da.ImageableArea HalfLetter/Statement: ""
+*de.ImageableArea HalfLetter/Statement: ""
+*es.ImageableArea HalfLetter/Declaración: ""
+*fi.ImageableArea HalfLetter/Statement: ""
+*fr.ImageableArea HalfLetter/1/2 Lettre: ""
+*it.ImageableArea HalfLetter/Dichiarazione: ""
+*ja.ImageableArea HalfLetter/Statement: ""
+*ko.ImageableArea HalfLetter/2절 레터: ""
+*nl.ImageableArea HalfLetter/1/2 Letter : ""
+*nb.ImageableArea HalfLetter/1/2 Letter: ""
+*pt.ImageableArea HalfLetter/Statement: ""
+*sv.ImageableArea HalfLetter/Statement: ""
+*zh_CN.ImageableArea HalfLetter/结算单: ""
+*zh_TW.ImageableArea HalfLetter/Statement: ""
+
+*ImageableArea w612h935/8.5x13: 				"12.00 12.00 599.76 922.76"
+*da.ImageableArea w612h935/8.5x13: ""
+*de.ImageableArea w612h935/8.5x13: ""
+*es.ImageableArea w612h935/8.5x13: ""
+*fi.ImageableArea w612h935/8.5x13: ""
+*fr.ImageableArea w612h935/8.5x13: ""
+*it.ImageableArea w612h935/8.5x13: ""
+*ja.ImageableArea w612h935/8.5x13: ""
+*ko.ImageableArea w612h935/8.5x13: ""
+*nl.ImageableArea w612h935/8.5x13: ""
+*nb.ImageableArea w612h935/8.5x13: ""
+*pt.ImageableArea w612h935/8.5x13: ""
+*sv.ImageableArea w612h935/8.5x13: ""
+*zh_CN.ImageableArea w612h935/8.5x13: ""
+*zh_TW.ImageableArea w612h935/8.5x13: ""
+
+*ImageableArea Tabloid/11x17:                   "12.00 12.00 779.88 1211.90"
+*da.ImageableArea Tabloid/11x17: ""
+*de.ImageableArea Tabloid/11x17 Zoll: ""
+*es.ImageableArea Tabloid/11x17: ""
+*fi.ImageableArea Tabloid/11x17: ""
+*fr.ImageableArea Tabloid/11 x 17 pouces: ""
+*it.ImageableArea Tabloid/11x17: ""
+*ja.ImageableArea Tabloid/11x17: ""
+*ko.ImageableArea Tabloid/11x17: ""
+*nl.ImageableArea Tabloid/11x17: ""
+*nb.ImageableArea Tabloid/11x17: ""
+*pt.ImageableArea Tabloid/11x17: ""
+*sv.ImageableArea Tabloid/11x17: ""
+*zh_CN.ImageableArea Tabloid/11x17: ""
+*zh_TW.ImageableArea Tabloid/11x17 : ""
+
+*ImageableArea 12X18/12x18:                     "12.00 12.12 851.88 1283.88"
+*da.ImageableArea 12X18/12x18: ""
+*de.ImageableArea 12X18/12x18: ""
+*es.ImageableArea 12X18/12x18: ""
+*fi.ImageableArea 12X18/12x18: ""
+*fr.ImageableArea 12X18/12x18: ""
+*it.ImageableArea 12X18/12x18: ""
+*ja.ImageableArea 12X18/12x18: ""
+*ko.ImageableArea 12X18/12x18: ""
+*nl.ImageableArea 12X18/12x18: ""
+*nb.ImageableArea 12X18/12x18: ""
+*pt.ImageableArea 12X18/12x18: ""
+*sv.ImageableArea 12X18/12x18: ""
+*zh_CN.ImageableArea 12X18/12x18: ""
+*zh_TW.ImageableArea 12X18/12x18: ""
+
+*ImageableArea A3/A3:                           "12.00 12.00 829.88 1178.90"
+*da.ImageableArea A3/A3: ""
+*de.ImageableArea A3/A3: ""
+*es.ImageableArea A3/A3: ""
+*fi.ImageableArea A3/A3: ""
+*fr.ImageableArea A3/A3: ""
+*it.ImageableArea A3/A3: ""
+*ja.ImageableArea A3/A3: ""
+*ko.ImageableArea A3/A3: ""
+*nl.ImageableArea A3/A3: ""
+*nb.ImageableArea A3/A3: ""
+*pt.ImageableArea A3/A3: ""
+*sv.ImageableArea A3/A3: ""
+*zh_CN.ImageableArea A3/A3: ""
+*zh_TW.ImageableArea A3/A3: ""
+
+*ImageableArea RA3/RA3:                         "12.00 12.12 852.60 1206.86"
+*da.ImageableArea RA3/RA3: ""
+*de.ImageableArea RA3/RA3: ""
+*es.ImageableArea RA3/RA3: ""
+*fi.ImageableArea RA3/RA3: ""
+*fr.ImageableArea RA3/RA3: ""
+*it.ImageableArea RA3/RA3: ""
+*ja.ImageableArea RA3/RA3: ""
+*ko.ImageableArea RA3/RA3: ""
+*nl.ImageableArea RA3/RA3: ""
+*nb.ImageableArea RA3/RA3: ""
+*pt.ImageableArea RA3/RA3: ""
+*sv.ImageableArea RA3/RA3: ""
+*zh_CN.ImageableArea RA3/RA3: ""
+*zh_TW.ImageableArea RA3/RA3: ""
+
+*ImageableArea A4/A4: 							"12.00 12.00 583.08 829.68"
+*da.ImageableArea A4/A4: ""
+*de.ImageableArea A4/A4: ""
+*es.ImageableArea A4/A4: ""
+*fi.ImageableArea A4/A4: ""
+*fr.ImageableArea A4/A4: ""
+*it.ImageableArea A4/A4: ""
+*ja.ImageableArea A4/A4: ""
+*ko.ImageableArea A4/A4: ""
+*nl.ImageableArea A4/A4: ""
+*nb.ImageableArea A4/A4: ""
+*pt.ImageableArea A4/A4: ""
+*sv.ImageableArea A4/A4: ""
+*zh_CN.ImageableArea A4/A4: ""
+*zh_TW.ImageableArea A4/A4: ""
+
+*ImageableArea A4Small/A4 (Small): 				"28.00 30.00 566.00 811.00"
+*da.ImageableArea A4Small/A4 (lille): ""
+*de.ImageableArea A4Small/A4 (Klein): ""
+*es.ImageableArea A4Small/A4 (pequeño): ""
+*fi.ImageableArea A4Small/A4 (pieni): ""
+*fr.ImageableArea A4Small/A4 (petit): ""
+*it.ImageableArea A4Small/A4 (ridotta): ""
+*ja.ImageableArea A4Small/A4 (小): ""
+*ko.ImageableArea A4Small/A4 (소): ""
+*nl.ImageableArea A4Small/A4 (klein): ""
+*nb.ImageableArea A4Small/A4 (lite): ""
+*pt.ImageableArea A4Small/A4 (pequeno): ""
+*sv.ImageableArea A4Small/A4 (litet): ""
+*zh_CN.ImageableArea A4Small/A4 (小): ""
+*zh_TW.ImageableArea A4Small/A4 (小): ""
+
+*ImageableArea A5/A5: 							"12.00 12.00 407.40 583.20"
+*da.ImageableArea A5/A5: ""
+*de.ImageableArea A5/A5: ""
+*es.ImageableArea A5/A5: ""
+*fi.ImageableArea A5/A5: ""
+*fr.ImageableArea A5/A5: ""
+*it.ImageableArea A5/A5: ""
+*ja.ImageableArea A5/A5: ""
+*ko.ImageableArea A5/A5: ""
+*nl.ImageableArea A5/A5: ""
+*nb.ImageableArea A5/A5: ""
+*pt.ImageableArea A5/A5: ""
+*sv.ImageableArea A5/A5: ""
+*zh_CN.ImageableArea A5/A5: ""
+*zh_TW.ImageableArea A5/A5: ""
+
+*ImageableArea B5/B5 (JIS): 					"12.00 12.00 503.88 715.92"
+*da.ImageableArea B5/JIS B5: ""
+*de.ImageableArea B5/B5 (JIS): ""
+*es.ImageableArea B5/JIS B5: ""
+*fi.ImageableArea B5/JIS B5: ""
+*fr.ImageableArea B5/JIS B5: ""
+*it.ImageableArea B5/JIS B5: ""
+*ja.ImageableArea B5/B5 (JIS): ""
+*ko.ImageableArea B5/JIS B5: ""
+*nl.ImageableArea B5/JIS B5: ""
+*nb.ImageableArea B5/JIS B5: ""
+*pt.ImageableArea B5/B5 JIS: ""
+*sv.ImageableArea B5/JIS B5: ""
+*zh_CN.ImageableArea B5/JIS B5: ""
+*zh_TW.ImageableArea B5/JIS B5: ""
+
+*ImageableArea B4/B4 (JIS):                     "12.00 12.00 716.88 1019.90"
+*da.ImageableArea B4/JIS B4: ""
+*de.ImageableArea B4/B4 (JIS): ""
+*es.ImageableArea B4/JIS B4: ""
+*fi.ImageableArea B4/JIS B4: ""
+*fr.ImageableArea B4/JIS B4: ""
+*it.ImageableArea B4/JIS B4: ""
+*ja.ImageableArea B4/B4 (JIS): ""
+*ko.ImageableArea B4/JIS B4: ""
+*nl.ImageableArea B4/JIS B4: ""
+*nb.ImageableArea B4/JIS B4: ""
+*pt.ImageableArea B4/B4 JIS: ""
+*sv.ImageableArea B4/JIS B4: ""
+*zh_CN.ImageableArea B4/JIS B4: ""
+*zh_TW.ImageableArea B4/JIS B4: ""
+
+*ImageableArea w612h936/Executive (JIS): 		"12.00 12.00 599.76 923.76"
+*da.ImageableArea w612h936/Executive (JIS): ""
+*de.ImageableArea w612h936/Executive (JIS): ""
+*es.ImageableArea w612h936/Ejecutivo (JIS): ""
+*fi.ImageableArea w612h936/Executive (JIS): ""
+*fr.ImageableArea w612h936/Exécutif (JIS): ""
+*it.ImageableArea w612h936/Executive (JIS): ""
+*ja.ImageableArea w612h936/エグゼクティブ (JIS): ""
+*ko.ImageableArea w612h936/Executive(JIS): ""
+*nl.ImageableArea w612h936/Executive (JIS): ""
+*nb.ImageableArea w612h936/Executive (JIS): ""
+*pt.ImageableArea w612h936/Executivo (JIS): ""
+*sv.ImageableArea w612h936/Executive (JIS): ""
+*zh_CN.ImageableArea w612h936/Executive (JIS): ""
+*zh_TW.ImageableArea w612h936/Executive (JIS): ""
+
+*ImageableArea DoublePostcard/Double Postcard (JIS):  "12.12 12.00 407.28 554.64"
+*da.ImageableArea DoublePostcard/Dobbelt postkort (JIS): ""
+*de.ImageableArea DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.ImageableArea DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.ImageableArea DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.ImageableArea DoublePostcard/Carte postale double (JIS): ""
+*it.ImageableArea DoublePostcard/Cartolina doppia (JIS): ""
+*ja.ImageableArea DoublePostcard/往復はがき (JIS): ""
+*ko.ImageableArea DoublePostcard/양면 엽서 (JIS): ""
+*nl.ImageableArea DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.ImageableArea DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.ImageableArea DoublePostcard/Postal duplo (JIS): ""
+*sv.ImageableArea DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.ImageableArea DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.ImageableArea DoublePostcard/雙面明信片 (JIS): ""
+
+*ImageableArea w774h1116/8K:                    "12.00 12.00 761.88 1103.90"
+*da.ImageableArea w774h1116/8K: ""
+*de.ImageableArea w774h1116/8K: ""
+*es.ImageableArea w774h1116/8K: ""
+*fi.ImageableArea w774h1116/8K: ""
+*fr.ImageableArea w774h1116/8K: ""
+*it.ImageableArea w774h1116/8K: ""
+*ja.ImageableArea w774h1116/8K: ""
+*ko.ImageableArea w774h1116/8K: ""
+*nl.ImageableArea w774h1116/8K: ""
+*nb.ImageableArea w774h1116/8K: ""
+*pt.ImageableArea w774h1116/8K: ""
+*sv.ImageableArea w774h1116/8K: ""
+*zh_CN.ImageableArea w774h1116/8K: ""
+*zh_TW.ImageableArea w774h1116/8K: ""
+
+*ImageableArea w558h774/16K: 					"12.00 12.12 545.76 761.76"
+*da.ImageableArea w558h774/16K: ""
+*de.ImageableArea w558h774/16K: ""
+*es.ImageableArea w558h774/16K: ""
+*fi.ImageableArea w558h774/16K: ""
+*fr.ImageableArea w558h774/16K: ""
+*it.ImageableArea w558h774/16K: ""
+*ja.ImageableArea w558h774/16K: ""
+*ko.ImageableArea w558h774/16K: ""
+*nl.ImageableArea w558h774/16K: ""
+*nb.ImageableArea w558h774/16K: ""
+*pt.ImageableArea w558h774/16K: ""
+*sv.ImageableArea w558h774/16K: ""
+*zh_CN.ImageableArea w558h774/16K: ""
+*zh_TW.ImageableArea w558h774/16K: ""
+
+*ImageableArea EnvISOB5/Env B5:				    "12.00 12.12 486.60 696.48"
+*da.ImageableArea EnvISOB5/Konv ISO B5: ""
+*de.ImageableArea EnvISOB5/Umschlag ISO B5: ""
+*es.ImageableArea EnvISOB5/Sobre ISO B5: ""
+*fi.ImageableArea EnvISOB5/Kirjekuori ISO B5: ""
+*fr.ImageableArea EnvISOB5/Enveloppe ISO B5: ""
+*it.ImageableArea EnvISOB5/Busta ISO B5: ""
+*ja.ImageableArea EnvISOB5/封筒 ISO B5: ""
+*ko.ImageableArea EnvISOB5/ISO B5 봉투: ""
+*nl.ImageableArea EnvISOB5/ISO B5-envelop: ""
+*nb.ImageableArea EnvISOB5/B5-konvolutt: ""
+*pt.ImageableArea EnvISOB5/Envelope B5: ""
+*sv.ImageableArea EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.ImageableArea EnvISOB5/信封 ISO B5: ""
+*zh_TW.ImageableArea EnvISOB5/ISO B5 信封: ""
+
+*ImageableArea Env10/Env Comm10:				"12.00 12.12 284.76 672.00"
+*da.ImageableArea Env10/Konv Comm10: ""
+*de.ImageableArea Env10/Umschlag Comm10: ""
+*es.ImageableArea Env10/Sobre Comm10: ""
+*fi.ImageableArea Env10/Kirjekuori Comm10: ""
+*fr.ImageableArea Env10/Enveloppe Comm10: ""
+*it.ImageableArea Env10/Busta Comm10: ""
+*ja.ImageableArea Env10/封筒 Comm10: ""
+*ko.ImageableArea Env10/Comm10 봉투: ""
+*nl.ImageableArea Env10/Comm10-envelop: ""
+*nb.ImageableArea Env10/Comm10-konvolutt: ""
+*pt.ImageableArea Env10/Envelope Comm10: ""
+*sv.ImageableArea Env10/Comm10-kuvert: ""
+*zh_CN.ImageableArea Env10/信封 Comm10: ""
+*zh_TW.ImageableArea Env10/Comm10 信封: ""
+
+*ImageableArea EnvC5/Env C5:					"12.00 12.12 447.00 636.96"
+*da.ImageableArea EnvC5/Konv C5: ""
+*de.ImageableArea EnvC5/Umschlag C5: ""
+*es.ImageableArea EnvC5/Sobre C5: ""
+*fi.ImageableArea EnvC5/Kirjekuori C5: ""
+*fr.ImageableArea EnvC5/Enveloppe C5: ""
+*it.ImageableArea EnvC5/Busta C5: ""
+*ja.ImageableArea EnvC5/封筒 C5: ""
+*ko.ImageableArea EnvC5/C5 봉투: ""
+*nl.ImageableArea EnvC5/C5-envelop: ""
+*nb.ImageableArea EnvC5/C5-konvolutt: ""
+*pt.ImageableArea EnvC5/Envelope C5: ""
+*sv.ImageableArea EnvC5/C5-kuvert: ""
+*zh_CN.ImageableArea EnvC5/信封 C5: ""
+*zh_TW.ImageableArea EnvC5/C5 信封: ""
+
+*ImageableArea EnvDL/Env DL:					"12.00 12.12 299.64 611.52"
+*da.ImageableArea EnvDL/Konv DL: ""
+*de.ImageableArea EnvDL/Umschlag DL: ""
+*es.ImageableArea EnvDL/Sobre DL: ""
+*fi.ImageableArea EnvDL/Kirjekuori DL: ""
+*fr.ImageableArea EnvDL/Enveloppe DL: ""
+*it.ImageableArea EnvDL/Busta DL: ""
+*ja.ImageableArea EnvDL/封筒 DL: ""
+*ko.ImageableArea EnvDL/DL 봉투: ""
+*nl.ImageableArea EnvDL/DL-envelop: ""
+*nb.ImageableArea EnvDL/DL-konvolutt: ""
+*pt.ImageableArea EnvDL/Envelope DL: ""
+*sv.ImageableArea EnvDL/DL-kuvert: ""
+*zh_CN.ImageableArea EnvDL/信封 DL: ""
+*zh_TW.ImageableArea EnvDL/DL 信封: ""
+
+*ImageableArea EnvMonarch/Env Monarch:			"12.00 12.12 266.76 528.00"
+*da.ImageableArea EnvMonarch/Konv Monarch: ""
+*de.ImageableArea EnvMonarch/Umschlag Monarch: ""
+*es.ImageableArea EnvMonarch/Sobre Monarch: ""
+*fi.ImageableArea EnvMonarch/Kirjekuori Monarch: ""
+*fr.ImageableArea EnvMonarch/Enveloppe Monarch: ""
+*it.ImageableArea EnvMonarch/Busta Monarch: ""
+*ja.ImageableArea EnvMonarch/封筒 Monarch: ""
+*ko.ImageableArea EnvMonarch/Monarch 봉투: ""
+*nl.ImageableArea EnvMonarch/Monarch-envelop: ""
+*nb.ImageableArea EnvMonarch/Monarch-konvolutt: ""
+*pt.ImageableArea EnvMonarch/Envelope Monarch: ""
+*sv.ImageableArea EnvMonarch/Monarch-kuvert: ""
+*zh_CN.ImageableArea EnvMonarch/信封 Monarch: ""
+*zh_TW.ImageableArea EnvMonarch/Monarch 信封: ""
+
+*?ImageableArea: "
+ save
+   /cvp { (                ) cvs print ( ) print } bind def
+   /upperright {10000 mul floor 10000 div} bind def
+   /lowerleft {10000 mul ceiling 10000 div} bind def
+   newpath clippath pathbbox
+   4 -2 roll exch 2 {Tray3left cvp} repeat
+   exch 2 {Tray1right cvp} repeat flush
+ restore
+"
+*End
+
+*% These provide the physical dimensions of the paper (by keyword)
+*DefaultPaperDimension: Letter
+*PaperDimension Letter/Letter: 					"612 792"
+*da.PaperDimension Letter/Letter: ""
+*de.PaperDimension Letter/Letter: ""
+*es.PaperDimension Letter/Letter: ""
+*fi.PaperDimension Letter/Letter: ""
+*fr.PaperDimension Letter/Lettre: ""
+*it.PaperDimension Letter/Letter: ""
+*ja.PaperDimension Letter/レター: ""
+*ko.PaperDimension Letter/레터: ""
+*nl.PaperDimension Letter/Letter: ""
+*nb.PaperDimension Letter/Letter: ""
+*pt.PaperDimension Letter/Carta: ""
+*sv.PaperDimension Letter/Letter: ""
+*zh_CN.PaperDimension Letter/信纸: ""
+*zh_TW.PaperDimension Letter/Letter: ""
+
+*PaperDimension LetterSmall/Letter (Small):		"612 792"
+*da.PaperDimension LetterSmall/Letter (lille): ""
+*de.PaperDimension LetterSmall/Letter (Klein): ""
+*es.PaperDimension LetterSmall/Letter (pequeño): ""
+*fi.PaperDimension LetterSmall/Letter (pieni): ""
+*fr.PaperDimension LetterSmall/Lettre (petit): ""
+*it.PaperDimension LetterSmall/Letter (ridotto): ""
+*ja.PaperDimension LetterSmall/レター (小): ""
+*ko.PaperDimension LetterSmall/레터 (소): ""
+*nl.PaperDimension LetterSmall/Letter (klein): ""
+*nb.PaperDimension LetterSmall/Letter (lite): ""
+*pt.PaperDimension LetterSmall/Carta (pequeno): ""
+*sv.PaperDimension LetterSmall/Letter (litet): ""
+*zh_CN.PaperDimension LetterSmall/信纸 (小): ""
+*zh_TW.PaperDimension LetterSmall/Letter (小): ""
+
+*PaperDimension Legal/Legal: 					"612 1008"
+*da.PaperDimension Legal/Legal: ""
+*de.PaperDimension Legal/Legal: ""
+*es.PaperDimension Legal/Legal: ""
+*fi.PaperDimension Legal/Legal: ""
+*fr.PaperDimension Legal/Légal: ""
+*it.PaperDimension Legal/Legal: ""
+*ja.PaperDimension Legal/リーガル: ""
+*ko.PaperDimension Legal/리갈: ""
+*nl.PaperDimension Legal/Legal: ""
+*nb.PaperDimension Legal/Legal: ""
+*pt.PaperDimension Legal/Legal: ""
+*sv.PaperDimension Legal/Legal: ""
+*zh_CN.PaperDimension Legal/Legal: ""
+*zh_TW.PaperDimension Legal/Legal: ""
+
+*PaperDimension LegalSmall/Legal (Small): 		"612 1008"
+*da.PaperDimension LegalSmall/Legal (lille): ""
+*de.PaperDimension LegalSmall/Legal (Klein): ""
+*es.PaperDimension LegalSmall/Legal (pequeño): ""
+*fi.PaperDimension LegalSmall/Legal (pieni): ""
+*fr.PaperDimension LegalSmall/Légal (petit): ""
+*it.PaperDimension LegalSmall/Legal (ridotto): ""
+*ja.PaperDimension LegalSmall/リーガル (小): ""
+*ko.PaperDimension LegalSmall/리갈 (소): ""
+*nl.PaperDimension LegalSmall/Legal (klein): ""
+*nb.PaperDimension LegalSmall/Legal (lite): ""
+*pt.PaperDimension LegalSmall/Legal (pequeno): ""
+*sv.PaperDimension LegalSmall/Legal (litet): ""
+*zh_CN.PaperDimension LegalSmall/Legal (小): ""
+*zh_TW.PaperDimension LegalSmall/Legal (小): ""
+
+*PaperDimension Executive/Executive: 			"522 756"
+*da.PaperDimension Executive/Executive: ""
+*de.PaperDimension Executive/Executive: ""
+*es.PaperDimension Executive/Ejecutivo: ""
+*fi.PaperDimension Executive/Executive: ""
+*fr.PaperDimension Executive/Exécutif: ""
+*it.PaperDimension Executive/Executive: ""
+*ja.PaperDimension Executive/エグゼクティブ: ""
+*ko.PaperDimension Executive/Executive: ""
+*nl.PaperDimension Executive/Executive: ""
+*nb.PaperDimension Executive/Executive: ""
+*pt.PaperDimension Executive/Executivo: ""
+*sv.PaperDimension Executive/Executive: ""
+*zh_CN.PaperDimension Executive/Executive: ""
+*zh_TW.PaperDimension Executive/Executive: ""
+
+*PaperDimension HalfLetter/Statement:			"396 612"
+*da.PaperDimension HalfLetter/Statement: ""
+*de.PaperDimension HalfLetter/Statement: ""
+*es.PaperDimension HalfLetter/Declaración: ""
+*fi.PaperDimension HalfLetter/Statement: ""
+*fr.PaperDimension HalfLetter/1/2 Lettre: ""
+*it.PaperDimension HalfLetter/Dichiarazione: ""
+*ja.PaperDimension HalfLetter/Statement: ""
+*ko.PaperDimension HalfLetter/2절 레터: ""
+*nl.PaperDimension HalfLetter/1/2 Letter : ""
+*nb.PaperDimension HalfLetter/1/2 Letter: ""
+*pt.PaperDimension HalfLetter/Statement: ""
+*sv.PaperDimension HalfLetter/Statement: ""
+*zh_CN.PaperDimension HalfLetter/结算单: ""
+*zh_TW.PaperDimension HalfLetter/Statement: ""
+
+*PaperDimension w612h935/8.5x13: 				"612 935"
+*da.PaperDimension w612h935/8.5x13: ""
+*de.PaperDimension w612h935/8.5x13: ""
+*es.PaperDimension w612h935/8.5x13: ""
+*fi.PaperDimension w612h935/8.5x13: ""
+*fr.PaperDimension w612h935/8.5x13: ""
+*it.PaperDimension w612h935/8.5x13: ""
+*ja.PaperDimension w612h935/8.5x13: ""
+*ko.PaperDimension w612h935/8.5x13: ""
+*nl.PaperDimension w612h935/8.5x13: ""
+*nb.PaperDimension w612h935/8.5x13: ""
+*pt.PaperDimension w612h935/8.5x13: ""
+*sv.PaperDimension w612h935/8.5x13: ""
+*zh_CN.PaperDimension w612h935/8.5x13: ""
+*zh_TW.PaperDimension w612h935/8.5x13: ""
+
+*PaperDimension Tabloid/11x17:                  "792 1224"
+*da.PaperDimension Tabloid/11x17: ""
+*de.PaperDimension Tabloid/11x17 Zoll: ""
+*es.PaperDimension Tabloid/11x17: ""
+*fi.PaperDimension Tabloid/11x17: ""
+*fr.PaperDimension Tabloid/11 x 17 pouces: ""
+*it.PaperDimension Tabloid/11x17: ""
+*ja.PaperDimension Tabloid/11x17: ""
+*ko.PaperDimension Tabloid/11x17: ""
+*nl.PaperDimension Tabloid/11x17: ""
+*nb.PaperDimension Tabloid/11x17: ""
+*pt.PaperDimension Tabloid/11x17: ""
+*sv.PaperDimension Tabloid/11x17: ""
+*zh_CN.PaperDimension Tabloid/11x17: ""
+*zh_TW.PaperDimension Tabloid/11x17 : ""
+
+*PaperDimension 12X18/12x18:                   	"864 1296"
+*da.PaperDimension 12X18/12x18: ""
+*de.PaperDimension 12X18/12x18: ""
+*es.PaperDimension 12X18/12x18: ""
+*fi.PaperDimension 12X18/12x18: ""
+*fr.PaperDimension 12X18/12x18: ""
+*it.PaperDimension 12X18/12x18: ""
+*ja.PaperDimension 12X18/12x18: ""
+*ko.PaperDimension 12X18/12x18: ""
+*nl.PaperDimension 12X18/12x18: ""
+*nb.PaperDimension 12X18/12x18: ""
+*pt.PaperDimension 12X18/12x18: ""
+*sv.PaperDimension 12X18/12x18: ""
+*zh_CN.PaperDimension 12X18/12x18: ""
+*zh_TW.PaperDimension 12X18/12x18: ""
+
+*PaperDimension A3/A3:                          "842 1191"
+*da.PaperDimension A3/A3: ""
+*de.PaperDimension A3/A3: ""
+*es.PaperDimension A3/A3: ""
+*fi.PaperDimension A3/A3: ""
+*fr.PaperDimension A3/A3: ""
+*it.PaperDimension A3/A3: ""
+*ja.PaperDimension A3/A3: ""
+*ko.PaperDimension A3/A3: ""
+*nl.PaperDimension A3/A3: ""
+*nb.PaperDimension A3/A3: ""
+*pt.PaperDimension A3/A3: ""
+*sv.PaperDimension A3/A3: ""
+*zh_CN.PaperDimension A3/A3: ""
+*zh_TW.PaperDimension A3/A3: ""
+
+*PaperDimension RA3/RA3:                        "865 1219"
+*da.PaperDimension RA3/RA3: ""
+*de.PaperDimension RA3/RA3: ""
+*es.PaperDimension RA3/RA3: ""
+*fi.PaperDimension RA3/RA3: ""
+*fr.PaperDimension RA3/RA3: ""
+*it.PaperDimension RA3/RA3: ""
+*ja.PaperDimension RA3/RA3: ""
+*ko.PaperDimension RA3/RA3: ""
+*nl.PaperDimension RA3/RA3: ""
+*nb.PaperDimension RA3/RA3: ""
+*pt.PaperDimension RA3/RA3: ""
+*sv.PaperDimension RA3/RA3: ""
+*zh_CN.PaperDimension RA3/RA3: ""
+*zh_TW.PaperDimension RA3/RA3: ""
+
+*PaperDimension A4/A4: 							"595 842"
+*da.PaperDimension A4/A4: ""
+*de.PaperDimension A4/A4: ""
+*es.PaperDimension A4/A4: ""
+*fi.PaperDimension A4/A4: ""
+*fr.PaperDimension A4/A4: ""
+*it.PaperDimension A4/A4: ""
+*ja.PaperDimension A4/A4: ""
+*ko.PaperDimension A4/A4: ""
+*nl.PaperDimension A4/A4: ""
+*nb.PaperDimension A4/A4: ""
+*pt.PaperDimension A4/A4: ""
+*sv.PaperDimension A4/A4: ""
+*zh_CN.PaperDimension A4/A4: ""
+*zh_TW.PaperDimension A4/A4: ""
+
+*PaperDimension A4Small/A4 (Small): 			"595 842"
+*da.PaperDimension A4Small/A4 (lille): ""
+*de.PaperDimension A4Small/A4 (Klein): ""
+*es.PaperDimension A4Small/A4 (pequeño): ""
+*fi.PaperDimension A4Small/A4 (pieni): ""
+*fr.PaperDimension A4Small/A4 (petit): ""
+*it.PaperDimension A4Small/A4 (ridotta): ""
+*ja.PaperDimension A4Small/A4 (小): ""
+*ko.PaperDimension A4Small/A4 (소): ""
+*nl.PaperDimension A4Small/A4 (klein): ""
+*nb.PaperDimension A4Small/A4 (lite): ""
+*pt.PaperDimension A4Small/A4 (pequeno): ""
+*sv.PaperDimension A4Small/A4 (litet): ""
+*zh_CN.PaperDimension A4Small/A4 (小): ""
+*zh_TW.PaperDimension A4Small/A4 (小): ""
+
+*PaperDimension A5/A5: 							"420 595"
+*da.PaperDimension A5/A5: ""
+*de.PaperDimension A5/A5: ""
+*es.PaperDimension A5/A5: ""
+*fi.PaperDimension A5/A5: ""
+*fr.PaperDimension A5/A5: ""
+*it.PaperDimension A5/A5: ""
+*ja.PaperDimension A5/A5: ""
+*ko.PaperDimension A5/A5: ""
+*nl.PaperDimension A5/A5: ""
+*nb.PaperDimension A5/A5: ""
+*pt.PaperDimension A5/A5: ""
+*sv.PaperDimension A5/A5: ""
+*zh_CN.PaperDimension A5/A5: ""
+*zh_TW.PaperDimension A5/A5: ""
+
+*PaperDimension B5/B5 (JIS): 					"516 729"
+*da.PaperDimension B5/JIS B5: ""
+*de.PaperDimension B5/B5 (JIS): ""
+*es.PaperDimension B5/JIS B5: ""
+*fi.PaperDimension B5/JIS B5: ""
+*fr.PaperDimension B5/JIS B5: ""
+*it.PaperDimension B5/B5 JIS: ""
+*ja.PaperDimension B5/B5 (JIS): ""
+*ko.PaperDimension B5/JIS B5: ""
+*nl.PaperDimension B5/JIS B5: ""
+*nb.PaperDimension B5/JIS B5: ""
+*pt.PaperDimension B5/B5 JIS: ""
+*sv.PaperDimension B5/JIS B5: ""
+*zh_CN.PaperDimension B5/JIS B5: ""
+*zh_TW.PaperDimension B5/JIS B5: ""
+
+*PaperDimension B4/B4 (JIS):                    "729 1032"
+*da.PaperDimension B4/JIS B4: ""
+*de.PaperDimension B4/B4 (JIS): ""
+*es.PaperDimension B4/JIS B4: ""
+*fi.PaperDimension B4/JIS B4: ""
+*fr.PaperDimension B4/JIS B4: ""
+*it.PaperDimension B4/B4 JIS: ""
+*ja.PaperDimension B4/B4 (JIS): ""
+*ko.PaperDimension B4/JIS B4: ""
+*nl.PaperDimension B4/JIS B4: ""
+*nb.PaperDimension B4/JIS B4: ""
+*pt.PaperDimension B4/B4 JIS: ""
+*sv.PaperDimension B4/JIS B4: ""
+*zh_CN.PaperDimension B4/JIS B4: ""
+*zh_TW.PaperDimension B4/JIS B4: ""
+
+*PaperDimension w612h936/Executive (JIS): 		"612 936"
+*da.PaperDimension w612h936/Executive (JIS): ""
+*de.PaperDimension w612h936/Executive (JIS): ""
+*es.PaperDimension w612h936/Ejecutivo (JIS): ""
+*fi.PaperDimension w612h936/Executive (JIS): ""
+*fr.PaperDimension w612h936/Exécutif (JIS): ""
+*it.PaperDimension w612h936/Executive (JIS): ""
+*ja.PaperDimension w612h936/エグゼクティブ (JIS): ""
+*ko.PaperDimension w612h936/Executive(JIS): ""
+*nl.PaperDimension w612h936/Executive (JIS): ""
+*nb.PaperDimension w612h936/Executive (JIS): ""
+*pt.PaperDimension w612h936/Executivo (JIS): ""
+*sv.PaperDimension w612h936/Executive (JIS): ""
+*zh_CN.PaperDimension w612h936/Executive (JIS): ""
+*zh_TW.PaperDimension w612h936/Executive (JIS): ""
+
+*PaperDimension DoublePostcard/Double Postcard (JIS): "419.5 567"
+*da.PaperDimension DoublePostcard/Dobbelt postkort (JIS): ""
+*de.PaperDimension DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.PaperDimension DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.PaperDimension DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.PaperDimension DoublePostcard/Carte postale double (JIS): ""
+*it.PaperDimension DoublePostcard/Cartolina doppia (JIS): ""
+*ja.PaperDimension DoublePostcard/往復はがき (JIS): ""
+*ko.PaperDimension DoublePostcard/양면 엽서 (JIS): ""
+*nl.PaperDimension DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.PaperDimension DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.PaperDimension DoublePostcard/Postal duplo (JIS): ""
+*sv.PaperDimension DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.PaperDimension DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.PaperDimension DoublePostcard/雙面明信片 (JIS): ""
+
+*PaperDimension w774h1116/8K:                   "774 1116"
+*da.PaperDimension w774h1116/8K: ""
+*de.PaperDimension w774h1116/8K: ""
+*es.PaperDimension w774h1116/8K: ""
+*fi.PaperDimension w774h1116/8 K: ""
+*fr.PaperDimension w774h1116/8K: ""
+*it.PaperDimension w774h1116/8K: ""
+*ja.PaperDimension w774h1116/8K: ""
+*ko.PaperDimension w774h1116/8K: ""
+*nl.PaperDimension w774h1116/8K: ""
+*nb.PaperDimension w774h1116/8K: ""
+*pt.PaperDimension w774h1116/8K: ""
+*sv.PaperDimension w774h1116/8K: ""
+*zh_CN.PaperDimension w774h1116/8K: ""
+*zh_TW.PaperDimension w774h1116/8K: ""
+
+*PaperDimension w558h774/16K:					"558 774"
+*da.PaperDimension w558h774/16K: ""
+*de.PaperDimension w558h774/16K: ""
+*es.PaperDimension w558h774/16K: ""
+*fi.PaperDimension w558h774/16 K: ""
+*fr.PaperDimension w558h774/16K: ""
+*it.PaperDimension w558h774/16K: ""
+*ja.PaperDimension w558h774/16K: ""
+*ko.PaperDimension w558h774/16K: ""
+*nl.PaperDimension w558h774/16K: ""
+*nb.PaperDimension w558h774/16K: ""
+*pt.PaperDimension w558h774/16K: ""
+*sv.PaperDimension w558h774/16K: ""
+*zh_CN.PaperDimension w558h774/16K: ""
+*zh_TW.PaperDimension w558h774/16K: ""
+
+*PaperDimension EnvISOB5/Env B5: 				"499 709"
+*da.PaperDimension EnvISOB5/Konv ISO B5: ""
+*de.PaperDimension EnvISOB5/Umschlag ISO B5: ""
+*es.PaperDimension EnvISOB5/Sobre ISO B5: ""
+*fi.PaperDimension EnvISOB5/Kirjekuori ISO B5: ""
+*fr.PaperDimension EnvISOB5/Enveloppe ISO B5: ""
+*it.PaperDimension EnvISOB5/Busta ISO B5: ""
+*ja.PaperDimension EnvISOB5/封筒 ISO B5: ""
+*ko.PaperDimension EnvISOB5/ISO B5 봉투: ""
+*nl.PaperDimension EnvISOB5/ISO B5-envelop: ""
+*nb.PaperDimension EnvISOB5/B5-konvolutt: ""
+*pt.PaperDimension EnvISOB5/Envelope B5: ""
+*sv.PaperDimension EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.PaperDimension EnvISOB5/信封 ISO B5: ""
+*zh_TW.PaperDimension EnvISOB5/ISO B5 信封: ""
+
+*PaperDimension Env10/Env Comm10:				"297 684"
+*da.PaperDimension Env10/Konv Comm10: ""
+*de.PaperDimension Env10/Umschlag Comm10: ""
+*es.PaperDimension Env10/Sobre Comm10: ""
+*fi.PaperDimension Env10/Kirjekuori Comm10: ""
+*fr.PaperDimension Env10/Enveloppe Comm10: ""
+*it.PaperDimension Env10/Busta Comm10: ""
+*ja.PaperDimension Env10/封筒 Comm10: ""
+*ko.PaperDimension Env10/Comm10 봉투: ""
+*nl.PaperDimension Env10/Comm10-envelop: ""
+*nb.PaperDimension Env10/Comm10-konvolutt: ""
+*pt.PaperDimension Env10/Envelope Comm10: ""
+*sv.PaperDimension Env10/Comm10-kuvert: ""
+*zh_CN.PaperDimension Env10/信封 Comm10: ""
+*zh_TW.PaperDimension Env10/Comm10 信封: ""
+
+*PaperDimension EnvC5/Env C5: 					"459 649"
+*da.PaperDimension EnvC5/Konv C5: ""
+*de.PaperDimension EnvC5/Umschlag C5: ""
+*es.PaperDimension EnvC5/Sobre C5: ""
+*fi.PaperDimension EnvC5/Kirjekuori C5: ""
+*fr.PaperDimension EnvC5/Enveloppe C5: ""
+*it.PaperDimension EnvC5/Busta C5: ""
+*ja.PaperDimension EnvC5/封筒 C5: ""
+*ko.PaperDimension EnvC5/C5 봉투: ""
+*nl.PaperDimension EnvC5/C5-envelop: ""
+*nb.PaperDimension EnvC5/C5-konvolutt: ""
+*pt.PaperDimension EnvC5/Envelope C5: ""
+*sv.PaperDimension EnvC5/C5-kuvert: ""
+*zh_CN.PaperDimension EnvC5/信封 C5: ""
+*zh_TW.PaperDimension EnvC5/C5 信封: ""
+
+*PaperDimension EnvDL/Env DL: 					"312 624"
+*da.PaperDimension EnvDL/Konv DL: ""
+*de.PaperDimension EnvDL/Umschlag DL: ""
+*es.PaperDimension EnvDL/Sobre DL: ""
+*fi.PaperDimension EnvDL/Kirjekuori DL: ""
+*fr.PaperDimension EnvDL/Enveloppe DL: ""
+*it.PaperDimension EnvDL/Busta DL: ""
+*ja.PaperDimension EnvDL/封筒 DL: ""
+*ko.PaperDimension EnvDL/DL 봉투: ""
+*nl.PaperDimension EnvDL/DL-envelop: ""
+*nb.PaperDimension EnvDL/DL-konvolutt: ""
+*pt.PaperDimension EnvDL/Envelope DL: ""
+*sv.PaperDimension EnvDL/DL-kuvert: ""
+*zh_CN.PaperDimension EnvDL/信封 DL: ""
+*zh_TW.PaperDimension EnvDL/DL 信封: ""
+
+*PaperDimension EnvMonarch/Env Monarch: 		"279 540"
+*da.PaperDimension EnvMonarch/Konv Monarch: ""
+*de.PaperDimension EnvMonarch/Umschlag Monarch: ""
+*es.PaperDimension EnvMonarch/Sobre Monarch: ""
+*fi.PaperDimension EnvMonarch/Kirjekuori Monarch: ""
+*fr.PaperDimension EnvMonarch/Enveloppe Monarch: ""
+*it.PaperDimension EnvMonarch/Busta Monarch: ""
+*ja.PaperDimension EnvMonarch/封筒 Monarch: ""
+*ko.PaperDimension EnvMonarch/Monarch 봉투: ""
+*nl.PaperDimension EnvMonarch/Monarch-envelop: ""
+*nb.PaperDimension EnvMonarch/Monarch-konvolutt: ""
+*pt.PaperDimension EnvMonarch/Envelope Monarch: ""
+*sv.PaperDimension EnvMonarch/Monarch-kuvert: ""
+*zh_CN.PaperDimension EnvMonarch/信封 Monarch: ""
+*zh_TW.PaperDimension EnvMonarch/Monarch 信封: ""
+
+
+*RequiresPageRegion All: True
+
+
+*%=================================================
+*%		 Custom Paper Support
+*%=================================================
+*%Orientation and Margin (offsets) values are not utilized
+
+*VariablePaperSize: True
+
+*LeadingEdge PreferLong: ""
+*DefaultLeadingEdge: PreferLong
+
+*% Smallest = 3.67x7.5, Largest = 11.7 x 17.7
+*MaxMediaWidth:  "884"
+*MaxMediaHeight: "1332"
+*HWMargins:      12 12 12 12
+*%CustomPageRegion True: ""
+*CustomPageSize True: "
+  pop pop pop
+  <</DeferredMediaSelection true /PageSize [ 7 -2 roll ] /ImagingBBox null >>
+  setpagedevice
+"
+*End
+
+
+*ParamCustomPageSize Width:        1 points 264 842
+*ParamCustomPageSize Height:       2 points 540 1274
+*ParamCustomPageSize WidthOffset:  3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation:  5 int 0 0
+
+*RequiresPageRegion All: True
+
+*%=================================================
+*%		 Paper Sources
+*%=================================================
+*OpenUI *InputSlot/Paper Source: PickOne
+*OrderDependency: 20 AnySetup *InputSlot
+*DefaultInputSlot: Tray2
+*da.Translation InputSlot/Papirkilde: ""
+*de.Translation InputSlot/Papierquelle: ""
+*es.Translation InputSlot/Alimentación de papel: ""
+*fi.Translation InputSlot/Paperilähde: ""
+*fr.Translation InputSlot/Source du papier: ""
+*it.Translation InputSlot/Alimentazione della carta: ""
+*ja.Translation InputSlot/給紙元: ""
+*ko.Translation InputSlot/용지함: ""
+*nl.Translation InputSlot/Papierbron: ""
+*nb.Translation InputSlot/Arkmating: ""
+*pt.Translation InputSlot/Fonte de papel: ""
+*sv.Translation InputSlot/Papperskälla: ""
+*zh_CN.Translation InputSlot/纸张来源: ""
+*zh_TW.Translation InputSlot/紙張來源: ""
+
+*InputSlot Tray1/Tray 1: "<</ManualFeed false /MediaPosition 3>> setpagedevice"
+*da.InputSlot Tray1/Bakke 1: ""
+*de.InputSlot Tray1/Zufuhrfach 1: ""
+*es.InputSlot Tray1/Bandeja 1: ""
+*fi.InputSlot Tray1/Lokero 1: ""
+*fr.InputSlot Tray1/Bac 1: ""
+*it.InputSlot Tray1/Cassetto 1: ""
+*ja.InputSlot Tray1/トレイ 1: ""
+*ko.InputSlot Tray1/용지함 1: ""
+*nl.InputSlot Tray1/Lade 1: ""
+*nb.InputSlot Tray1/Skuff 1: ""
+*pt.InputSlot Tray1/Bandeja 1: ""
+*sv.InputSlot Tray1/Fack 1: ""
+*zh_CN.InputSlot Tray1/纸盒 1: ""
+*zh_TW.InputSlot Tray1/1 號紙匣: ""
+
+*InputSlot Tray2/Tray 2: "<</ManualFeed false /MediaPosition 0>> setpagedevice"
+*da.InputSlot Tray2/Bakke 2: ""
+*de.InputSlot Tray2/Zufuhrfach 2: ""
+*es.InputSlot Tray2/Bandeja 2: ""
+*fi.InputSlot Tray2/Lokero 2: ""
+*fr.InputSlot Tray2/Bac 2: ""
+*it.InputSlot Tray2/Cassetto 2: ""
+*ja.InputSlot Tray2/トレイ 2: ""
+*ko.InputSlot Tray2/용지함 2: ""
+*nl.InputSlot Tray2/Lade 2: ""
+*nb.InputSlot Tray2/Skuff 2: ""
+*pt.InputSlot Tray2/Bandeja 2: ""
+*sv.InputSlot Tray2/Fack 2: ""
+*zh_CN.InputSlot Tray2/纸盒 2: ""
+*zh_TW.InputSlot Tray2/2 號紙匣: ""
+
+*InputSlot Tray3/Tray 3: "<</ManualFeed false /MediaPosition 1>> setpagedevice"
+*da.InputSlot Tray3/Bakke 3: ""
+*de.InputSlot Tray3/Zufuhrfach 3: ""
+*es.InputSlot Tray3/Bandeja 3: ""
+*fi.InputSlot Tray3/Lokero 3: ""
+*fr.InputSlot Tray3/Bac 3: ""
+*it.InputSlot Tray3/Cassetto 3: ""
+*ja.InputSlot Tray3/トレイ 3: ""
+*ko.InputSlot Tray3/용지함 3: ""
+*nl.InputSlot Tray3/Lade 3: ""
+*nb.InputSlot Tray3/Skuff 3: ""
+*pt.InputSlot Tray3/Bandeja 3: ""
+*sv.InputSlot Tray3/Fack 3: ""
+*zh_CN.InputSlot Tray3/纸盒 3: ""
+*zh_TW.InputSlot Tray3/3 號紙匣: ""
+
+*InputSlot Tray4Optional/Tray 4 (Optional): "<</ManualFeed false /MediaPosition 5>> setpagedevice"
+*da.InputSlot Tray4Optional/Bakke 4 (Ekstraudstyr): ""
+*de.InputSlot Tray4Optional/Zufuhrfach 4 (Optional): ""
+*es.InputSlot Tray4Optional/Bandeja 4 (Opcional): ""
+*fi.InputSlot Tray4Optional/Lokero 4 (valinnainen): ""
+*fr.InputSlot Tray4Optional/Bac 4 (Optionnel): ""
+*it.InputSlot Tray4Optional/Cassetto 4 (Opzionale): ""
+*ja.InputSlot Tray4Optional/トレイ 4 (ｵﾌﾟｼｮﾝ): ""
+*ko.InputSlot Tray4Optional/용지함 4 (선택사양): ""
+*nl.InputSlot Tray4Optional/Lade 4 (Optioneel): ""
+*nb.InputSlot Tray4Optional/Skuff 4 (ekstrautstyr): ""
+*pt.InputSlot Tray4Optional/Bandeja 4 (opcional): ""
+*sv.InputSlot Tray4Optional/Fack 4 (extra tillbehör): ""
+*zh_CN.InputSlot Tray4Optional/纸盒 4 (供选用): ""
+*zh_TW.InputSlot Tray4Optional/4 號紙匣（選購）: ""
+
+*?InputSlot: "
+ save
+   [(Tray1) (Tray2) (Tray3) (Tray4Optional)]
+   statusdict /papertray get exec
+   {get exec} stopped { pop pop (Unknown) } if = flush
+ restore
+"
+*End
+*CloseUI: *InputSlot
+
+*% Enable/Disable Manual Feed
+*OpenUI *ManualFeed/Tray 1 (Manual): Boolean
+*OrderDependency: 20 AnySetup *ManualFeed
+*DefaultManualFeed: False
+*da.Translation ManualFeed/Bakke 1 (manuel): ""
+*de.Translation ManualFeed/Zufuhrfach 1 (Manuell): ""
+*es.Translation ManualFeed/Bandeja 1 (Manual): ""
+*fi.Translation ManualFeed/Lokero 1 (Käsinsyöttö): ""
+*fr.Translation ManualFeed/Bac 1 (manuel): ""
+*it.Translation ManualFeed/Cassetto 1 (Manuale): ""
+*ja.Translation ManualFeed/トレイ 1 (手動): ""
+*ko.Translation ManualFeed/용지함 1(수동): ""
+*nl.Translation ManualFeed/Lade 1 (handmatig): ""
+*nb.Translation ManualFeed/Skuff 1 (manuell): ""
+*pt.Translation ManualFeed/Bandeja 1 (manual): ""
+*sv.Translation ManualFeed/Fack 1 (manuell): ""
+*zh_CN.Translation ManualFeed/纸盒1 (手工): ""
+*zh_TW.Translation ManualFeed/紙匣1 ( 手動): ""
+
+*ManualFeed True/True: "
+	<</ManualFeed true>> setpagedevice"
+*End
+*da.ManualFeed True/Sand: ""
+*de.ManualFeed True/Ja: ""
+*es.ManualFeed True/Verdadero: ""
+*fi.ManualFeed True/Käytössä: ""
+*fr.ManualFeed True/Vrai: ""
+*it.ManualFeed True/Vero: ""
+*ja.ManualFeed True/はい: ""
+*ko.ManualFeed True/참: ""
+*nl.ManualFeed True/Waar: ""
+*nb.ManualFeed True/Sann: ""
+*pt.ManualFeed True/Verdadeiro: ""
+*sv.ManualFeed True/Sant: ""
+*zh_CN.ManualFeed True/真: ""
+*zh_TW.ManualFeed True/真: ""
+
+*ManualFeed False/False: "
+	<</ManualFeed false>> setpagedevice"
+*End
+*da.ManualFeed False/Falsk: ""
+*de.ManualFeed False/Nein: ""
+*es.ManualFeed False/Falso: ""
+*fi.ManualFeed False/Ei käytössä: ""
+*fr.ManualFeed False/Faux: ""
+*it.ManualFeed False/Falso: ""
+*ja.ManualFeed False/いいえ: ""
+*ko.ManualFeed False/거짓: ""
+*nl.ManualFeed False/Onwaar: ""
+*nb.ManualFeed False/Usann: ""
+*pt.ManualFeed False/Falso: ""
+*sv.ManualFeed False/Falskt: ""
+*zh_CN.ManualFeed False/伪: ""
+*zh_TW.ManualFeed False/假: ""
+
+*?ManualFeed: "
+	save
+		currentpagedevice /ManualFeed get
+		{(True)}{(False)}ifelse = flush
+	restore
+"
+*End
+*CloseUI: *ManualFeed
+
+*%==========================================
+*%		Media Type
+*%=========================================
+*OpenUI *MediaType/Media Type: PickOne
+*OrderDependency: 20 AnySetup *MediaType
+*DefaultMediaType: Unspecified
+*da.Translation MediaType/Medietype: ""
+*de.Translation MediaType/Medientyp: ""
+*es.Translation MediaType/Tipo de sustrato: ""
+*fi.Translation MediaType/Tulostusmateriaali: ""
+*fr.Translation MediaType/Type de support: ""
+*it.Translation MediaType/Tipo di supporto: ""
+*ja.Translation MediaType/用紙の種類: ""
+*ko.Translation MediaType/용지 종류: ""
+*nl.Translation MediaType/Type afdrukmateriaal: ""
+*nb.Translation MediaType/Utskriftsmateriale: ""
+*pt.Translation MediaType/Tipo de mídia: ""
+*sv.Translation MediaType/Material: ""
+*zh_CN.Translation MediaType/介质类型: ""
+*zh_TW.Translation MediaType/媒體類型: ""
+
+*MediaType Unspecified/Unspecified:  "
+    <</ManualFeed false /MediaType null >> setpagedevice"
+*End
+*da.MediaType Unspecified/Uspecificeret: ""
+*de.MediaType Unspecified/Nicht bestimmt: ""
+*es.MediaType Unspecified/No especificado: ""
+*fi.MediaType Unspecified/Määrittämätön: ""
+*fr.MediaType Unspecified/Non spécifié: ""
+*it.MediaType Unspecified/Non specificato: ""
+*ja.MediaType Unspecified/指定なし: ""
+*ko.MediaType Unspecified/지정되지 않음: ""
+*nl.MediaType Unspecified/Onbekend: ""
+*nb.MediaType Unspecified/Uspesifisert: ""
+*pt.MediaType Unspecified/Não especificado: ""
+*sv.MediaType Unspecified/Ospecificerad: ""
+*zh_CN.MediaType Unspecified/未指定: ""
+*zh_TW.MediaType Unspecified/未指定: ""
+
+*MediaType Plain/Plain:  "
+    <</ManualFeed false /MediaType (Plain)>> setpagedevice"
+*End
+*da.MediaType Plain/Almindeligt: ""
+*de.MediaType Plain/Normalpapier: ""
+*es.MediaType Plain/Estándar: ""
+*fi.MediaType Plain/Tavallinen: ""
+*fr.MediaType Plain/Ordinaire: ""
+*it.MediaType Plain/Normale: ""
+*ja.MediaType Plain/普通用紙: ""
+*ko.MediaType Plain/일반용지: ""
+*nl.MediaType Plain/Gewoon: ""
+*nb.MediaType Plain/Vanlig: ""
+*pt.MediaType Plain/Comum: ""
+*sv.MediaType Plain/Vanligt: ""
+*zh_CN.MediaType Plain/普通纸: ""
+*zh_TW.MediaType Plain/素面紙: ""
+
+*MediaType Preprinted/Preprinted:  "
+    <</ManualFeed false /MediaType (Preprinted)>> setpagedevice"
+*End
+*da.MediaType Preprinted/Fortrykt: ""
+*de.MediaType Preprinted/Vordruckpapier: ""
+*es.MediaType Preprinted/Preimpreso: ""
+*fi.MediaType Preprinted/Esipainettu: ""
+*fr.MediaType Preprinted/Préimprimé: ""
+*it.MediaType Preprinted/Prestampata: ""
+*ja.MediaType Preprinted/印刷フォーム: ""
+*ko.MediaType Preprinted/미리 인쇄: ""
+*nl.MediaType Preprinted/Voorbedrukt: ""
+*nb.MediaType Preprinted/Forhåndstrykt: ""
+*pt.MediaType Preprinted/Pré-impresso: ""
+*sv.MediaType Preprinted/Förtryckt: ""
+*zh_CN.MediaType Preprinted/预先打印纸: ""
+*zh_TW.MediaType Preprinted/預印的: ""
+
+*MediaType Letterhead/Letterhead:  "
+    <</ManualFeed false /MediaType (Letterhead)>> setpagedevice"
+*End
+*da.MediaType Letterhead/Brevpapir: ""
+*de.MediaType Letterhead/Briefkopfpapier: ""
+*es.MediaType Letterhead/Membrete: ""
+*fi.MediaType Letterhead/Kirjelomake: ""
+*fr.MediaType Letterhead/Papier à en-tête: ""
+*it.MediaType Letterhead/Carta intestata: ""
+*ja.MediaType Letterhead/レターヘッド付き: ""
+*ko.MediaType Letterhead/레터헤드: ""
+*nl.MediaType Letterhead/Briefpapier: ""
+*nb.MediaType Letterhead/Brevhode: ""
+*pt.MediaType Letterhead/Timbrado: ""
+*sv.MediaType Letterhead/Brevpapper: ""
+*zh_CN.MediaType Letterhead/信头纸: ""
+*zh_TW.MediaType Letterhead/信頭紙: ""
+
+*MediaType Transparency/Transparency:  "
+    <</ManualFeed false /MediaType (Transparency)>> setpagedevice"
+*End
+*da.MediaType Transparency/Transparent: ""
+*de.MediaType Transparency/Transparentfolie: ""
+*es.MediaType Transparency/Transparencia: ""
+*fi.MediaType Transparency/Kalvo: ""
+*fr.MediaType Transparency/Transparent: ""
+*it.MediaType Transparency/Lucido: ""
+*ja.MediaType Transparency/OHP ﾌｨﾙﾑ: ""
+*ko.MediaType Transparency/투명 용지: ""
+*nl.MediaType Transparency/Transparant: ""
+*nb.MediaType Transparency/Transparent: ""
+*pt.MediaType Transparency/Transparência: ""
+*sv.MediaType Transparency/OH-film: ""
+*zh_CN.MediaType Transparency/透明胶片: ""
+*zh_TW.MediaType Transparency/投影片: ""
+
+*MediaType Prepunched/Prepunched:  "
+    <</ManualFeed false /MediaType (Prepunched)>> setpagedevice"
+*End
+*da.MediaType Prepunched/Hullet: ""
+*de.MediaType Prepunched/Vorgelochtes Papier: ""
+*es.MediaType Prepunched/Preperforado: ""
+*fi.MediaType Prepunched/Rei’itetty: ""
+*fr.MediaType Prepunched/Perforé: ""
+*it.MediaType Prepunched/Perforata: ""
+*ja.MediaType Prepunched/穴あき用紙: ""
+*ko.MediaType Prepunched/천공 용지: ""
+*nl.MediaType Prepunched/Geperforeerd: ""
+*nb.MediaType Prepunched/Hullark: ""
+*pt.MediaType Prepunched/Perfurado: ""
+*sv.MediaType Prepunched/Hålat: ""
+*zh_CN.MediaType Prepunched/预先打孔纸: ""
+*zh_TW.MediaType Prepunched/打孔過的: ""
+
+*MediaType Labels/Labels:  "
+    <</ManualFeed false /MediaType (Labels)>> setpagedevice"
+*End
+*da.MediaType Labels/Etiketter: ""
+*de.MediaType Labels/Etiketten: ""
+*es.MediaType Labels/Etiquetas: ""
+*fi.MediaType Labels/Tarrat: ""
+*fr.MediaType Labels/Étiquettes: ""
+*it.MediaType Labels/Etichette: ""
+*ja.MediaType Labels/ラベル: ""
+*ko.MediaType Labels/레이블: ""
+*nl.MediaType Labels/Etiketten: ""
+*nb.MediaType Labels/Etiketter: ""
+*pt.MediaType Labels/Etiquetas: ""
+*sv.MediaType Labels/Etiketter: ""
+*zh_CN.MediaType Labels/标签: ""
+*zh_TW.MediaType Labels/標籤: ""
+
+*MediaType Bond/Bond:  "
+    <</ManualFeed false /MediaType (Bond)>> setpagedevice"
+*End
+*da.MediaType Bond/Bond: ""
+*de.MediaType Bond/Briefpapier: ""
+*es.MediaType Bond/Bond: ""
+*fi.MediaType Bond/Kova asiakirjapaperi: ""
+*fr.MediaType Bond/Document: ""
+*it.MediaType Bond/Carta fine: ""
+*ja.MediaType Bond/ボンド紙: ""
+*ko.MediaType Bond/본드지: ""
+*nl.MediaType Bond/Bankpost: ""
+*nb.MediaType Bond/Bond: ""
+*pt.MediaType Bond/Superbond: ""
+*sv.MediaType Bond/Finpapper: ""
+*zh_CN.MediaType Bond/证券纸: ""
+*zh_TW.MediaType Bond/雪銅紙: ""
+
+*MediaType Recycled/Recycled:  "
+    <</ManualFeed false /MediaType (Recycled)>> setpagedevice"
+*End
+*da.MediaType Recycled/Genbrug: ""
+*de.MediaType Recycled/Recyclingpapier: ""
+*es.MediaType Recycled/Reciclado: ""
+*fi.MediaType Recycled/Uusiopaperi: ""
+*fr.MediaType Recycled/Recyclé: ""
+*it.MediaType Recycled/Riciclata: ""
+*ja.MediaType Recycled/再生紙: ""
+*ko.MediaType Recycled/재활용지: ""
+*nl.MediaType Recycled/Gerecycled: ""
+*nb.MediaType Recycled/Resirkulert: ""
+*pt.MediaType Recycled/Reciclado: ""
+*sv.MediaType Recycled/Returpapper: ""
+*zh_CN.MediaType Recycled/再生纸: ""
+*zh_TW.MediaType Recycled/再生紙: ""
+
+*MediaType Color/Color:  "
+    <</ManualFeed false /MediaType (Color)>> setpagedevice"
+*End
+*da.MediaType Color/Farvet: ""
+*de.MediaType Color/Farbpapier: ""
+*es.MediaType Color/Color: ""
+*fi.MediaType Color/Väri: ""
+*fr.MediaType Color/Couleur: ""
+*it.MediaType Color/Colorata: ""
+*ja.MediaType Color/カラー: ""
+*ko.MediaType Color/색: ""
+*nl.MediaType Color/Kleur: ""
+*nb.MediaType Color/Farge: ""
+*pt.MediaType Color/Colorido: ""
+*sv.MediaType Color/Färgat: ""
+*zh_CN.MediaType Color/颜色: ""
+*zh_TW.MediaType Color/顏色: ""
+
+*MediaType CardStock164/Cardstock (<3e>164g/m2):  "
+    <</ManualFeed false /MediaType (Card Stock)>> setpagedevice"
+*End
+*da.MediaType CardStock164/Karton (<3e>164g/m2): ""
+*de.MediaType CardStock164/Karton (<3e>164g/m2): ""
+*es.MediaType CardStock164/Cardstock (<3e>164g/m2): ""
+*fi.MediaType CardStock164/Korttipaperi (<3e>164g/m2): ""
+*fr.MediaType CardStock164/Cartonné (<3e>164g/m2): ""
+*it.MediaType CardStock164/Cartoncino (<3e>164g/m2): ""
+*ja.MediaType CardStock164/カード ストック (<3e>164g/m2): ""
+*ko.MediaType CardStock164/카드 용지 (<3e>164g/m2): ""
+*nl.MediaType CardStock164/Kartonkaart (<3e>164g/m2): ""
+*nb.MediaType CardStock164/Kort (<3e>164g/m2): ""
+*pt.MediaType CardStock164/Cartolina (<3e>164g/m2): ""
+*sv.MediaType CardStock164/Kort (<3e>164g/m2): ""
+*zh_CN.MediaType CardStock164/卡片纸 (<3e>164g/m2): ""
+*zh_TW.MediaType CardStock164/卡片紙 (<3e>164g/m2): ""
+
+*MediaType Rough/Rough:  "
+    <</ManualFeed false /MediaType (Rough)>> setpagedevice"
+*End
+*da.MediaType Rough/Groft (90-105g/m2): ""
+*de.MediaType Rough/Rauhpapier: ""
+*es.MediaType Rough/Rugoso: ""
+*fi.MediaType Rough/Karkea: ""
+*fr.MediaType Rough/Rugueux: ""
+*it.MediaType Rough/Ruvida: ""
+*ja.MediaType Rough/ざら紙: ""
+*ko.MediaType Rough/거친 용지: ""
+*nl.MediaType Rough/Ruw: ""
+*nb.MediaType Rough/Grovt: ""
+*pt.MediaType Rough/Áspero: ""
+*sv.MediaType Rough/Grovt: ""
+*zh_CN.MediaType Rough/粗糙: ""
+*zh_TW.MediaType Rough/粗糙紙: ""
+
+*MediaType Envelope/Envelope:  "
+    <</ManualFeed false /MediaType (Envelope)>> setpagedevice"
+*End
+*da.MediaType Envelope/Konvolut: ""
+*de.MediaType Envelope/Briefumschlag: ""
+*es.MediaType Envelope/Sobre: ""
+*fi.MediaType Envelope/Kirjekuori: ""
+*fr.MediaType Envelope/Enveloppe: ""
+*it.MediaType Envelope/Busta: ""
+*ja.MediaType Envelope/封筒: ""
+*ko.MediaType Envelope/봉투: ""
+*nl.MediaType Envelope/Enveloppen: ""
+*nb.MediaType Envelope/Konvolutt: ""
+*pt.MediaType Envelope/Envelope: ""
+*sv.MediaType Envelope/Kuvert: ""
+*zh_CN.MediaType Envelope/信封: ""
+*zh_TW.MediaType Envelope/信封: ""
+
+*?MediaType: "
+  save
+    currentpagedevice /MediaType get
+    dup null eq {pop (Unknown)} if
+    = flush
+  restore
+"
+*End
+*CloseUI: *MediaType
+
+
+*%=================================================
+*%		 Duplex
+*%=================================================
+*OpenUI *Duplex/Two-Sided:  PickOne
+*OrderDependency: 50 AnySetup *Duplex
+*DefaultDuplex: None
+*da.Translation Duplex/Dupleks: ""
+*de.Translation Duplex/Beidseitig: ""
+*es.Translation Duplex/A doble cara: ""
+*fi.Translation Duplex/Kaksipuolinen: ""
+*fr.Translation Duplex/Recto verso: ""
+*it.Translation Duplex/Fronte-retro: ""
+*ja.Translation Duplex/両面: ""
+*ko.Translation Duplex/양면: ""
+*nl.Translation Duplex/Dubbelzijdig: ""
+*nb.Translation Duplex/Tosidig: ""
+*pt.Translation Duplex/Frente e verso: ""
+*sv.Translation Duplex/Dubbelsidig: ""
+*zh_CN.Translation Duplex/双面打印: ""
+*zh_TW.Translation Duplex/雙面: ""
+
+*Duplex None/Off (1-Sided): "
+  <</Duplex false>> setpagedevice"
+*End
+*da.Duplex None/Fra (1-sidet): ""
+*de.Duplex None/Aus (einseitig): ""
+*es.Duplex None/Des (por un solo lado): ""
+*fi.Duplex None/Ei käytössä: ""
+*fr.Duplex None/Désactivé: ""
+*it.Duplex None/Disattivato (facciata singola): ""
+*ja.Duplex None/オフ (片面印刷): ""
+*ko.Duplex None/끔 (한 면): ""
+*nl.Duplex None/Uit (enkelzijdig): ""
+*nb.Duplex None/Av (1-sidig): ""
+*pt.Duplex None/Desligado (face única): ""
+*sv.Duplex None/Av (enkelsidig): ""
+*zh_CN.Duplex None/关 (1面): ""
+*zh_TW.Duplex None/關( 單面): ""
+
+*Duplex DuplexNoTumble/Flip on Long Edge (Standard): "
+  <</Duplex true /Tumble false>> setpagedevice"
+*End
+*da.Duplex DuplexNoTumble/Vend på langs: ""
+*de.Duplex DuplexNoTumble/Lange Kante spiegeln (Standard): ""
+*es.Duplex DuplexNoTumble/Dar vuelta - borde largo (estándar): ""
+*fi.Duplex DuplexNoTumble/Pitkän reunan sidonta: ""
+*fr.Duplex DuplexNoTumble/Reliure sur bord long: ""
+*it.Duplex DuplexNoTumble/Ruota sul lato lungo (Standard): ""
+*ja.Duplex DuplexNoTumble/長辺綴じ (標準): ""
+*ko.Duplex DuplexNoTumble/긴 가장자리로 뒤집기(표준): ""
+*nl.Duplex DuplexNoTumble/Over lange zijde spiegelen (standaard): ""
+*nb.Duplex DuplexNoTumble/Vend på langsiden (standard): ""
+*pt.Duplex DuplexNoTumble/Inversão na margem longa (padrão): ""
+*sv.Duplex DuplexNoTumble/Vänd längs långsidan (standard): ""
+*zh_CN.Duplex DuplexNoTumble/长边翻转（标准）: ""
+*zh_TW.Duplex DuplexNoTumble/在長邊緣倒轉( 標準): ""
+
+*Duplex DuplexTumble/Flip on Short Edge: "
+  <</Duplex true /Tumble true>> setpagedevice"
+*End
+*da.Duplex DuplexTumble/Vend på tværs: ""
+*de.Duplex DuplexTumble/Kurze Kante spiegeln: ""
+*es.Duplex DuplexTumble/Dar vuelta - borde corto: ""
+*fi.Duplex DuplexTumble/Lyhyen reunan sidonta: ""
+*fr.Duplex DuplexTumble/Reliure sur bord court: ""
+*it.Duplex DuplexTumble/Ruota sul lato corto: ""
+*ja.Duplex DuplexTumble/短辺綴じ: ""
+*ko.Duplex DuplexTumble/짧은 가장자리로 뒤집기: ""
+*nl.Duplex DuplexTumble/Over korte zijde spiegelen: ""
+*nb.Duplex DuplexTumble/Vend på kortsiden: ""
+*pt.Duplex DuplexTumble/Inversão na margem curta: ""
+*sv.Duplex DuplexTumble/Vänd längs kortsidan: ""
+*zh_CN.Duplex DuplexTumble/短边翻转: ""
+*zh_TW.Duplex DuplexTumble/在短邊緣倒轉: ""
+
+*?Duplex: "
+   save
+   currentpagedevice /Duplex known
+   false ne
+     { currentpagedevice /Duplex get
+        { currentpagedevice /Tumble get
+            {(DuplexTumble)}{(DuplexNoTumble)}ifelse
+        } { (None)}    ifelse
+     }{(None)}  ifelse = flush
+   restore
+"
+*End
+*CloseUI: *Duplex
+
+*%=================================================
+*%		 Color Control
+*%=================================================
+*DefaultColorSep: ProcessBlack.106lpi.600dpi/106 lpi / 600 dpi
+*InkName: ProcessBlack/Process Black
+*InkName: CustomColor/Custom Color
+*InkName: ProcessCyan/Process Cyan
+*InkName: ProcessMagenta/Process Magenta
+*InkName: ProcessYellow/Process Yellow
+
+*%  For 60 lpi / 300 dpi  =========================
+*ColorSepScreenAngle ProcessBlack.60lpi.300dpi/60 lpi / 300 dpi: "45"
+
+*ColorSepScreenAngle CustomColor.60lpi.300dpi/60 lpi / 300 dpi: "45"
+
+*ColorSepScreenAngle ProcessCyan.60lpi.300dpi/60 lpi / 300 dpi: "15"
+
+*ColorSepScreenAngle ProcessMagenta.60lpi.300dpi/60 lpi / 300 dpi: "75"
+
+*ColorSepScreenAngle ProcessYellow.60lpi.300dpi/60 lpi / 300 dpi: "0"
+
+
+*ColorSepScreenFreq ProcessBlack.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq CustomColor.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq ProcessCyan.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq ProcessMagenta.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq ProcessYellow.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+
+*%  For 85 lpi / 600 dpi  (5,5,2,6,6,2,20/3,0) ====
+*ColorSepScreenAngle ProcessBlack.85lpi.600dpi/85 lpi / 600 dpi: "45.0"
+
+*ColorSepScreenAngle CustomColor.85lpi.600dpi/85 lpi / 600 dpi: "45.0"
+
+*ColorSepScreenAngle ProcessCyan.85lpi.600dpi/85 lpi / 600 dpi: "71.5651"
+
+*ColorSepScreenAngle ProcessMagenta.85lpi.600dpi/85 lpi / 600 dpi: "18.4349"
+
+*ColorSepScreenAngle ProcessYellow.85lpi.600dpi/85 lpi / 600 dpi: "0.0"
+
+
+*ColorSepScreenFreq ProcessBlack.85lpi.600dpi/85 lpi / 600 dpi: "84.8528"
+
+*ColorSepScreenFreq CustomColor.85lpi.600dpi/85 lpi / 600 dpi: "84.8528"
+
+*ColorSepScreenFreq ProcessCyan.85lpi.600dpi/85 lpi / 600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessMagenta.85lpi.600dpi/85 lpi / 600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessYellow.85lpi.600dpi/85 lpi / 600 dpi: "30.0"
+
+*ColorSepScreenProc ProcessYellow.85lpi.600dpi/85 lpi / 600 dpi: "
+{1 add 2 div 3 mul dup floor sub 2 mul 1 sub exch
+1 add 2 div 3 mul dup floor sub 2 mul 1 sub exch
+abs exch abs 2 copy add 1 gt {1 sub dup mul exch 1 sub dup mul add 1
+sub }{dup mul exch dup mul add 1 exch sub }ifelse }"
+*End
+
+
+*%  For 106 lpi /300 dpi  =========================
+*ColorSepScreenAngle ProcessBlack.106lpi.300dpi/106 lpi /300 dpi: "45.0"
+
+*ColorSepScreenAngle CustomColor.106lpi.300dpi/106 lpi /300 dpi: "45.0"
+
+*ColorSepScreenAngle ProcessCyan.106lpi.300dpi/106 lpi /300 dpi: "71.5651"
+
+*ColorSepScreenAngle ProcessMagenta.106lpi.300dpi/106 lpi /300 dpi: "18.4349"
+
+*ColorSepScreenAngle ProcessYellow.106lpi.300dpi/106 lpi /300 dpi: "0.0"
+
+
+*ColorSepScreenFreq ProcessBlack.106lpi.300dpi/106 lpi /300 dpi: "106.066"
+
+*ColorSepScreenFreq CustomColor.106lpi.300dpi/106 lpi /300 dpi: "106.066"
+
+*ColorSepScreenFreq ProcessCyan.106lpi.300dpi/106 lpi /300 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessMagenta.106lpi.300dpi/106 lpi /300 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessYellow.106lpi.300dpi/106 lpi /300 dpi: "100.0"
+
+
+*%  For 106 lpi /600 dpi  =========================
+
+*ColorSepScreenAngle ProcessBlack.106lpi.600dpi/106 lpi /600 dpi: "45.0"
+
+*ColorSepScreenAngle CustomColor.106lpi.600dpi/106 lpi /600 dpi: "45.0"
+
+*ColorSepScreenAngle ProcessCyan.106lpi.600dpi/106 lpi /600 dpi: "71.5651"
+
+*ColorSepScreenAngle ProcessMagenta.106lpi.600dpi/106 lpi /600 dpi: "18.4349"
+
+*ColorSepScreenAngle ProcessYellow.106lpi.600dpi/106 lpi /600 dpi: "0.0"
+
+
+*ColorSepScreenFreq ProcessBlack.106lpi.600dpi/106 lpi /600 dpi: "106.066"
+
+*ColorSepScreenFreq CustomColor.106lpi.600dpi/106 lpi /600 dpi: "106.066"
+
+*ColorSepScreenFreq ProcessCyan.106lpi.600dpi/106 lpi /600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessMagenta.106lpi.600dpi/106 lpi /600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessYellow.106lpi.600dpi/106 lpi /600 dpi: "100.0"
+
+
+*%=================================================
+*%		 Font Information
+*%=================================================
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font Marigold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Standard "(001.008S)" Standard ROM
+*?FontQuery: "
+   save
+   { count 1 gt
+      { exch dup 127 string cvs (/) print print (:) print
+      /Font resourcestatus {pop pop (Yes)} {(No)} ifelse =
+      } { exit } ifelse
+   } bind loop
+   (*) = flush
+   restore
+"
+*End
+
+*?FontList: "
+   save
+     (*) {cvn ==} 128 string /Font resourceforall
+     (*) = flush
+   restore
+"
+*End
+
+*%=================================================
+*%		 Printer Messages (verbatim from printer):
+*%=================================================
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ] %%)
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*Status: "PrinterError: cover open or no toner cartridge"/cover open or no toner cartridge
+*Status: "PrinterError: cover open"/cover open
+*Status: "PrinterError: needs attention"/needs attention
+*Status: "PrinterError: no toner cartridge"/no toner cartridge
+*Status: "PrinterError: warming up"/warming up
+*Status: "PrinterError: manual feed"/manual feed
+*Status: "PrinterError: out of paper"/out of paper
+*Status: "PrinterError: Paper Jam"/Paper Jam
+*Status: "PrinterError: paper jam"/paper jam
+*Status: "PrinterError: page protect needed"/page protect needed
+*Status: "PrinterError: out of memory"/out of memory
+*Status: "PrinterError: output bin full"/output bin full
+*Status: "PrinterError: resetting printer"/resetting printer
+*Status: "PrinterError: toner is low"/toner is low
+*Status: "PrinterError: off line"/off line
+
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%%)
+*PrinterError: "cover open or no toner cartridge"/cover open or no toner cartridge
+*PrinterError: "cover open"/cover open
+*PrinterError: "needs attention"/needs attention
+*PrinterError: "no toner cartridge"/no toner cartridge
+*PrinterError: "warming up"/warming up
+*PrinterError: "manual feed"/manual feed
+*PrinterError: "out of paper"/out of paper
+*PrinterError: "Paper Jam"/Paper Jam
+*PrinterError: "paper jam"/paper jam
+*PrinterError: "page protect needed"/page protect needed
+*PrinterError: "out of memory"/out of memory
+*PrinterError: "output bin full"/output bin full
+*PrinterError: "resetting printer"/resetting printer
+*PrinterError: "toner is low"/toner is low
+*PrinterError: "off line"/off line
+
+*% Input Sources (format: %%[ status: <stat>; source: <one of these> ]%% )
+*Source: "BiTronics"/BiTronics
+*Source: "other I/O"/other I/O
+*Source: "AppleTalk"/AppleTalk
+*Source: "APPLETALK"/AppleTalk
+*Source: "ATALK"/AppleTalk
+*Source: "LocalTalk"/LocalTalk
+*Source: "Parallel"/Parallel
+*Source: "EtherTalk"/EtherTalk
+*Source: "NOVELL"/NOVELL
+*Source: "DLC/LLC"/DLC/LLC
+*Source: "ETALK"/EtherTalk
+*Source: "TCP/IP"/TCP/IP
+
+*Password: "()"
+*ExitServer: "
+ count 0 eq
+ { false } { true exch startjob } ifelse
+ not {
+     (WARNING: Cannot modify initial VM.) =
+     (Missing or invalid password.) =
+     (Please contact the author of this software.) = flush quit
+     } if
+"
+*End
+*Reset: "
+  count 0 eq { false } { true exch startjob } ifelse
+  not {
+    (WARNING: Cannot reset printer.) =
+    (Missing or invalid password.) =
+    (Please contact the author of this software.) = flush quit
+    } if
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush
+"
+*End
+
+*% =======================================
+*% For HP LaserJet 9050

--- a/hp-laserjet-9050-Linux.ppd
+++ b/hp-laserjet-9050-Linux.ppd
@@ -1,0 +1,6458 @@
+*PPD-Adobe: "4.3"
+*% =================================
+*% Copyright 1992-2009 Hewlett-Packard Company
+*% Permission is hereby granted, free of charge, to any person obtaining
+*% a copy of this software and associated documentation files (the
+*% "Software"), to deal in the Software without restriction, including
+*% without limitation the rights to use, copy, modify, merge, publish,
+*% distribute, sublicense, and/or sell copies of the Software, and to
+*% permit persons to whom the Software is furnished to do so, subject to
+*% the following conditions:
+*%
+*% The above copyright notice and this permission notice shall be
+*% included in all copies or substantial portions of the Software.
+*%
+*% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*% EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*% MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+*% LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+*% OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+*% WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*%
+*% [this is the MIT open source license -- please see www.opensource.org]
+*%
+*% Disclaimer:  The above statement indicates
+*% that this PPD was written using the Adobe PPD
+*% File Format Specification 4.3, but does not
+*% intend to imply approval and acceptance by
+*% Adobe Systems, Inc.
+*% =======================================================
+*% Printer Description File
+*% (c) Copyright 2004-2009 Hewlett-Packard Development Company, L.P.
+*%========================================================
+*% PPD for HP LaserJet 9050
+*% For Macintosh
+*%========================================================
+
+*%=================================================
+*% 		 PPD File Version Information
+*%=================================================
+*FileVersion: "PPD-VERSION-STRING"
+*HPBuildNumber: "005"
+*FormatVersion: "4.3"
+*LanguageEncoding: ISOLatin1
+*LanguageVersion: English
+*cupsLanguages: "da de es fi fr it ja ko nl nb pt sv zh_CN zh_TW"
+*PCFileName: "HP9050_H.PPD"
+
+*HPPDEPanel: "HPFinishingPanel"
+
+*HPPDEPanel: "HPImagingOptions"
+
+*%=================================================
+*% 		 Product Version Information
+*%=================================================
+*ModelName: "HP LaserJet 9050 "
+*ShortNickName: "HP LaserJet 9050 "
+*NickName: "HP LaserJet 9050 Postscript (recommended)"
+*Product: "(hp LaserJet 9050)"
+*Product: "(Hewlett-Packard hp LaserJet 9050)"
+*Product: "(HP LaserJet 9050)"
+*Manufacturer: "HP"
+
+*PSVersion: "(3010.107) 0"
+
+*%=================================================
+*%		 Device Capabilities
+*%=================================================
+*ColorDevice:       False
+*DefaultColorSpace: Gray
+*FileSystem:        True
+*?FileSystem: "
+   save
+     false
+     (%disk?%)
+     { currentdevparams dup /Writeable known
+        { /Writeable get {pop true} if }  { pop } ifelse
+     } 100 string /IODevice resourceforall
+     {(True)}{(False)} ifelse = flush
+   restore
+"
+*End
+
+*LanguageLevel: "3"
+*Throughput:    "50"
+*TTRasterizer:  Type42
+*?TTRasterizer: "
+   save
+      42 /FontType resourcestatus
+      { pop pop (Type42)} {pop pop (None)} ifelse = flush
+   restore
+"
+*End
+
+*%=================================================
+*%		 Emulations and Protocols
+*%=================================================
+*Protocols: TBCP
+
+*SuggestedJobTimeout:  "0"
+*SuggestedWaitTimeout: "120"
+
+*PrintPSErrors: True
+
+*%=== Output Bin ======================
+*PageStackOrder Upper: Normal
+*PageStackOrder Left: Reverse
+*PageStackOrder Stacker: Normal
+*PageStackOrder StackerFaceUp: Reverse
+*PageStackOrder UStapler: Normal
+*PageStackOrder HPBooklet: Normal
+*PageStackOrder HP8BinMB: Normal
+
+*%=================================================
+*%		 Installable Options
+*%=================================================
+*OpenGroup: InstallableOptions/Installed Options
+*da.Translation InstallableOptions/Installeret tilbehør: ""
+*de.Translation InstallableOptions/Installierte Optionen: ""
+*es.Translation InstallableOptions/Opciones instaladas: ""
+*fi.Translation InstallableOptions/Asennetut lisävarusteet: ""
+*fr.Translation InstallableOptions/Options installées: ""
+*it.Translation InstallableOptions/Installed Options: ""
+*ja.Translation InstallableOptions/インストール済オプション: ""
+*ko.Translation InstallableOptions/설치된 선택사양: ""
+*nl.Translation InstallableOptions/Geïnstalleerde opties: ""
+*nb.Translation InstallableOptions/Installerte alternativer: ""
+*pt.Translation InstallableOptions/Versıes Instaladas: ""
+*sv.Translation InstallableOptions/Installerade tillbehör: ""
+*zh_CN.Translation InstallableOptions/已安装的选项: ""
+*zh_TW.Translation InstallableOptions/安裝的選項: ""
+
+
+*OpenUI *HPOption_Tray1/Tray 1: Boolean
+*DefaultHPOption_Tray1: False
+*da.Translation HPOption_Tray1/Bakke 1: ""
+*de.Translation HPOption_Tray1/Zufuhrfach 1: ""
+*es.Translation HPOption_Tray1/Bandeja 1: ""
+*fi.Translation HPOption_Tray1/Lokero 1: ""
+*fr.Translation HPOption_Tray1/Bac 1: ""
+*it.Translation HPOption_Tray1/Vassoio 1: ""
+*ja.Translation HPOption_Tray1/トレイ 1: ""
+*ko.Translation HPOption_Tray1/용지함 1: ""
+*nl.Translation HPOption_Tray1/Lade 1: ""
+*nb.Translation HPOption_Tray1/Skuff 1: ""
+*pt.Translation HPOption_Tray1/Bandeja 1: ""
+*sv.Translation HPOption_Tray1/Fack 1: ""
+*zh_CN.Translation HPOption_Tray1/纸盒1: ""
+*zh_TW.Translation HPOption_Tray1/紙匣1: ""
+
+*HPOption_Tray1 True/Installed: ""
+*da.HPOption_Tray1 True/Installeret: ""
+*de.HPOption_Tray1 True/Installiert: ""
+*es.HPOption_Tray1 True/Instalado: ""
+*fi.HPOption_Tray1 True/Asennettu: ""
+*fr.HPOption_Tray1 True/Installé: ""
+*it.HPOption_Tray1 True/Installato: ""
+*ja.HPOption_Tray1 True/インストール済: ""
+*ko.HPOption_Tray1 True/설치됨: ""
+*nl.HPOption_Tray1 True/Geïnstalleerd: ""
+*nb.HPOption_Tray1 True/Installert: ""
+*pt.HPOption_Tray1 True/Instalada: ""
+*sv.HPOption_Tray1 True/Installerat: ""
+*zh_CN.HPOption_Tray1 True/已安装: ""
+*zh_TW.HPOption_Tray1 True/已安裝: ""
+
+*HPOption_Tray1 False/Not Installed: ""
+*da.HPOption_Tray1 False/Ikke installeret: ""
+*de.HPOption_Tray1 False/Nicht installiert: ""
+*es.HPOption_Tray1 False/No Instalado: ""
+*fi.HPOption_Tray1 False/Ei asennettu: ""
+*fr.HPOption_Tray1 False/Non installé: ""
+*it.HPOption_Tray1 False/Non installato: ""
+*ja.HPOption_Tray1 False/インストールされていない: ""
+*ko.HPOption_Tray1 False/설치되지 않음: ""
+*nl.HPOption_Tray1 False/Niet geïnstalleerd: ""
+*nb.HPOption_Tray1 False/Ikke installert: ""
+*pt.HPOption_Tray1 False/Não instalada: ""
+*sv.HPOption_Tray1 False/Ej installerat: ""
+*zh_CN.HPOption_Tray1 False/未安装: ""
+*zh_TW.HPOption_Tray1 False/尚未安裝: ""
+
+*?HPOption_Tray1: "
+  save
+    currentpagedevice /InputAttributes get 3 known
+    {(True)}{(False)} ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPOption_Tray1
+
+*OpenUI *HPOption_2000_Sheet_Tray/2000-Sheet Input Tray (Tray 4): Boolean
+*DefaultHPOption_2000_Sheet_Tray: False
+*da.Translation HPOption_2000_Sheet_Tray/Bakke 4: ""
+*de.Translation HPOption_2000_Sheet_Tray/2000-Blatt-Zufuhrfach (Fach 4): ""
+*es.Translation HPOption_2000_Sheet_Tray/Bandeja de entrada para 2000 hojas (Bandeja 4): ""
+*fi.Translation HPOption_2000_Sheet_Tray/2 000 arkin syöttölokero (lokero 4): ""
+*fr.Translation HPOption_2000_Sheet_Tray/Bac d'alim. de 2 000 feuilles (bac 4): ""
+*it.Translation HPOption_2000_Sheet_Tray/Vassoio da 2000 fogli (Vassoio 4): ""
+*ja.Translation HPOption_2000_Sheet_Tray/2000 枚給紙トレイ (トレイ 4): ""
+*ko.Translation HPOption_2000_Sheet_Tray/2,000매 입력 용지함(용지함 4): ""
+*nl.Translation HPOption_2000_Sheet_Tray/Invoerlade voor 2.000 vel (Lade 4): ""
+*nb.Translation HPOption_2000_Sheet_Tray/2000-arks innskuff (skuff 4): ""
+*pt.Translation HPOption_2000_Sheet_Tray/Bandeja de entrada para 2000 folhas (bandeja 4): ""
+*sv.Translation HPOption_2000_Sheet_Tray/Inmatningsfack för 2 000 ark (Fack 4): ""
+*zh_CN.Translation HPOption_2000_Sheet_Tray/2000 页进纸盒（纸盒 4）: ""
+*zh_TW.Translation HPOption_2000_Sheet_Tray/可容納 2000 張紙的進紙匣 (4 號紙匣): ""
+
+*HPOption_2000_Sheet_Tray True/Installed: ""
+*da.HPOption_2000_Sheet_Tray True/Installeret: ""
+*de.HPOption_2000_Sheet_Tray True/Installiert: ""
+*es.HPOption_2000_Sheet_Tray True/Instalado: ""
+*fi.HPOption_2000_Sheet_Tray True/Asennettu: ""
+*fr.HPOption_2000_Sheet_Tray True/Installé: ""
+*it.HPOption_2000_Sheet_Tray True/Installato: ""
+*ja.HPOption_2000_Sheet_Tray True/インストール済み: ""
+*ko.HPOption_2000_Sheet_Tray True/설치: ""
+*nl.HPOption_2000_Sheet_Tray True/Geïnstalleerd: ""
+*nb.HPOption_2000_Sheet_Tray True/Installert: ""
+*pt.HPOption_2000_Sheet_Tray True/Instalada: ""
+*sv.HPOption_2000_Sheet_Tray True/Installerat: ""
+*zh_CN.HPOption_2000_Sheet_Tray True/已安装: ""
+*zh_TW.HPOption_2000_Sheet_Tray True/已安裝: ""
+
+*HPOption_2000_Sheet_Tray False/Not Installed: ""
+*da.HPOption_2000_Sheet_Tray False/Ikke installeret: ""
+*de.HPOption_2000_Sheet_Tray False/Nicht installiert: ""
+*es.HPOption_2000_Sheet_Tray False/No instalado: ""
+*fi.HPOption_2000_Sheet_Tray False/Ei asennettu: ""
+*fr.HPOption_2000_Sheet_Tray False/Non installé: ""
+*it.HPOption_2000_Sheet_Tray False/Non Installato: ""
+*ja.HPOption_2000_Sheet_Tray False/インストールされていない: ""
+*ko.HPOption_2000_Sheet_Tray False/미설치: ""
+*nl.HPOption_2000_Sheet_Tray False/Geïnstalleerd: ""
+*nb.HPOption_2000_Sheet_Tray False/Ikke installert: ""
+*pt.HPOption_2000_Sheet_Tray False/Não Instalado: ""
+*sv.HPOption_2000_Sheet_Tray False/Ej installerad: ""
+*zh_CN.HPOption_2000_Sheet_Tray False/未安装: ""
+*zh_TW.HPOption_2000_Sheet_Tray False/未安裝: ""
+
+*?HPOption_2000_Sheet_Tray: "
+  save
+    currentpagedevice /InputAttributes get 5 known
+    {(True)}{(False)} ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPOption_2000_Sheet_Tray
+
+*OpenUI *HPOption_Duplexer/Duplex Unit: Boolean
+*DefaultHPOption_Duplexer: False
+*da.Translation HPOption_Duplexer/Dupleksudskrivningsudstyr: ""
+*de.Translation HPOption_Duplexer/Duplexdruck-Zubehör: ""
+*es.Translation HPOption_Duplexer/Accesorio para impresión dúplex: ""
+*fi.Translation HPOption_Duplexer/Kaksipuolisen tulostuksen lisälaite: ""
+*fr.Translation HPOption_Duplexer/Accessoire d'impression recto verso: ""
+*it.Translation HPOption_Duplexer/Accessorio per stampa duplex: ""
+*ja.Translation HPOption_Duplexer/両面印刷アクセサリ: ""
+*ko.Translation HPOption_Duplexer/양면 인쇄 부속품: ""
+*nl.Translation HPOption_Duplexer/Duplexeenheid: ""
+*nb.Translation HPOption_Duplexer/Ekstrautstyr for dobbeltsidig utskrift: ""
+*pt.Translation HPOption_Duplexer/Ùnidade dúplex: ""
+*sv.Translation HPOption_Duplexer/Tillbehör för dubbelsidig utskrift: ""
+*zh_CN.Translation HPOption_Duplexer/双面打印附件: ""
+*zh_TW.Translation HPOption_Duplexer/雙面列印裝置: ""
+
+*HPOption_Duplexer True/Installed: ""
+*da.HPOption_Duplexer True/Installeret: ""
+*de.HPOption_Duplexer True/Installiert: ""
+*es.HPOption_Duplexer True/Instalado: ""
+*fi.HPOption_Duplexer True/Asennettu: ""
+*fr.HPOption_Duplexer True/Installé: ""
+*it.HPOption_Duplexer True/Installato: ""
+*ja.HPOption_Duplexer True/インストール済み: ""
+*ko.HPOption_Duplexer True/설치: ""
+*nl.HPOption_Duplexer True/Geïnstalleerd: ""
+*nb.HPOption_Duplexer True/Installert: ""
+*pt.HPOption_Duplexer True/Instalado: ""
+*sv.HPOption_Duplexer True/Installerad: ""
+*zh_CN.HPOption_Duplexer True/已安装: ""
+*zh_TW.HPOption_Duplexer True/已安裝: ""
+
+*HPOption_Duplexer False/Not Installed: ""
+*da.HPOption_Duplexer False/Ikke installeret: ""
+*de.HPOption_Duplexer False/Nicht installiert: ""
+*es.HPOption_Duplexer False/No instalado: ""
+*fi.HPOption_Duplexer False/Ei asennettu: ""
+*fr.HPOption_Duplexer False/Non installé: ""
+*it.HPOption_Duplexer False/Non installato: ""
+*ja.HPOption_Duplexer False/インストールされていない: ""
+*ko.HPOption_Duplexer False/미설치: ""
+*nl.HPOption_Duplexer False/Niet geïnstalleerd: ""
+*nb.HPOption_Duplexer False/Ikke installert: ""
+*pt.HPOption_Duplexer False/Não Instalado: ""
+*sv.HPOption_Duplexer False/Ej installerad: ""
+*zh_CN.HPOption_Duplexer False/未安装: ""
+*zh_TW.HPOption_Duplexer False/未安裝: ""
+
+*?HPOption_Duplexer: "
+  save
+    currentpagedevice /Duplex known
+    {(True)}{(False)}ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPOption_Duplexer
+
+*OpenUI *HPOption_Disk/Printer Disk: PickOne
+*DefaultHPOption_Disk: None
+*da.Translation HPOption_Disk/Printerens harddisk: ""
+*de.Translation HPOption_Disk/Druckerfestplatte: ""
+*es.Translation HPOption_Disk/Disco de la impresora: ""
+*fi.Translation HPOption_Disk/Tulostimen kiintolevy: ""
+*fr.Translation HPOption_Disk/Disque dur de l'imprimante: ""
+*it.Translation HPOption_Disk/Disco rigido stampante: ""
+*ja.Translation HPOption_Disk/プリンタ ハード ディスク: ""
+*ko.Translation HPOption_Disk/프린터 하드 디스크: ""
+*nl.Translation HPOption_Disk/Harde schijf van printer: ""
+*nb.Translation HPOption_Disk/Skriverharddisk: ""
+*pt.Translation HPOption_Disk/Disco rÌgido da impressora: ""
+*sv.Translation HPOption_Disk/Skrivarens hårddisk: ""
+*zh_CN.Translation HPOption_Disk/打印机硬盘: ""
+*zh_TW.Translation HPOption_Disk/印表機硬碟: ""
+
+*HPOption_Disk None/None: ""
+*da.HPOption_Disk None/Ingen: ""
+*de.HPOption_Disk None/Keine: ""
+*es.HPOption_Disk None/Ninguno: ""
+*fi.HPOption_Disk None/Ei mitään: ""
+*fr.HPOption_Disk None/Aucun: ""
+*it.HPOption_Disk None/Nessuno: ""
+*ja.HPOption_Disk None/なし: ""
+*ko.HPOption_Disk None/없음: ""
+*nl.HPOption_Disk None/Geen: ""
+*nb.HPOption_Disk None/Ingen: ""
+*pt.HPOption_Disk None/Nenhuma: ""
+*sv.HPOption_Disk None/Inget: ""
+*zh_CN.HPOption_Disk None/无: ""
+*zh_TW.HPOption_Disk None/無: ""
+
+*HPOption_Disk RAMDisk/RAM Disk: ""
+*da.HPOption_Disk RAMDisk/RAM-disk: ""
+*de.HPOption_Disk RAMDisk/RAM-Disk: ""
+*es.HPOption_Disk RAMDisk/Disco RAM: ""
+*fi.HPOption_Disk RAMDisk/RAM-levy: ""
+*fr.HPOption_Disk RAMDisk/Disque MEV: ""
+*it.HPOption_Disk RAMDisk/Disco RAM: ""
+*ja.HPOption_Disk RAMDisk/RAMディスク: ""
+*ko.HPOption_Disk RAMDisk/RAM 디스크: ""
+*nl.HPOption_Disk RAMDisk/RAM-station: ""
+*nb.HPOption_Disk RAMDisk/RAM-disk: ""
+*pt.HPOption_Disk RAMDisk/Disco RAM: ""
+*sv.HPOption_Disk RAMDisk/RAM-disk: ""
+*zh_CN.HPOption_Disk RAMDisk/RAM 磁盘: ""
+*zh_TW.HPOption_Disk RAMDisk/RAM 磁碟: ""
+
+*HPOption_Disk HardDisk/Hard Disk: ""
+*da.HPOption_Disk HardDisk/Harddisk: ""
+*de.HPOption_Disk HardDisk/Festplatte: ""
+*es.HPOption_Disk HardDisk/Disco duro: ""
+*fi.HPOption_Disk HardDisk/Kiintolevy: ""
+*fr.HPOption_Disk HardDisk/Disque dur: ""
+*it.HPOption_Disk HardDisk/Disco rigido: ""
+*ja.HPOption_Disk HardDisk/ハードディスク: ""
+*ko.HPOption_Disk HardDisk/하드 디스크: ""
+*nl.HPOption_Disk HardDisk/Harde schijf: ""
+*nb.HPOption_Disk HardDisk/Harddisk: ""
+*pt.HPOption_Disk HardDisk/Disco rígido: ""
+*sv.HPOption_Disk HardDisk/Hårddisk: ""
+*zh_CN.HPOption_Disk HardDisk/硬盘: ""
+*zh_TW.HPOption_Disk HardDisk/硬碟: ""
+
+*?HPOption_Disk: "
+save
+  /FWMax 2048 def /RAMMax 500000 def
+  (HardDisk) (RAMDisk) (None)
+  0
+  (%disk?%)
+  { currentdevparams dup /Writeable known
+    { dup /Writeable get
+      { /PhysicalSize get dup FWMax gt
+        { RAMMax gt {2}{1} ifelse 2 copy lt { exch }if pop }
+        { pop } ifelse
+      }
+      { pop } ifelse
+    }
+    { pop } ifelse
+  } 100 string /IODevice resourceforall
+  index =  flush pop pop pop
+restore
+"
+*End
+*CloseUI: *HPOption_Disk
+
+*OpenUI *HPOption_MBM_Mixed/Accessory Output Bins: PickOne
+*OrderDependency: 10 AnySetup *HPOption_MBM_Mixed
+*DefaultHPOption_MBM_Mixed: Standard
+*da.Translation HPOption_MBM_Mixed/Tilbehørudskriftsbakker: ""
+*de.Translation HPOption_MBM_Mixed/Zusatzausgabefächer: ""
+*es.Translation HPOption_MBM_Mixed/Bandejas de salida accesorias: ""
+*fi.Translation HPOption_MBM_Mixed/Lisätulostelokerot: ""
+*fr.Translation HPOption_MBM_Mixed/Bacs de sortie optionnels: ""
+*it.Translation HPOption_MBM_Mixed/Scomparti di uscita accessori: ""
+*ja.Translation HPOption_MBM_Mixed/アクセサリ排出ビン: ""
+*ko.Translation HPOption_MBM_Mixed/부속품 출력함: ""
+*nl.Translation HPOption_MBM_Mixed/Accessoire-uitvoerbakken: ""
+*nb.Translation HPOption_MBM_Mixed/Ekstra utskuffer: ""
+*pt.Translation HPOption_MBM_Mixed/Compartimentos acessórios de saída: ""
+*sv.Translation HPOption_MBM_Mixed/Extra utmatningsfack: ""
+*zh_CN.Translation HPOption_MBM_Mixed/附加出纸槽: ""
+*zh_TW.Translation HPOption_MBM_Mixed/附件輸出紙槽: ""
+
+*HPOption_MBM_Mixed Standard/Not Installed: ""
+*da.HPOption_MBM_Mixed Standard/Ingen: ""
+*de.HPOption_MBM_Mixed Standard/Nicht installiert: ""
+*es.HPOption_MBM_Mixed Standard/Ninguna: ""
+*fi.HPOption_MBM_Mixed Standard/Ei asennettu: ""
+*fr.HPOption_MBM_Mixed Standard/Non installé: ""
+*it.HPOption_MBM_Mixed Standard/Nessuno: ""
+*ja.HPOption_MBM_Mixed Standard/インストールされていない: ""
+*ko.HPOption_MBM_Mixed Standard/설치되지 않았음: ""
+*nl.HPOption_MBM_Mixed Standard/Niet geïnstalleerd: ""
+*nb.HPOption_MBM_Mixed Standard/Ikke installert: ""
+*pt.HPOption_MBM_Mixed Standard/Nenhum: ""
+*sv.HPOption_MBM_Mixed Standard/Inget: ""
+*zh_CN.HPOption_MBM_Mixed Standard/未安装: ""
+*zh_TW.HPOption_MBM_Mixed Standard/尚未安裝: ""
+
+*HPOption_MBM_Mixed MBMStaplerStacker/HP 3000-Sheet Stapler-Stacker: "userdict /HPConfigurableStapler 0 put"
+*da.HPOption_MBM_Mixed MBMStaplerStacker/hphæfter/stabler: ""
+*de.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000-Blatt-Hefter/Ablage: ""
+*es.HPOption_MBM_Mixed MBMStaplerStacker/Grapadora y apilador de 3000 hojas de HP : ""
+*fi.HPOption_MBM_Mixed MBMStaplerStacker/HP<3A>n 3000 arkin nitoja/pinoaja: ""
+*fr.HPOption_MBM_Mixed MBMStaplerStacker/Agrafeuse-empileuse de 3000 feuilles HP: ""
+*it.HPOption_MBM_Mixed MBMStaplerStacker/Cucitrice-Fascicolatrice HP da 3000 fogli: ""
+*ja.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000枚ホチキス/スタッカ: ""
+*ko.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000매 스테이플러-스택커: ""
+*nl.HPOption_MBM_Mixed MBMStaplerStacker/hp-nietmachine/stapelaar voor 3000 vel: ""
+*nb.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000-arks stifteenhets-magasin: ""
+*pt.HPOption_MBM_Mixed MBMStaplerStacker/Empilhador/Grampeador de 3000 Folhas HP: ""
+*sv.HPOption_MBM_Mixed MBMStaplerStacker/hp Häftning och stapling för 3000 ark: ""
+*zh_CN.HPOption_MBM_Mixed MBMStaplerStacker/hp 3000页装订堆栈器: ""
+*zh_TW.HPOption_MBM_Mixed MBMStaplerStacker/hp 300紙頁裝訂機/堆疊機: ""
+
+*HPOption_MBM_Mixed MBMStacker/HP 3000-Sheet Stacker: ""
+*da.HPOption_MBM_Mixed MBMStacker/hp 3000-ark hphæfter: ""
+*de.HPOption_MBM_Mixed MBMStacker/hp 3000-Blatt-Ablage: ""
+*es.HPOption_MBM_Mixed MBMStacker/Apilador de 3000 hojas de hp: ""
+*fi.HPOption_MBM_Mixed MBMStacker/hp<3A>n 3000 arkin pinoaja: ""
+*fr.HPOption_MBM_Mixed MBMStacker/Empileuse de 3000 feuilles hp: ""
+*it.HPOption_MBM_Mixed MBMStacker/Impilatrice HP da 3000 fogli: ""
+*ja.HPOption_MBM_Mixed MBMStacker/hp 3000枚スタッカ: ""
+*ko.HPOption_MBM_Mixed MBMStacker/hp 3000-스태커 용지함: ""
+*nl.HPOption_MBM_Mixed MBMStacker/HP stapelaar: ""
+*nb.HPOption_MBM_Mixed MBMStacker/hp 3000-arks magasin: ""
+*pt.HPOption_MBM_Mixed MBMStacker/hp 3000 Folhas empilhador: ""
+*sv.HPOption_MBM_Mixed MBMStacker/HP staplingsenhet för 3000 ark: ""
+*zh_CN.HPOption_MBM_Mixed MBMStacker/HP 3000 页堆栈器: ""
+*zh_TW.HPOption_MBM_Mixed MBMStacker/可容納 3000 張紙的 HP 堆疊器: ""
+
+*HPOption_MBM_Mixed HPFinisher/HP Multifunction Finisher: ""
+*da.HPOption_MBM_Mixed HPFinisher/hp-multifunktionsfinisher: ""
+*de.HPOption_MBM_Mixed HPFinisher/hp Mehrzweck-Abschlussgerät: ""
+*es.HPOption_MBM_Mixed HPFinisher/Dispositivo de acabados multifunción de hp: ""
+*fi.HPOption_MBM_Mixed HPFinisher/hp monitoiminen viimeistelylaite: ""
+*fr.HPOption_MBM_Mixed HPFinisher/Module de finition multifonction hp: ""
+*it.HPOption_MBM_Mixed HPFinisher/Unità di finitura multifunzione hp: ""
+*ja.HPOption_MBM_Mixed HPFinisher/hp 多目的仕上げデバイス: ""
+*ko.HPOption_MBM_Mixed HPFinisher/hp 다기능 마감장치: ""
+*nl.HPOption_MBM_Mixed HPFinisher/hp Multifunctioneel afwerkingsapparaat: ""
+*nb.HPOption_MBM_Mixed HPFinisher/hp flerfunksjonsetterbeh: ""
+*pt.HPOption_MBM_Mixed HPFinisher/Dispositivo de acabamento multifunção hp: ""
+*sv.HPOption_MBM_Mixed HPFinisher/hp efterbehandlare med fler funktioner: ""
+*zh_CN.HPOption_MBM_Mixed HPFinisher/hp 多功能装订器: ""
+*zh_TW.HPOption_MBM_Mixed HPFinisher/hp 多功能處理機: ""
+
+*HPOption_MBM_Mixed HPMultiBinMailbox/HP Multi-Bin Mailbox: ""
+*da.HPOption_MBM_Mixed HPMultiBinMailbox/HP Postkasse med flere bakker: ""
+*de.HPOption_MBM_Mixed HPMultiBinMailbox/hp Multifächer-Mailbox: ""
+*es.HPOption_MBM_Mixed HPMultiBinMailbox/Buzón de bandejas múltiples: ""
+*fi.HPOption_MBM_Mixed HPMultiBinMailbox/Monilokeroinen postilaatikko: ""
+*fr.HPOption_MBM_Mixed HPMultiBinMailbox/Trieuse à bacs multiples: ""
+*it.HPOption_MBM_Mixed HPMultiBinMailbox/Casella a più scomparti: ""
+*ja.HPOption_MBM_Mixed HPMultiBinMailbox/マルチトレイメールボックス: ""
+*ko.HPOption_MBM_Mixed HPMultiBinMailbox/hp 다단 우편함: ""
+*nl.HPOption_MBM_Mixed HPMultiBinMailbox/Postbus met multibakken: ""
+*nb.HPOption_MBM_Mixed HPMultiBinMailbox/Postkasse med flere skuffer: ""
+*pt.HPOption_MBM_Mixed HPMultiBinMailbox/Caixa de correio com vários compartimentos: ""
+*sv.HPOption_MBM_Mixed HPMultiBinMailbox/Extra utmatningsfack: ""
+*zh_CN.HPOption_MBM_Mixed HPMultiBinMailbox/多槽信箱: ""
+*zh_TW.HPOption_MBM_Mixed HPMultiBinMailbox/多槽式信箱: ""
+
+*?HPOption_MBM_Mixed: "
+currentpagedevice /OutputAttributes known{
+	currentpagedevice /MediaProcessingDetails known{
+		currentpagedevice /MediaProcessingDetails get /ModelID known{				
+			currentpagedevice /MediaProcessingDetails get /ModelID get (C8088B) search 
+				{pop pop pop (HPFinisher)} 
+				  {(C8085A) search 
+				  {pop pop pop (MBMStaplerStacker)} 
+				  {(C8084A) search 
+				  {pop pop pop (MBMStacker)} 
+				  {(Q5693A) search 
+				    {pop pop pop (HPMultiBinMailbox)} {pop (Standard)} ifelse} 
+				 ifelse}
+				 ifelse}
+				 ifelse}    
+			{(Standard)}
+			ifelse}
+		{(Standard)}
+		ifelse}
+	{(Standard)}
+ifelse = flush"
+*End
+*CloseUI: *HPOption_MBM_Mixed
+
+*%=== 8 Bin MultiBin MailBox Modes =========================
+*OpenUI *HPMailboxMode/Mailbox Mode: PickOne
+*OrderDependency: 46 AnySetup *HPMailboxMode
+*DefaultHPMailboxMode: PrintersDefault
+*da.Translation HPMailboxMode/Postkasse-tilstand: ""
+*de.Translation HPMailboxMode/Mailbox-Modus: ""
+*es.Translation HPMailboxMode/Modo Buzón: ""
+*fi.Translation HPMailboxMode/Postilaatikkotila: ""
+*fr.Translation HPMailboxMode/Mode trieuse: ""
+*it.Translation HPMailboxMode/Modalità Mailbox: ""
+*ja.Translation HPMailboxMode/メールボックスモード: ""
+*ko.Translation HPMailboxMode/우편함 모드: ""
+*nl.Translation HPMailboxMode/Postbusmodus: ""
+*nb.Translation HPMailboxMode/Postkassemodus: ""
+*pt.Translation HPMailboxMode/Modo de caixa de correio: ""
+*sv.Translation HPMailboxMode/Sorterarlåge: ""
+*zh_CN.Translation HPMailboxMode/信箱模式: ""
+*zh_TW.Translation HPMailboxMode/信箱模式: ""
+
+*HPMailboxMode PrintersDefault/Printer's Current Setting: ""
+*da.HPMailboxMode PrintersDefault/Ingen: ""
+*de.HPMailboxMode PrintersDefault/Aktuelle Einstellung: ""
+*es.HPMailboxMode PrintersDefault/Valor actual: ""
+*fi.HPMailboxMode PrintersDefault/Nykyinen asetus: ""
+*fr.HPMailboxMode PrintersDefault/Paramétre actuel: ""
+*it.HPMailboxMode PrintersDefault/Impostazione corrente: ""
+*ja.HPMailboxMode PrintersDefault/現在の設定: ""
+*ko.HPMailboxMode PrintersDefault/현재 설정: ""
+*nl.HPMailboxMode PrintersDefault/Huidige instelling: ""
+*nb.HPMailboxMode PrintersDefault/Ingen: ""
+*pt.HPMailboxMode PrintersDefault/Configuração atual: ""
+*sv.HPMailboxMode PrintersDefault/Aktuell inställning: ""
+*zh_CN.HPMailboxMode PrintersDefault/当前设置: ""
+*zh_TW.HPMailboxMode PrintersDefault/目前設定值: ""
+
+*HPMailboxMode Standard/Not Installed: ""
+*da.HPMailboxMode Standard/Ikke installeret: ""
+*de.HPMailboxMode Standard/Nicht installiert: ""
+*es.HPMailboxMode Standard/No Instalado: ""
+*fi.HPMailboxMode Standard/Ei asennettu: ""
+*fr.HPMailboxMode Standard/Non installé: ""
+*it.HPMailboxMode Standard/Non installato: ""
+*ja.HPMailboxMode Standard/取り付けられていない: ""
+*ko.HPMailboxMode Standard/설치되지 않음: ""
+*nl.HPMailboxMode Standard/Niet geïnstalleerd: ""
+*nb.HPMailboxMode Standard/Ikke installert: ""
+*pt.HPMailboxMode Standard/Não instalada: ""
+*sv.HPMailboxMode Standard/Ej installerat: ""
+*zh_CN.HPMailboxMode Standard/未安装: ""
+*zh_TW.HPMailboxMode Standard/未安裝: ""
+
+*HPMailboxMode MBMode/Mailbox Mode: ""
+*da.HPMailboxMode MBMode/Postkassetilstand: ""
+*de.HPMailboxMode MBMode/Mailbox-Modus: ""
+*es.HPMailboxMode MBMode/Modo buzón: ""
+*fi.HPMailboxMode MBMode/Postilaatikkotila: ""
+*fr.HPMailboxMode MBMode/Mode Trieuse: ""
+*it.HPMailboxMode MBMode/modalità Cassetta postale: ""
+*ja.HPMailboxMode MBMode/メールボックスモード: ""
+*ko.HPMailboxMode MBMode/우편함 모드: ""
+*nl.HPMailboxMode MBMode/Modus voor postbus: ""
+*nb.HPMailboxMode MBMode/Postkassemodus: ""
+*pt.HPMailboxMode MBMode/Modo de caixa de correio: ""
+*sv.HPMailboxMode MBMode/Sorterarlåge: ""
+*zh_CN.HPMailboxMode MBMode/邮箱模式: ""
+*zh_TW.HPMailboxMode MBMode/信箱模式: ""
+
+*HPMailboxMode StackerMode/Stacker Mode: ""
+*da.HPMailboxMode StackerMode/Stablertilstand: ""
+*de.HPMailboxMode StackerMode/Stapelmodus: ""
+*es.HPMailboxMode StackerMode/Modo apilador: ""
+*fi.HPMailboxMode StackerMode/Pinontatila: ""
+*fr.HPMailboxMode StackerMode/Mode Réceptacle: ""
+*it.HPMailboxMode StackerMode/modalità Raccoglitore: ""
+*ja.HPMailboxMode StackerMode/排紙トレイモード: ""
+*ko.HPMailboxMode StackerMode/스태커 모드: ""
+*nl.HPMailboxMode StackerMode/Modus voor stapelaar: ""
+*nb.HPMailboxMode StackerMode/Stablingsmodus: ""
+*pt.HPMailboxMode StackerMode/Modo de empilhador: ""
+*sv.HPMailboxMode StackerMode/Låget Stapling: ""
+*zh_CN.HPMailboxMode StackerMode/堆栈器模式: ""
+*zh_TW.HPMailboxMode StackerMode/堆疊器模式: ""
+
+*HPMailboxMode SeparatorMode/Separator Mode: ""
+*da.HPMailboxMode SeparatorMode/Jobadskillertilstand: ""
+*de.HPMailboxMode SeparatorMode/Jobtrennmodus: ""
+*es.HPMailboxMode SeparatorMode/Modo separador de trabajos: ""
+*fi.HPMailboxMode SeparatorMode/Työn erottelutila: ""
+*fr.HPMailboxMode SeparatorMode/Mode Séparateur de tâche: ""
+*it.HPMailboxMode SeparatorMode/modalità Separatore processi: ""
+*ja.HPMailboxMode SeparatorMode/ジョブ仕分けモード: ""
+*ko.HPMailboxMode SeparatorMode/작업 분리기 모드: ""
+*nl.HPMailboxMode SeparatorMode/Modus voor taakscheiding: ""
+*nb.HPMailboxMode SeparatorMode/Jobbskillingsmodus: ""
+*pt.HPMailboxMode SeparatorMode/Modo de separador de trabalhos: ""
+*sv.HPMailboxMode SeparatorMode/Låget Dokumentseparation: ""
+*zh_CN.HPMailboxMode SeparatorMode/作业分隔器模式: ""
+*zh_TW.HPMailboxMode SeparatorMode/工作分隔器模式: ""
+
+*HPMailboxMode SorterCollatorMode/Sorter Collator Mode: ""
+*da.HPMailboxMode SorterCollatorMode/Sorteringsenhedstilstand: ""
+*de.HPMailboxMode SorterCollatorMode/Sortiermodus: ""
+*es.HPMailboxMode SorterCollatorMode/Modo clasificador/organizador: ""
+*fi.HPMailboxMode SorterCollatorMode/Lajittelutila: ""
+*fr.HPMailboxMode SorterCollatorMode/Mode Trieur/Classeur: ""
+*it.HPMailboxMode SorterCollatorMode/modalità Fascicolatore: ""
+*ja.HPMailboxMode SorterCollatorMode/分類/丁合いモード: ""
+*ko.HPMailboxMode SorterCollatorMode/분류기/조합기 모드: ""
+*nl.HPMailboxMode SorterCollatorMode/Modus voor sorteerder: ""
+*nb.HPMailboxMode SorterCollatorMode/Stablings-/sorteringsmodus: ""
+*pt.HPMailboxMode SorterCollatorMode/Modo de classificador/intercalador: ""
+*sv.HPMailboxMode SorterCollatorMode/Låget Dokumentsorterare: ""
+*zh_CN.HPMailboxMode SorterCollatorMode/排序器/分页器模式: ""
+*zh_TW.HPMailboxMode SorterCollatorMode/分類器/分頁器模式: ""
+
+*?HPMailboxMode: "
+currentpagedevice /OutputAttributes known{
+	currentpagedevice /MediaProcessingDetails known{
+		currentpagedevice /MediaProcessingDetails get /DeviceID known{				
+			currentpagedevice /MediaProcessingDetails get /DeviceID get (HP 8-BIN MAILBOX) search 
+				{pop pop pop (MBMode)} 
+				  {(HP 8-BIN STACKER) search 
+				  {pop pop pop (StackerMode)} 
+				  {(HP 8-BIN JOB SEPARATOR) search 
+				  {pop pop pop (SeparatorMode)} 
+				  {(HP 8-BIN SORTER/COLLATOR) search 
+				    {pop pop pop (SorterCollatorMode)} {pop (Standard)} ifelse} 
+				 ifelse}
+				 ifelse}
+				 ifelse}    
+			{(Standard)}
+			ifelse}
+		{(Standard)}
+		ifelse}
+	{(Standard)}
+ifelse = flush"
+*End
+*CloseUI: *HPMailboxMode
+
+*OpenUI *InstalledMemory/Total Printer Memory: PickOne
+*DefaultInstalledMemory: 64-127MB
+*da.Translation InstalledMemory/Printerhukommelse i alt: ""
+*de.Translation InstalledMemory/Druckerspeicher insgesamt: ""
+*es.Translation InstalledMemory/Memoria total de la impresora: ""
+*fi.Translation InstalledMemory/Kirjoittimen kokonaismuisti: ""
+*fr.Translation InstalledMemory/Mémoire totale de l’imprimante: ""
+*it.Translation InstalledMemory/Configurazione della memoria: ""
+*ja.Translation InstalledMemory/プリンタ総メモリ容量: ""
+*ko.Translation InstalledMemory/메모리 구성: ""
+*nl.Translation InstalledMemory/Geheugenconfiguratie: ""
+*nb.Translation InstalledMemory/Total skriverhukommelse: ""
+*pt.Translation InstalledMemory/Configuração de memória: ""
+*sv.Translation InstalledMemory/Minneskonfiguration: ""
+*zh_CN.Translation InstalledMemory/内存配置: ""
+*zh_TW.Translation InstalledMemory/記憶體設定: ""
+
+*InstalledMemory 64-127MB/64 - 127 MB: ""
+*da.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*de.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*es.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*fi.InstalledMemory 64-127MB/64 - 127 megatavua: ""
+*fr.InstalledMemory 64-127MB/64 - 127 Mo de RAM: ""
+*it.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*ja.InstalledMemory 64-127MB/64 〜 127 MB RAM: ""
+*ko.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*nl.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*nb.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*pt.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*sv.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*zh_CN.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+*zh_TW.InstalledMemory 64-127MB/64 - 127 MB RAM: ""
+
+*InstalledMemory 128-255MB/128 - 255 MB: ""
+*da.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*de.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*es.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*fi.InstalledMemory 128-255MB/128 - 255 megatavua: ""
+*fr.InstalledMemory 128-255MB/128 - 255 Mo de RAM: ""
+*it.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*ja.InstalledMemory 128-255MB/128 〜 255 MB RAM: ""
+*ko.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*nl.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*nb.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*pt.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*sv.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*zh_CN.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+*zh_TW.InstalledMemory 128-255MB/128 - 255 MB RAM: ""
+
+*InstalledMemory 256-383MB/256 - 383 MB: ""
+*da.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*de.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*es.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*fi.InstalledMemory 256-383MB/256 - 383 megatavua: ""
+*fr.InstalledMemory 256-383MB/256 - 383 Mo de RAM: ""
+*it.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*ja.InstalledMemory 256-383MB/256 〜 383 MB RAM: ""
+*ko.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*nl.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*nb.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*pt.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*sv.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*zh_CN.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+*zh_TW.InstalledMemory 256-383MB/256 - 383 MB RAM: ""
+
+*InstalledMemory 384-512MB/384 - 512 MB: ""
+*da.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*de.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*es.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*fi.InstalledMemory 384-512MB/384 - 512 megatavua: ""
+*fr.InstalledMemory 384-512MB/384 - 512 Mo de RAM: ""
+*it.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*ja.InstalledMemory 384-512MB/384 〜 512 MB RAM: ""
+*ko.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*nl.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*nb.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*pt.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*sv.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*zh_CN.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+*zh_TW.InstalledMemory 384-512MB/384 - 512 MB RAM: ""
+
+*?InstalledMemory: "
+  save
+    currentsystemparams /RamSize get
+    524288 div ceiling cvi 2 div
+    /size exch def
+    size 384 ge
+       {(384-512MB)}
+       {size 256 ge
+          {(256-383MB)}
+          {size 128 ge
+             {(128-255MB)}
+             {(64-127MB)} ifelse
+          } ifelse
+    	} ifelse = flush
+  	restore
+	"
+*End
+*CloseUI: *InstalledMemory
+
+*%=================================================
+*%		 Fit to Page
+*%=================================================
+*OpenUI *HPOption_PaperPolicy/Fit to Page: PickOne
+*OrderDependency: 10 AnySetup *HPOption_PaperPolicy
+*DefaultHPOption_PaperPolicy: PromptUser
+*da.Translation HPOption_PaperPolicy/Tilpas til siden: ""
+*de.Translation HPOption_PaperPolicy/An Seite anpassen: ""
+*es.Translation HPOption_PaperPolicy/Hacer que quepa en la hoja: ""
+*fi.Translation HPOption_PaperPolicy/Sovita sivulle: ""
+*fr.Translation HPOption_PaperPolicy/Ajuster à la page: ""
+*it.Translation HPOption_PaperPolicy/Adatta alle dimensioni della pagina: ""
+*ja.Translation HPOption_PaperPolicy/用紙のマッチング: ""
+*ko.Translation HPOption_PaperPolicy/용지 일치: ""
+*nl.Translation HPOption_PaperPolicy/Papieraanpassing: ""
+*nb.Translation HPOption_PaperPolicy/Papirtilpasning: ""
+*pt.Translation HPOption_PaperPolicy/Correspondência de papel: ""
+*sv.Translation HPOption_PaperPolicy/Pappersmatchning: ""
+*zh_CN.Translation HPOption_PaperPolicy/纸张匹配: ""
+*zh_TW.Translation HPOption_PaperPolicy/紙張相符: ""
+
+*HPOption_PaperPolicy PromptUser/Prompt User: "
+   <</DeferredMediaSelection true>> setpagedevice"
+*End
+*da.HPOption_PaperPolicy PromptUser/Spørg brugeren: ""
+*de.HPOption_PaperPolicy PromptUser/Benutzer auffordern: ""
+*es.HPOption_PaperPolicy PromptUser/Informar al usuario: ""
+*fi.HPOption_PaperPolicy PromptUser/Kysy käyttäjältä: ""
+*fr.HPOption_PaperPolicy PromptUser/Demander à l’utilisateur: ""
+*it.HPOption_PaperPolicy PromptUser/Avvisa utente: ""
+*ja.HPOption_PaperPolicy PromptUser/正しいサイズを入力するように要求: ""
+*ko.HPOption_PaperPolicy PromptUser/프롬프트 사용자: ""
+*nl.HPOption_PaperPolicy PromptUser/Gebruiker waarschuwen: ""
+*nb.HPOption_PaperPolicy PromptUser/Gi beskjed til bruker: ""
+*pt.HPOption_PaperPolicy PromptUser/Avisar usuário: ""
+*sv.HPOption_PaperPolicy PromptUser/Meddela användaren: ""
+*zh_CN.HPOption_PaperPolicy PromptUser/提示用户: ""
+*zh_TW.HPOption_PaperPolicy PromptUser/提示使用者: ""
+
+*HPOption_PaperPolicy NearestSizeAdjust/Nearest Size and Scale: "
+   <</DeferredMediaSelection false /Policies << /PageSize 3 >> >> setpagedevice"
+*End
+*da.HPOption_PaperPolicy NearestSizeAdjust/Nærmeste størrelse og skalering: ""
+*de.HPOption_PaperPolicy NearestSizeAdjust/Nächstkleineres/größeres Format mit Skalierung: ""
+*es.HPOption_PaperPolicy NearestSizeAdjust/Usar tamaño más parecido y cambiar a escala: ""
+*fi.HPOption_PaperPolicy NearestSizeAdjust/Lähin koko ja skaalaus: ""
+*fr.HPOption_PaperPolicy NearestSizeAdjust/Format et échelle les plus proches: ""
+*it.HPOption_PaperPolicy NearestSizeAdjust/Usa le dimensioni più vicine e adatta: ""
+*ja.HPOption_PaperPolicy NearestSizeAdjust/近似サイズに拡大/縮小: ""
+*ko.HPOption_PaperPolicy NearestSizeAdjust/근사 크기와 축소/확대: ""
+*nl.HPOption_PaperPolicy NearestSizeAdjust/Dichtst benaderende afmeting en schaal: ""
+*nb.HPOption_PaperPolicy NearestSizeAdjust/Nærmeste størrelse og skala: ""
+*pt.HPOption_PaperPolicy NearestSizeAdjust/Tamanho mais próximo e ajusta a escala: ""
+*sv.HPOption_PaperPolicy NearestSizeAdjust/Närmaste storlek och skala: ""
+*zh_CN.HPOption_PaperPolicy NearestSizeAdjust/最接近之尺寸和缩放度: ""
+*zh_TW.HPOption_PaperPolicy NearestSizeAdjust/最接近的尺寸並按比例縮放: ""
+
+*HPOption_PaperPolicy NearestSizeNoAdjust/Nearest Size and Crop: "
+   <</DeferredMediaSelection false /Policies << /PageSize 5 >> >> setpagedevice"
+*End
+*da.HPOption_PaperPolicy NearestSizeNoAdjust/Nærmeste størrelse og beskæring: ""
+*de.HPOption_PaperPolicy NearestSizeNoAdjust/Nächstkleineres/größeres Format mit Beschnitt: ""
+*es.HPOption_PaperPolicy NearestSizeNoAdjust/Usar tamaño más parecido y recortar: ""
+*fi.HPOption_PaperPolicy NearestSizeNoAdjust/Lähin koko ja rajaus: ""
+*fr.HPOption_PaperPolicy NearestSizeNoAdjust/Format et coupe les plus proches: ""
+*it.HPOption_PaperPolicy NearestSizeNoAdjust/Usa le dimensioni più vicine e taglia: ""
+*ja.HPOption_PaperPolicy NearestSizeNoAdjust/近似サイズにトリミング: ""
+*ko.HPOption_PaperPolicy NearestSizeNoAdjust/근사 크기와 자르기: ""
+*nl.HPOption_PaperPolicy NearestSizeNoAdjust/Dichtst benaderende grootte en trim: ""
+*nb.HPOption_PaperPolicy NearestSizeNoAdjust/Nærmeste størrelse og beskjæring: ""
+*pt.HPOption_PaperPolicy NearestSizeNoAdjust/Tamanho mais próximo e corta: ""
+*sv.HPOption_PaperPolicy NearestSizeNoAdjust/Närmaste storlek och beskär: ""
+*zh_CN.HPOption_PaperPolicy NearestSizeNoAdjust/最接近之尺寸和剪裁: ""
+*zh_TW.HPOption_PaperPolicy NearestSizeNoAdjust/最接近的尺寸並裁剪: ""
+
+*?HPOption_PaperPolicy: "(PromptUser) = flush"
+*CloseUI: *HPOption_PaperPolicy
+
+*CloseGroup: InstallableOptions
+
+
+*%=================================================
+*%		 UI Constraints
+*%=================================================
+*% If A than not B  (Also include the reverse constraints if appropriate)
+*%
+*% Constraints against Installable Options
+*%-------------------------------------------------------------------------
+*UIConstraints: *HPOption_Tray1 False *InputSlot Tray1
+*UIConstraints: *HPOption_Tray1 False *ManualFeed True
+*UIConstraints: *HPOption_2000_Sheet_Tray False *InputSlot Tray4Optional
+
+*UIConstraints: *InputSlot Tray1 *HPOption_Tray1 False
+*UIConstraints: *ManualFeed True *HPOption_Tray1 False
+*UIConstraints: *InputSlot Tray4Optional *HPOption_2000_Sheet_Tray False
+
+*% Constraints on Output devices and the OutputBins
+*%-------------------------------------------------------------------
+*% Standard (Nothing Attaced)
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin Stacker
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin StackerFaceUp
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin UStapler
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin HPBooklet
+*UIConstraints: *HPOption_MBM_Mixed Standard *OutputBin HP8BinMB
+
+*UIConstraints: *OutputBin Stacker *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin StackerFaceUp *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin UStapler *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed Standard
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed Standard
+
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed Standard
+
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed Standard
+
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 1parallel
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 2parallel
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed Standard *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 1parallel *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 2parallel *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed Standard
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed Standard
+
+*% Stacker
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin UStapler
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin HP8BinMB
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin HPBooklet
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *OutputBin StackerFaceUp
+
+
+*UIConstraints: *OutputBin UStapler *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *OutputBin StackerFaceUp *HPOption_MBM_Mixed MBMStacker
+
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed MBMStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed MBMStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 1parallel
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 2parallel
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed MBMStacker *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 1parallel *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 2parallel *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed MBMStacker
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed MBMStacker
+
+*% StaplerStacker
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *OutputBin HP8BinMB
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *OutputBin HPBooklet
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *OutputBin StackerFaceUp
+
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *OutputBin StackerFaceUp *HPOption_MBM_Mixed MBMStaplerStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed MBMStaplerStacker
+
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed MBMStaplerStacker *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed MBMStaplerStacker
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed MBMStaplerStacker
+
+
+*% BookletMaker
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *OutputBin HP8BinMB
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *OutputBin Left
+
+*UIConstraints: *OutputBin HP8BinMB *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *OutputBin Left *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode MBMode
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode StackerMode
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode SeparatorMode
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxMode SorterCollatorMode
+
+*UIConstraints: *HPMailboxMode MBMode *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxMode StackerMode *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxMode SeparatorMode *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin1
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin2
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin3
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin4
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin5
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin6
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin7
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin8
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin2 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin3 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin4 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin5 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin6 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin7 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin8 *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed HPFinisher *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed HPFinisher
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed HPFinisher
+
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin HPBooklet *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin HPBooklet
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin HPBooklet
+
+
+
+*% MultiBin Mailbox HPMBM
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin Left
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin Stacker
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin UStapler
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *OutputBin HPBooklet
+
+*UIConstraints: *OutputBin Left *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *OutputBin Stacker *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *OutputBin UStapler *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *OutputBin HPBooklet *HPOption_MBM_Mixed HPMultiBinMailbox
+
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 1diagonal
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 1parallel
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 2parallel
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 3parallel
+*UIConstraints: *HPOption_MBM_Mixed HPMultiBinMailbox *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 1parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 2parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 3parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+*UIConstraints: *HPStaplerOptions 6parallel *HPOption_MBM_Mixed HPMultiBinMailbox
+
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin8
+*UIConstraints: *HPMailboxMode Standard *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin2 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin3 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin4 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin5 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin6 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin7 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin8 	*HPMailboxMode Standard
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPMailboxMode Standard
+
+*% Constraints on the Paper Sizes and Output Bins
+*%------------------------------------------------------------
+*% Trays 2, 3.
+*UIConstraints: *PageSize 12X18       *InputSlot Tray2
+*UIConstraints: *PageRegion 12X18       *InputSlot Tray2
+*UIConstraints: *PageSize 12X18       *InputSlot Tray3
+*UIConstraints: *PageRegion 12X18       *InputSlot Tray3
+*UIConstraints: *PageSize RA3       *InputSlot Tray2
+*UIConstraints: *PageRegion RA3       *InputSlot Tray2
+*UIConstraints: *PageSize RA3       *InputSlot Tray3
+*UIConstraints: *PageRegion RA3       *InputSlot Tray3
+*UIConstraints: *PageSize DoublePostcard       *InputSlot Tray2
+*UIConstraints: *PageRegion DoublePostcard       *InputSlot Tray2
+*UIConstraints: *PageSize DoublePostcard       *InputSlot Tray3
+*UIConstraints: *PageRegion DoublePostcard       *InputSlot Tray3
+*UIConstraints: *PageSize Env10       *InputSlot Tray2
+*UIConstraints: *PageRegion Env10       *InputSlot Tray2
+*UIConstraints: *PageSize Env10       *InputSlot Tray3
+*UIConstraints: *PageRegion Env10       *InputSlot Tray3
+*UIConstraints: *PageSize EnvMonarch  *InputSlot Tray2
+*UIConstraints: *PageRegion EnvMonarch  *InputSlot Tray2
+*UIConstraints: *PageSize EnvMonarch  *InputSlot Tray3
+*UIConstraints: *PageRegion EnvMonarch  *InputSlot Tray3
+*UIConstraints: *PageSize EnvDL       *InputSlot Tray2
+*UIConstraints: *PageRegion EnvDL       *InputSlot Tray2
+*UIConstraints: *PageSize EnvDL       *InputSlot Tray3
+*UIConstraints: *PageRegion EnvDL       *InputSlot Tray3
+*UIConstraints: *PageSize EnvC5       *InputSlot Tray2
+*UIConstraints: *PageRegion EnvC5       *InputSlot Tray2
+*UIConstraints: *PageSize EnvC5       *InputSlot Tray3
+*UIConstraints: *PageRegion EnvC5       *InputSlot Tray3
+*UIConstraints: *PageSize EnvISOB5    *InputSlot Tray2
+*UIConstraints: *PageRegion EnvISOB5    *InputSlot Tray2
+*UIConstraints: *PageSize EnvISOB5    *InputSlot Tray3
+*UIConstraints: *PageRegion EnvISOB5    *InputSlot Tray3
+
+*UIConstraints: *InputSlot Tray2	  *PageSize 12X18
+*UIConstraints: *InputSlot Tray2	  *PageRegion 12X18
+*UIConstraints: *InputSlot Tray3	  *PageSize 12X18
+*UIConstraints: *InputSlot Tray3	  *PageRegion 12X18
+*UIConstraints: *InputSlot Tray2	  *PageSize RA3
+*UIConstraints: *InputSlot Tray2	  *PageRegion RA3
+*UIConstraints: *InputSlot Tray3	  *PageSize RA3
+*UIConstraints: *InputSlot Tray3	  *PageRegion RA3
+*UIConstraints: *InputSlot Tray2	  *PageSize DoublePostcard
+*UIConstraints: *InputSlot Tray2	  *PageRegion DoublePostcard
+*UIConstraints: *InputSlot Tray3	  *PageSize DoublePostcard
+*UIConstraints: *InputSlot Tray3	  *PageRegion DoublePostcard
+*UIConstraints: *InputSlot Tray2	  *PageSize Env10
+*UIConstraints: *InputSlot Tray2	  *PageRegion Env10
+*UIConstraints: *InputSlot Tray3	  *PageSize Env10
+*UIConstraints: *InputSlot Tray3	  *PageRegion Env10
+*UIConstraints: *InputSlot Tray2      *PageSize EnvMonarch
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvMonarch
+*UIConstraints: *InputSlot Tray3      *PageSize EnvMonarch
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvMonarch
+*UIConstraints: *InputSlot Tray2      *PageSize EnvDL
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvDL
+*UIConstraints: *InputSlot Tray3      *PageSize EnvDL
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvDL
+*UIConstraints: *InputSlot Tray2      *PageSize EnvC5
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvC5
+*UIConstraints: *InputSlot Tray3      *PageSize EnvC5
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvC5
+*UIConstraints: *InputSlot Tray2      *PageSize EnvISOB5
+*UIConstraints: *InputSlot Tray2      *PageRegion EnvISOB5
+*UIConstraints: *InputSlot Tray3      *PageSize EnvISOB5
+*UIConstraints: *InputSlot Tray3      *PageRegion EnvISOB5
+
+*% Tray 4 (Supports only A4 and Letter sizes).
+
+*UIConstraints: *PageSize HalfLetter      *InputSlot Tray4Optional
+*UIConstraints: *PageRegion HalfLetter    *InputSlot Tray4Optional
+*UIConstraints: *PageSize 12X18        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion 12X18      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize RA3        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion RA3      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize A5        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion A5      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize DoublePostcard  *InputSlot Tray4Optional
+*UIConstraints: *PageRegion DoublePostcard *InputSlot Tray4Optional
+*UIConstraints: *PageSize Env10        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion Env10      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvMonarch    	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvMonarch  	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvC5        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvC5      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvDL        	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvDL      	*InputSlot Tray4Optional
+*UIConstraints: *PageSize EnvISOB5      	*InputSlot Tray4Optional
+*UIConstraints: *PageRegion EnvISOB5    	*InputSlot Tray4Optional
+
+*UIConstraints: *InputSlot Tray4Optional	*PageSize HalfLetter
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion HalfLetter
+*UIConstraints: *InputSlot Tray4Optional	*PageSize 12X18
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion 12X18
+*UIConstraints: *InputSlot Tray4Optional	*PageSize A3
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion A3
+*UIConstraints: *InputSlot Tray4Optional	*PageSize RA3
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion RA3
+*UIConstraints: *InputSlot Tray4Optional	*PageSize A5
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion A5
+*UIConstraints: *InputSlot Tray4Optional	*PageSize DoublePostcard
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion DoublePostcard
+*UIConstraints: *InputSlot Tray4Optional	*PageSize Env10
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion Env10
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvMonarch
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvMonarch
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvC5
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvC5
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvDL
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvDL
+*UIConstraints: *InputSlot Tray4Optional	*PageSize EnvISOB5
+*UIConstraints: *InputSlot Tray4Optional	*PageRegion EnvISOB5
+
+*% MBMStacker and MBMStaplerStacker, HPBooklet and Mailbox which all use the  OutputBin Stacker
+*UIConstraints: *OutputBin Stacker			*PageSize DoublePostcard
+*UIConstraints: *OutputBin Stacker			*PageRegion DoublePostcard
+*UIConstraints: *OutputBin Stacker			*PageSize Env10
+*UIConstraints: *OutputBin Stacker			*PageRegion Env10
+*UIConstraints: *OutputBin Stacker			*PageSize EnvMonarch
+*UIConstraints: *OutputBin Stacker			*PageRegion EnvMonarch
+*UIConstraints: *OutputBin Stacker			*PageSize EnvC5
+*UIConstraints: *OutputBin Stacker			*PageRegion EnvC5
+*UIConstraints: *OutputBin Stacker			*PageSize EnvDL
+*UIConstraints: *OutputBin Stacker			*PageRegion EnvDL
+*UIConstraints: *OutputBin Stacker			*PageSize EnvISOB5
+*UIConstraints: *OutputBin Stacker			*PageRegion EnvISOB5
+
+*UIConstraints: *PageSize DoublePostcard *OutputBin Stacker
+*UIConstraints: *PageRegion DoublePostcard *OutputBin Stacker
+*UIConstraints: *PageSize Env10 		*OutputBin Stacker
+*UIConstraints: *PageRegion Env10		*OutputBin Stacker
+*UIConstraints: *PageSize EnvMonarch	*OutputBin Stacker
+*UIConstraints: *PageRegion EnvMonarch	*OutputBin Stacker
+*UIConstraints: *PageSize EnvC5			*OutputBin Stacker
+*UIConstraints: *PageRegion EnvC5		*OutputBin Stacker
+*UIConstraints: *PageSize EnvDL			*OutputBin Stacker
+*UIConstraints: *PageRegion EnvDL		*OutputBin Stacker
+*UIConstraints: *PageSize EnvISOB5		*OutputBin Stacker
+*UIConstraints: *PageRegion EnvISOB5	*OutputBin Stacker
+
+*% Duplex Constraints
+*%--------------------------------------------------------------------
+*UIConstraints: *PageSize DoublePostcard	*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion DoublePostcard *Duplex DuplexNoTumble
+*UIConstraints: *PageSize Env10		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion Env10         *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvMonarch	*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvMonarch    *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvDL		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvDL         *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvC5		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvC5         *Duplex DuplexNoTumble
+*UIConstraints: *PageSize EnvISOB5		*Duplex DuplexNoTumble
+*UIConstraints: *PageRegion EnvISOB5      *Duplex DuplexNoTumble
+
+*UIConstraints: *PageSize DoublePostcard  *Duplex DuplexTumble
+*UIConstraints: *PageRegion DoublePostcard *Duplex DuplexTumble
+*UIConstraints: *PageSize Env10           *Duplex DuplexTumble
+*UIConstraints: *PageRegion Env10         *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvMonarch      *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvMonarch    *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvDL           *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvDL         *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvC5           *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvC5         *Duplex DuplexTumble
+*UIConstraints: *PageSize EnvISOB5        *Duplex DuplexTumble
+*UIConstraints: *PageRegion EnvISOB5      *Duplex DuplexTumble
+
+*UIConstraints: *Duplex DuplexNoTumble 	*PageSize DoublePostcard
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion DoublePostcard
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize Env10
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion Env10
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvMonarch
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvMonarch
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvDL
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvDL
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvC5
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvC5
+*UIConstraints: *Duplex DuplexNoTumble	*PageSize EnvISOB5
+*UIConstraints: *Duplex DuplexNoTumble	*PageRegion EnvISOB5
+
+*UIConstraints: *Duplex DuplexTumble	*PageSize DoublePostcard
+*UIConstraints: *Duplex DuplexTumble	*PageRegion DoublePostcard
+*UIConstraints: *Duplex DuplexTumble	*PageSize Env10
+*UIConstraints: *Duplex DuplexTumble	*PageRegion Env10
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvMonarch
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvMonarch
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvDL
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvDL
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvC5
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvC5
+*UIConstraints: *Duplex DuplexTumble	*PageSize EnvISOB5
+*UIConstraints: *Duplex DuplexTumble	*PageRegion EnvISOB5
+
+*% Constrain Stapling to the stapling bin (Output Destination and Stapler Option Menus)
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin PrinterDefault *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin PrinterDefault
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin PrinterDefault
+
+*UIConstraints: *OutputBin Left *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin Left *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin Left *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin Left *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin Left *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin Left
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin Left
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin Left
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin Left
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin Left
+
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin Upper *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin Upper
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin Upper
+
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin Stacker *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin Stacker
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin Stacker
+
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin StackerFaceUp *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin StackerFaceUp
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin StackerFaceUp
+
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 1diagonal
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 1parallel
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 2parallel
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 3parallel
+*UIConstraints: *OutputBin HP8BinMB *HPStaplerOptions 6parallel
+
+*UIConstraints: *HPStaplerOptions 1diagonal *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 1parallel *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 2parallel *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 3parallel *OutputBin HP8BinMB
+*UIConstraints: *HPStaplerOptions 6parallel *OutputBin HP8BinMB
+
+*% Booklet Bin
+
+
+*% Collate
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 1diagonal
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 1parallel
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 2parallel
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 3parallel
+*HPConstraints: *Collate False *HPMinNumCopies 2 *HPStaplerOptions 6parallel
+
+
+*% Constrain Stapling to the stapling bin (Output Destination and Stapler Option Menus)
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin1
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin1
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin2
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin2
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin3
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin3
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin4
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin4
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin5
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin5
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin6
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin6
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin7
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin7
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin8
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin8
+
+*UIConstraints: *HPStaplerOptions 1diagonal *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 1parallel *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 2parallel *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 3parallel *HPMailboxOptions Bin1_8
+*UIConstraints: *HPStaplerOptions 6parallel *HPMailboxOptions Bin1_8
+
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin1	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin2	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin3	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin4	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin5	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin6	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin7	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin8	*HPStaplerOptions 6parallel
+
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 1diagonal
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 1parallel
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 2parallel
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 3parallel
+*UIConstraints: *HPMailboxOptions Bin1_8	*HPStaplerOptions 6parallel
+
+*% Constrained PageSizes (Constrains Stacker/Stapler/and Mailbox attachments)
+*UIConstraints: *PageSize DoublePostcard   *OutputBin UStapler
+*UIConstraints: *PageRegion DoublePostcard *OutputBin UStapler
+*UIConstraints: *PageSize Env10        *OutputBin UStapler
+*UIConstraints: *PageRegion Env10      *OutputBin UStapler
+*UIConstraints: *PageSize EnvMonarch   *OutputBin UStapler
+*UIConstraints: *PageRegion EnvMonarch *OutputBin UStapler
+*UIConstraints: *PageSize EnvDL        *OutputBin UStapler
+*UIConstraints: *PageRegion EnvDL      *OutputBin UStapler
+*UIConstraints: *PageSize EnvC5        *OutputBin UStapler
+*UIConstraints: *PageRegion EnvC5      *OutputBin UStapler
+*UIConstraints: *PageSize EnvISOB5     *OutputBin UStapler
+*UIConstraints: *PageRegion EnvISOB5   *OutputBin UStapler
+
+*UIConstraints: *OutputBin UStapler *PageSize DoublePostcard
+*UIConstraints: *OutputBin UStapler *PageRegion DoublePostcard
+*UIConstraints: *OutputBin UStapler *PageSize Env10
+*UIConstraints: *OutputBin UStapler *PageRegion Env10
+*UIConstraints: *OutputBin UStapler *PageSize EnvMonarch
+*UIConstraints: *OutputBin UStapler *PageRegion EnvMonarch
+*UIConstraints: *OutputBin UStapler *PageSize EnvDL
+*UIConstraints: *OutputBin UStapler *PageRegion EnvDL
+*UIConstraints: *OutputBin UStapler *PageSize EnvC5
+*UIConstraints: *OutputBin UStapler *PageRegion EnvC5
+*UIConstraints: *OutputBin UStapler *PageSize EnvISOB5
+*UIConstraints: *OutputBin UStapler *PageRegion EnvISOB5
+
+*% Booklet Bin
+*UIConstraints: *PageSize Executive   *OutputBin HPBooklet
+*UIConstraints: *PageRegion Executive *OutputBin HPBooklet
+*UIConstraints: *PageSize HalfLetter   *OutputBin HPBooklet
+*UIConstraints: *PageRegion HalfLetter *OutputBin HPBooklet
+*UIConstraints: *PageSize w612h935   *OutputBin HPBooklet
+*UIConstraints: *PageRegion w612h935 *OutputBin HPBooklet
+*UIConstraints: *PageSize 12X18   *OutputBin HPBooklet
+*UIConstraints: *PageRegion 12X18 *OutputBin HPBooklet
+*UIConstraints: *PageSize A5   *OutputBin HPBooklet
+*UIConstraints: *PageRegion A5 *OutputBin HPBooklet
+*UIConstraints: *PageSize RA3   *OutputBin HPBooklet
+*UIConstraints: *PageRegion RA3 *OutputBin HPBooklet
+*UIConstraints: *PageSize B5   *OutputBin HPBooklet
+*UIConstraints: *PageRegion B5 *OutputBin HPBooklet
+*UIConstraints: *PageSize w612h936   *OutputBin HPBooklet
+*UIConstraints: *PageRegion w612h936 *OutputBin HPBooklet
+*UIConstraints: *PageSize DoublePostcard   *OutputBin HPBooklet
+*UIConstraints: *PageRegion DoublePostcard *OutputBin HPBooklet
+*UIConstraints: *PageSize w558h774   *OutputBin HPBooklet
+*UIConstraints: *PageRegion w558h774 *OutputBin HPBooklet
+*UIConstraints: *PageSize w774h1116   *OutputBin HPBooklet
+*UIConstraints: *PageRegion w774h1116 *OutputBin HPBooklet
+*UIConstraints: *PageSize Env10   *OutputBin HPBooklet
+*UIConstraints: *PageRegion Env10 *OutputBin HPBooklet
+*UIConstraints: *PageSize EnvMonarch   *OutputBin HPBooklet
+*UIConstraints: *PageRegion EnvMonarch *OutputBin HPBooklet
+*UIConstraints: *PageSize EnvDL   *OutputBin HPBooklet
+*UIConstraints: *PageRegion EnvDL *OutputBin HPBooklet
+*UIConstraints: *PageSize EnvC5   *OutputBin HPBooklet
+*UIConstraints: *PageRegion EnvC5 *OutputBin HPBooklet
+*UIConstraints: *PageSize EnvISOB5   *OutputBin HPBooklet
+*UIConstraints: *PageRegion EnvISOB5 *OutputBin HPBooklet
+
+*UIConstraints: *OutputBin HPBooklet *PageSize Executive
+*UIConstraints: *OutputBin HPBooklet *PageRegion Executive
+*UIConstraints: *OutputBin HPBooklet *PageSize HalfLetter
+*UIConstraints: *OutputBin HPBooklet *PageRegion HalfLetter
+*UIConstraints: *OutputBin HPBooklet *PageSize w612h935
+*UIConstraints: *OutputBin HPBooklet *PageRegion w612h935
+*UIConstraints: *OutputBin HPBooklet *PageSize 12X18
+*UIConstraints: *OutputBin HPBooklet *PageRegion 12X18
+*UIConstraints: *OutputBin HPBooklet *PageSize A5
+*UIConstraints: *OutputBin HPBooklet *PageRegion A5
+*UIConstraints: *OutputBin HPBooklet *PageSize RA3
+*UIConstraints: *OutputBin HPBooklet *PageRegion RA3
+*UIConstraints: *OutputBin HPBooklet *PageSize B5
+*UIConstraints: *OutputBin HPBooklet *PageRegion B5
+*UIConstraints: *OutputBin HPBooklet *PageSize w612h936
+*UIConstraints: *OutputBin HPBooklet *PageRegion w612h936
+*UIConstraints: *OutputBin HPBooklet *PageSize DoublePostcard
+*UIConstraints: *OutputBin HPBooklet *PageRegion DoublePostcard
+*UIConstraints: *OutputBin HPBooklet *PageSize w558h774
+*UIConstraints: *OutputBin HPBooklet *PageRegion w558h774
+*UIConstraints: *OutputBin HPBooklet *PageSize w774h1116
+*UIConstraints: *OutputBin HPBooklet *PageRegion w774h1116
+*UIConstraints: *OutputBin HPBooklet *PageSize Env10
+*UIConstraints: *OutputBin HPBooklet *PageRegion Env10
+*UIConstraints: *OutputBin HPBooklet *PageSize EnvMonarch
+*UIConstraints: *OutputBin HPBooklet *PageRegion EnvMonarch
+*UIConstraints: *OutputBin HPBooklet *PageSize EnvDL
+*UIConstraints: *OutputBin HPBooklet *PageRegion EnvDL
+*UIConstraints: *OutputBin HPBooklet *PageSize EnvC5
+*UIConstraints: *OutputBin HPBooklet *PageRegion EnvC5
+*UIConstraints: *OutputBin HPBooklet *PageSize EnvISOB5
+*UIConstraints: *OutputBin HPBooklet *PageRegion EnvISOB5
+
+*% Force Output destination to MailBox  if any of the Mailbox options are choosen
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin PrinterDefault
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin PrinterDefault
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin Upper
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin Upper
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin Left
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin Left
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin StackerFaceUp
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin StackerFaceUp
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin Stacker
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin Stacker
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin UStapler
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin UStapler
+
+*UIConstraints: *HPMailboxOptions Bin1 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin2 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin3 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin4 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin5 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin6 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin7 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin8 *OutputBin HPBooklet
+*UIConstraints: *HPMailboxOptions Bin1_8 *OutputBin HPBooklet
+
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin PrinterDefault *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin Upper *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin Left *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin StackerFaceUp *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin Stacker *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin UStapler *HPMailboxOptions Bin1_8
+
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin1
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin2
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin3
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin4
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin5
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin6
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin7
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin8
+*UIConstraints: *OutputBin HPBooklet *HPMailboxOptions Bin1_8
+
+*% Media types
+*%------------------------------------------------------
+*% Trays 2,3 or 4
+*UIConstraints: *InputSlot Tray2 *MediaType Envelope
+*UIConstraints: *InputSlot Tray3 *MediaType Envelope
+*UIConstraints: *InputSlot Tray4Optional *MediaType Envelope
+
+*UIConstraints: *MediaType Envelope *InputSlot Tray2
+*UIConstraints: *MediaType Envelope *InputSlot Tray3
+*UIConstraints: *MediaType Envelope *InputSlot Tray4Optional
+
+*UIConstraints: *InputSlot Tray2 *MediaType Labels
+*UIConstraints: *InputSlot Tray3 *MediaType Labels
+*UIConstraints: *InputSlot Tray4Optional *MediaType Labels
+
+*UIConstraints: *MediaType Labels *InputSlot Tray2
+*UIConstraints: *MediaType Labels *InputSlot Tray3
+*UIConstraints: *MediaType Labels *InputSlot Tray4Optional
+
+*% Duplex
+*UIConstraints: *MediaType Transparency *Duplex DuplexNoTumble
+*UIConstraints: *MediaType Labels       *Duplex DuplexNoTumble
+*UIConstraints: *MediaType Envelope     *Duplex DuplexNoTumble
+*UIConstraints: *Duplex DuplexNoTumble	*MediaType Transparency
+*UIConstraints: *Duplex DuplexNoTumble	*MediaType Labels
+*UIConstraints: *Duplex DuplexNoTumble	*MediaType Envelope
+
+*UIConstraints: *MediaType Transparency *Duplex DuplexTumble
+*UIConstraints: *MediaType Labels       *Duplex DuplexTumble
+*UIConstraints: *MediaType Envelope     *Duplex DuplexTumble
+*UIConstraints: *Duplex DuplexTumble	*MediaType Transparency
+*UIConstraints: *Duplex DuplexTumble	*MediaType Labels
+*UIConstraints: *Duplex DuplexTumble	*MediaType Envelope
+
+*% Face up Stacker bin for Stacker, Stapler, Booklet Maker
+*UIConstraints: *OutputBin Stacker *MediaType Labels
+*UIConstraints: *OutputBin Stacker *MediaType Transparency
+*UIConstraints: *OutputBin Stacker *MediaType Rough
+*UIConstraints: *OutputBin Stacker *MediaType Envelope
+
+*UIConstraints: *MediaType Labels *OutputBin Stacker
+*UIConstraints: *MediaType Transparency *OutputBin Stacker
+*UIConstraints: *MediaType Rough *OutputBin Stacker
+*UIConstraints: *MediaType Envelope *OutputBin Stacker
+
+*% Stapler
+*UIConstraints: *OutputBin UStapler *MediaType Labels
+*UIConstraints: *OutputBin UStapler *MediaType Envelope
+*UIConstraints: *OutputBin UStapler *MediaType Transparency
+
+*UIConstraints: *MediaType Labels *OutputBin UStapler
+*UIConstraints: *MediaType Envelope *OutputBin UStapler
+*UIConstraints: *MediaType Transparency *OutputBin UStapler
+
+*% Booklet bin
+*UIConstraints: *OutputBin HPBooklet *MediaType Transparency
+*UIConstraints: *OutputBin HPBooklet *MediaType Labels
+*UIConstraints: *OutputBin HPBooklet *MediaType Envelope
+
+*UIConstraints: *MediaType Transparency *OutputBin HPBooklet
+*UIConstraints: *MediaType Labels *OutputBin HPBooklet
+*UIConstraints: *MediaType Envelope *OutputBin HPBooklet
+
+*% Can't staple Custom sizes in the Booklet Maker, Booklet Bin or Tray 4)
+*%---------------------------------------------------------------------
+*NonUIConstraints: *CustomPageSize True *OutputBin HPBooklet
+*NonUIConstraints: *OutputBin HPBooklet *CustomPageSize True 
+
+
+
+*% Contraints on Mailbox Mode and the Mailbox Bins
+*%---------------------------------------------------
+*%Mailbox Mode
+*UIConstraints: *HPMailboxMode MBMode *HPMailboxOptions Bin1_8
+*UIConstraints: *HPMailboxOptions Bin1_8 *HPMailboxMode MBMode
+
+*% Stacker Mode
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode StackerMode *HPMailboxOptions Bin8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin2 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin3 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin4 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin5 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin6 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin7 *HPMailboxMode StackerMode
+*UIConstraints: *HPMailboxOptions Bin8 *HPMailboxMode StackerMode
+
+*% Separator Mode
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode SeparatorMode *HPMailboxOptions Bin8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin2 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin3 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin4 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin5 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin6 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin7 *HPMailboxMode SeparatorMode
+*UIConstraints: *HPMailboxOptions Bin8 *HPMailboxMode SeparatorMode 
+
+*% Sorter Collator Mode
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin1
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin2
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin3
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin4
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin5
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin6
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin7
+*UIConstraints: *HPMailboxMode SorterCollatorMode *HPMailboxOptions Bin8
+
+*UIConstraints: *HPMailboxOptions Bin1 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin2 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin3 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin4 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin5 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin6 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin7 *HPMailboxMode SorterCollatorMode
+*UIConstraints: *HPMailboxOptions Bin8 *HPMailboxMode SorterCollatorMode
+
+*% Fills not allowed with overlays
+*%=============================================
+
+
+*% ### The following lines are left in for visibility but commented out because though it
+*% ### seems like requiring a PIN for a private job is the thing to do, the way it works
+*% ### from the driver is very annoying. If you select a Private Job the UI constraint
+*% ### immediately presents an alert saying that you must have a PIN without giving the
+*% ### user a chance to even get to the PIN field yet. It would be nice if the alert were
+*% ### presented when the Print button is pushed, but it isn't.
+*%Job Retention not allowed unless printer has a hard disk
+
+
+*% ===================================
+
+*% =================================
+*% =================================
+
+*%================================
+*%    Media Output Destination
+*%================================
+*OpenGroup: HPFinishing/Finishing Panel
+*da.Translation HPFinishing/Finisher-indstillinger: ""
+*de.Translation HPFinishing/Optionen zum Fertigstellen: ""
+*es.Translation HPFinishing/Acabado: ""
+*fi.Translation HPFinishing/Viimeistelyasetukset: ""
+*fr.Translation HPFinishing/Finition: ""
+*it.Translation HPFinishing/Finitura: ""
+*ja.Translation HPFinishing/仕上げオプション: ""
+*ko.Translation HPFinishing/마감장치 옵션: ""
+*nl.Translation HPFinishing/Afwerkingsopties: ""
+*nb.Translation HPFinishing/Etterbehandlingsvalg: ""
+*pt.Translation HPFinishing/Acabamento: ""
+*sv.Translation HPFinishing/Efterbehandling: ""
+*zh_CN.Translation HPFinishing/完成选项: ""
+*zh_TW.Translation HPFinishing/外觀選項: ""
+*% ================================================
+*% Constraints on MediaType for Booklet printing
+*% ================================================
+*UIConstraints: *MediaType Transparency *HPBookletFilter True
+*UIConstraints: *MediaType Labels *HPBookletFilter True
+*UIConstraints: *MediaType Envelope *HPBookletFilter True
+
+*UIConstraints: *HPBookletFilter True *MediaType Transparency
+*UIConstraints: *HPBookletFilter True *MediaType Labels
+*UIConstraints: *HPBookletFilter True *MediaType Envelope
+*UIConstraints: *HPOption_Duplexer False *HPBookletFilter True
+*% ================================================
+*% Booklet
+*% ================================================
+*% Booklet printing is not allowed without Auto Duplex turned on
+*UIConstraints: *HPBookletFilter True *Duplex None
+*UIConstraints: *Duplex None *HPBookletFilter True
+*OpenUI *HPBookletFilter/Format Output As Booklet: Boolean
+*OrderDependency: 60 AnySetup *HPBookletFilter
+*DefaultHPBookletFilter: False
+*da.Translation HPBookletFilter/Formater Udskrift Som Brochure: ""
+*de.Translation HPBookletFilter/Ausgabeformat als Broschüre: ""
+*es.Translation HPBookletFilter/Formatear impr. como folleto: ""
+*fi.Translation HPBookletFilter/Tulostetaan kirjasena: ""
+*fr.Translation HPBookletFilter/Formate la sortie comme brochure: ""
+*it.Translation HPBookletFilter/Output in formato di opuscolo: ""
+*ja.Translation HPBookletFilter/ブックレット印刷用フォーマット: ""
+*ko.Translation HPBookletFilter/소책자 형식으로 출력: ""
+*nl.Translation HPBookletFilter/Opmaakuitvoer als brochure: ""
+*nb.Translation HPBookletFilter/Formater utskrift som hefte: ""
+*pt.Translation HPBookletFilter/Formatar saída como folheto: ""
+*sv.Translation HPBookletFilter/Broschyr som utskriftsformat: ""
+*zh_CN.Translation HPBookletFilter/以小册子格式输出: ""
+*zh_TW.Translation HPBookletFilter/輸出格式為手冊: ""
+
+*HPBookletFilter True/Yes: ""
+*da.HPBookletFilter True/På: ""
+*de.HPBookletFilter True/Ein: ""
+*es.HPBookletFilter True/Activado: ""
+*fi.HPBookletFilter True/käytössä: ""
+*fr.HPBookletFilter True/Activé: ""
+*it.HPBookletFilter True/Attiva: ""
+*ja.HPBookletFilter True/オン: ""
+*ko.HPBookletFilter True/켜짐: ""
+*nl.HPBookletFilter True/Aan: ""
+*nb.HPBookletFilter True/På: ""
+*pt.HPBookletFilter True/Ativado: ""
+*sv.HPBookletFilter True/På: ""
+*zh_CN.HPBookletFilter True/开: ""
+*zh_TW.HPBookletFilter True/開啟: ""
+
+*HPBookletFilter False/No: ""
+*da.HPBookletFilter False/Fra: ""
+*de.HPBookletFilter False/Aus: ""
+*es.HPBookletFilter False/Desactivado: ""
+*fi.HPBookletFilter False/Ei käytössä: ""
+*fr.HPBookletFilter False/Désactivé: ""
+*it.HPBookletFilter False/Disattivata: ""
+*ja.HPBookletFilter False/オフ: ""
+*ko.HPBookletFilter False/꺼짐: ""
+*nl.HPBookletFilter False/Uit: ""
+*nb.HPBookletFilter False/Av: ""
+*pt.HPBookletFilter False/Desativado: ""
+*sv.HPBookletFilter False/Av: ""
+*zh_CN.HPBookletFilter False/关: ""
+*zh_TW.HPBookletFilter False/關閉: ""
+
+*CloseUI: *HPBookletFilter
+
+*OpenUI *HPBookletBackCover/Last Page Is Back Cover: Boolean
+*OrderDependency: 61 AnySetup *HPBookletBackCover
+*DefaultHPBookletBackCover: False
+*da.Translation HPBookletBackCover/Sidste Side Er Bagomslag: ""
+*de.Translation HPBookletBackCover/Endseite = Broschürenrücken: ""
+*es.Translation HPBookletBackCover/La últ. pág. es la contraport.: ""
+*fi.Translation HPBookletBackCover/Viimeinen sivu on takakansi: ""
+*fr.Translation HPBookletBackCover/Dernière page page de garde: ""
+*it.Translation HPBookletBackCover/Ultima pag come retrocopertina: ""
+*ja.Translation HPBookletBackCover/最後のページを背表紙にする: ""
+*ko.Translation HPBookletBackCover/마지막 페이지는 뒤 표지입니다: ""
+*nl.Translation HPBookletBackCover/Laatste pagina is achterblad: ""
+*nb.Translation HPBookletBackCover/Siste side er bakside: ""
+*pt.Translation HPBookletBackCover/A última pág. é a quarta capa: ""
+*sv.Translation HPBookletBackCover/Sista sidan är bakre omslag: ""
+*zh_CN.Translation HPBookletBackCover/最后一页是封底: ""
+*zh_TW.Translation HPBookletBackCover/最後一頁為封底: ""
+
+*HPBookletBackCover True/Yes: ""
+*da.HPBookletBackCover True/På: ""
+*de.HPBookletBackCover True/Ein: ""
+*es.HPBookletBackCover True/Activado: ""
+*fi.HPBookletBackCover True/käytössä: ""
+*fr.HPBookletBackCover True/Activé: ""
+*it.HPBookletBackCover True/Attiva: ""
+*ja.HPBookletBackCover True/オン: ""
+*ko.HPBookletBackCover True/켜짐: ""
+*nl.HPBookletBackCover True/Aan: ""
+*nb.HPBookletBackCover True/På: ""
+*pt.HPBookletBackCover True/Ativado: ""
+*sv.HPBookletBackCover True/På: ""
+*zh_CN.HPBookletBackCover True/开: ""
+*zh_TW.HPBookletBackCover True/開啟: ""
+
+*HPBookletBackCover False/No: ""
+*da.HPBookletBackCover False/Fra: ""
+*de.HPBookletBackCover False/Aus: ""
+*es.HPBookletBackCover False/Desactivado: ""
+*fi.HPBookletBackCover False/Ei käytössä: ""
+*fr.HPBookletBackCover False/Désactivé: ""
+*it.HPBookletBackCover False/Disattivata: ""
+*ja.HPBookletBackCover False/オフ: ""
+*ko.HPBookletBackCover False/꺼짐: ""
+*nl.HPBookletBackCover False/Uit: ""
+*nb.HPBookletBackCover False/Av: ""
+*pt.HPBookletBackCover False/Desativado: ""
+*sv.HPBookletBackCover False/Av: ""
+*zh_CN.HPBookletBackCover False/关: ""
+*zh_TW.HPBookletBackCover False/關閉: ""
+
+*CloseUI: *HPBookletBackCover
+
+*OpenUI *HPBookletPageOrder/Page Order: PickOne
+*OrderDependency: 62 AnySetup *HPBookletPageOrder
+*DefaultHPBookletPageOrder: Normal
+*da.Translation HPBookletPageOrder/Siderækkefølge: ""
+*de.Translation HPBookletPageOrder/Seitenreihenfolge: ""
+*es.Translation HPBookletPageOrder/Orden de páginas: ""
+*fi.Translation HPBookletPageOrder/Sivujärjestys: ""
+*fr.Translation HPBookletPageOrder/Ordre des pages: ""
+*it.Translation HPBookletPageOrder/Ordine delle pagine: ""
+*ja.Translation HPBookletPageOrder/ページ方向: ""
+*ko.Translation HPBookletPageOrder/페이지 순서: ""
+*nl.Translation HPBookletPageOrder/Paginavolgorde: ""
+*nb.Translation HPBookletPageOrder/Siderekkefølge: ""
+*pt.Translation HPBookletPageOrder/Ordem das páginas: ""
+*sv.Translation HPBookletPageOrder/Sidföljd: ""
+*zh_CN.Translation HPBookletPageOrder/页面顺序: ""
+*zh_TW.Translation HPBookletPageOrder/頁序: ""
+
+*HPBookletPageOrder Normal/Pages Bound on the Left: ""
+*da.HPBookletPageOrder Normal/Sider bundet i venstre side: ""
+*de.HPBookletPageOrder Normal/Seiten links gebunden: ""
+*es.HPBookletPageOrder Normal/Encuadernación a la izquierda: ""
+*fi.HPBookletPageOrder Normal/Sivut sidottu vasemmalle: ""
+*fr.HPBookletPageOrder Normal/Pages reliées sur la gauche: ""
+*it.HPBookletPageOrder Normal/Pagine rilegate a sinistra: ""
+*ja.HPBookletPageOrder Normal/とじしろ左: ""
+*ko.HPBookletPageOrder Normal/왼쪽 제본 페이지: ""
+*nl.HPBookletPageOrder Normal/Links gebonden pagina’s: ""
+*nb.HPBookletPageOrder Normal/Sider bundet på venstre side: ""
+*pt.HPBookletPageOrder Normal/Páginas encadernadas à esquerda: ""
+*sv.HPBookletPageOrder Normal/Sidorna binds i vänsterkanten: ""
+*zh_CN.HPBookletPageOrder Normal/左侧装订: ""
+*zh_TW.HPBookletPageOrder Normal/左邊裝訂: ""
+
+*HPBookletPageOrder Asian/Pages Bound on the Right: ""
+*da.HPBookletPageOrder Asian/Sider bundet i højre side: ""
+*de.HPBookletPageOrder Asian/Seiten rechts gebunden: ""
+*es.HPBookletPageOrder Asian/Encuadernación a la derecha: ""
+*fi.HPBookletPageOrder Asian/Sivut sidottu oikealle: ""
+*fr.HPBookletPageOrder Asian/Pages reliées sur la droite: ""
+*it.HPBookletPageOrder Asian/Pagine rilegate a destra: ""
+*ja.HPBookletPageOrder Asian/とじしろ右: ""
+*ko.HPBookletPageOrder Asian/오른쪽 제본 페이지: ""
+*nl.HPBookletPageOrder Asian/Rechts gebonden pagina’s: ""
+*nb.HPBookletPageOrder Asian/Sider bundet på høyre side: ""
+*pt.HPBookletPageOrder Asian/Páginas encadernadas à direita: ""
+*sv.HPBookletPageOrder Asian/Sidorna binds i högerkanten: ""
+*zh_CN.HPBookletPageOrder Asian/右侧装订: ""
+*zh_TW.HPBookletPageOrder Asian/右邊裝訂: ""
+
+*CloseUI: *HPBookletPageOrder
+
+*OpenUI *HPBookletScaling/Scaling: PickOne
+*OrderDependency: 63 AnySetup *HPBookletScaling
+*DefaultHPBookletScaling: Proportional
+*da.Translation HPBookletScaling/Skalering: ""
+*de.Translation HPBookletScaling/Skalierung: ""
+*es.Translation HPBookletScaling/Cambio de escala: ""
+*fi.Translation HPBookletScaling/Skaalaus: ""
+*fr.Translation HPBookletScaling/Mise à l'échelle: ""
+*it.Translation HPBookletScaling/Scala: ""
+*ja.Translation HPBookletScaling/拡大縮小: ""
+*ko.Translation HPBookletScaling/스케일링: ""
+*nl.Translation HPBookletScaling/Schaal aanpassen: ""
+*nb.Translation HPBookletScaling/Skalering: ""
+*pt.Translation HPBookletScaling/Escalonando: ""
+*sv.Translation HPBookletScaling/Skalning: ""
+*zh_CN.Translation HPBookletScaling/缩放: ""
+*zh_TW.Translation HPBookletScaling/縮放: ""
+
+*HPBookletScaling Proportional/Proportional: ""
+*da.HPBookletScaling Proportional/Proportional: ""
+*de.HPBookletScaling Proportional/Proportional: ""
+*es.HPBookletScaling Proportional/Proporcional: ""
+*fi.HPBookletScaling Proportional/Suhteutettu: ""
+*fr.HPBookletScaling Proportional/Proportionnel: ""
+*it.HPBookletScaling Proportional/Proporzionale: ""
+*ja.HPBookletScaling Proportional/自動均等調整: ""
+*ko.HPBookletScaling Proportional/비례: ""
+*nl.HPBookletScaling Proportional/Proportioneel: ""
+*nb.HPBookletScaling Proportional/Proporsjonal: ""
+*pt.HPBookletScaling Proportional/Proporcional: ""
+*sv.HPBookletScaling Proportional/Proportionellt: ""
+*zh_CN.HPBookletScaling Proportional/按比例: ""
+*zh_TW.HPBookletScaling Proportional/比例: ""
+
+*HPBookletScaling FitPage/Fit To Page: ""
+*da.HPBookletScaling FitPage/Tilpas Til Side: ""
+*de.HPBookletScaling FitPage/Seite anpassen: ""
+*es.HPBookletScaling FitPage/Ajustar página: ""
+*fi.HPBookletScaling FitPage/Sovita sivu: ""
+*fr.HPBookletScaling FitPage/Ajuster la page: ""
+*it.HPBookletScaling FitPage/Adattamento pagina: ""
+*ja.HPBookletScaling FitPage/全体表示: ""
+*ko.HPBookletScaling FitPage/페이지에 맞춤: ""
+*nl.HPBookletScaling FitPage/Passend op pagina: ""
+*nb.HPBookletScaling FitPage/Tilpass til siden: ""
+*pt.HPBookletScaling FitPage/Ajuste a página: ""
+*sv.HPBookletScaling FitPage/Anpassa sida: ""
+*zh_CN.HPBookletScaling FitPage/适合页面: ""
+*zh_TW.HPBookletScaling FitPage/符合頁面: ""
+
+*CloseUI: *HPBookletScaling
+
+*% These values are set of PageSize settings so we need find
+*% the way to refer on to PageSize values 
+
+
+*OpenUI *HPBookletPageSize/Paper For Booklet: PickOne
+*OrderDependency: 66 AnySetup *HPBookletPageSize
+*DefaultHPBookletPageSize: Letter
+*da.Translation HPBookletPageSize/Format På Brochure: ""
+*de.Translation HPBookletPageSize/Papier für Broschüre: ""
+*es.Translation HPBookletPageSize/Papel para folleto: ""
+*fi.Translation HPBookletPageSize/Kirjasen paperi: ""
+*fr.Translation HPBookletPageSize/Papier pour brochure: ""
+*it.Translation HPBookletPageSize/Carta per opuscolo: ""
+*ja.Translation HPBookletPageSize/ブックレットの用紙: ""
+*ko.Translation HPBookletPageSize/소책자용 용지: ""
+*nl.Translation HPBookletPageSize/Papier voor brochure: ""
+*nb.Translation HPBookletPageSize/Papir for hefte: ""
+*pt.Translation HPBookletPageSize/Papel para folheto: ""
+*sv.Translation HPBookletPageSize/Papper för broschyr: ""
+*zh_CN.Translation HPBookletPageSize/用于小册子的纸张: ""
+*zh_TW.Translation HPBookletPageSize/用於手冊的紙張: ""
+
+
+*HPBookletPageSize Letter/Letter: ""
+*da.HPBookletPageSize Letter/Letter: ""
+*de.HPBookletPageSize Letter/Letter: ""
+*es.HPBookletPageSize Letter/Letter: ""
+*fi.HPBookletPageSize Letter/Letter: ""
+*fr.HPBookletPageSize Letter/Lettre: ""
+*it.HPBookletPageSize Letter/Letter: ""
+*ja.HPBookletPageSize Letter/レター: ""
+*ko.HPBookletPageSize Letter/레터: ""
+*nl.HPBookletPageSize Letter/Letter: ""
+*nb.HPBookletPageSize Letter/Letter: ""
+*pt.HPBookletPageSize Letter/Carta: ""
+*sv.HPBookletPageSize Letter/Letter: ""
+*zh_CN.HPBookletPageSize Letter/信纸: ""
+*zh_TW.HPBookletPageSize Letter/Letter: ""
+
+*HPBookletPageSize LetterSmall/Letter (Small): ""
+*da.HPBookletPageSize LetterSmall/Letter (lille): ""
+*de.HPBookletPageSize LetterSmall/Letter (Klein): ""
+*es.HPBookletPageSize LetterSmall/Letter (pequeño): ""
+*fi.HPBookletPageSize LetterSmall/Letter (pieni): ""
+*fr.HPBookletPageSize LetterSmall/Lettre (petit): ""
+*it.HPBookletPageSize LetterSmall/Letter (ridotta): ""
+*ja.HPBookletPageSize LetterSmall/レター (小): ""
+*ko.HPBookletPageSize LetterSmall/레터 (소): ""
+*nl.HPBookletPageSize LetterSmall/Letter (klein): ""
+*nb.HPBookletPageSize LetterSmall/Letter (lite): ""
+*pt.HPBookletPageSize LetterSmall/Carta (pequeno): ""
+*sv.HPBookletPageSize LetterSmall/Letter (litet): ""
+*zh_CN.HPBookletPageSize LetterSmall/信纸 (小): ""
+*zh_TW.HPBookletPageSize LetterSmall/Letter (小): ""
+
+*HPBookletPageSize Legal/Legal: ""
+*da.HPBookletPageSize Legal/Legal: ""
+*de.HPBookletPageSize Legal/Legal: ""
+*es.HPBookletPageSize Legal/Legal: ""
+*fi.HPBookletPageSize Legal/Legal: ""
+*fr.HPBookletPageSize Legal/Légal: ""
+*it.HPBookletPageSize Legal/Legal: ""
+*ja.HPBookletPageSize Legal/リーガル: ""
+*ko.HPBookletPageSize Legal/리갈: ""
+*nl.HPBookletPageSize Legal/Legal: ""
+*nb.HPBookletPageSize Legal/Legal: ""
+*pt.HPBookletPageSize Legal/Legal: ""
+*sv.HPBookletPageSize Legal/Legal: ""
+*zh_CN.HPBookletPageSize Legal/Legal: ""
+*zh_TW.HPBookletPageSize Legal/Legal: ""
+
+*HPBookletPageSize LegalSmall/Legal (Small): ""
+*da.HPBookletPageSize LegalSmall/Legal (lille): ""
+*de.HPBookletPageSize LegalSmall/Legal (Klein): ""
+*es.HPBookletPageSize LegalSmall/Legal (pequeño): ""
+*fi.HPBookletPageSize LegalSmall/Legal (pieni): ""
+*fr.HPBookletPageSize LegalSmall/Légal (petit): ""
+*it.HPBookletPageSize LegalSmall/Legal (ridotto): ""
+*ja.HPBookletPageSize LegalSmall/リーガル (小): ""
+*ko.HPBookletPageSize LegalSmall/리갈 (소): ""
+*nl.HPBookletPageSize LegalSmall/Legal (klein): ""
+*nb.HPBookletPageSize LegalSmall/Legal (lite): ""
+*pt.HPBookletPageSize LegalSmall/Legal (pequeno): ""
+*sv.HPBookletPageSize LegalSmall/Legal (litet): ""
+*zh_CN.HPBookletPageSize LegalSmall/Legal (小): ""
+*zh_TW.HPBookletPageSize LegalSmall/Legal (小): ""
+
+*HPBookletPageSize Executive/Executive: ""
+*da.HPBookletPageSize Executive/Executive: ""
+*de.HPBookletPageSize Executive/Executive: ""
+*es.HPBookletPageSize Executive/Ejecutivo: ""
+*fi.HPBookletPageSize Executive/Executive: ""
+*fr.HPBookletPageSize Executive/Exécutif: ""
+*it.HPBookletPageSize Executive/Executive: ""
+*ja.HPBookletPageSize Executive/エグゼクティブ: ""
+*ko.HPBookletPageSize Executive/Executive: ""
+*nl.HPBookletPageSize Executive/Executive: ""
+*nb.HPBookletPageSize Executive/Executive: ""
+*pt.HPBookletPageSize Executive/Executivo: ""
+*sv.HPBookletPageSize Executive/Executive: ""
+*zh_CN.HPBookletPageSize Executive/Executive: ""
+*zh_TW.HPBookletPageSize Executive/Executive: ""
+
+*HPBookletPageSize HalfLetter/Statement: ""
+*da.HPBookletPageSize HalfLetter/Statement: ""
+*de.HPBookletPageSize HalfLetter/Statement: ""
+*es.HPBookletPageSize HalfLetter/Declaración: ""
+*fi.HPBookletPageSize HalfLetter/Statement: ""
+*fr.HPBookletPageSize HalfLetter/1/2 Lettre: ""
+*it.HPBookletPageSize HalfLetter/Dichiarazione: ""
+*ja.HPBookletPageSize HalfLetter/Statement: ""
+*ko.HPBookletPageSize HalfLetter/2절 레터: ""
+*nl.HPBookletPageSize HalfLetter/1/2 Letter : ""
+*nb.HPBookletPageSize HalfLetter/1/2 Letter: ""
+*pt.HPBookletPageSize HalfLetter/Statement: ""
+*sv.HPBookletPageSize HalfLetter/Statement: ""
+*zh_CN.HPBookletPageSize HalfLetter/结算单: ""
+*zh_TW.HPBookletPageSize HalfLetter/Statement: ""
+
+*HPBookletPageSize w612h935/8.5x13: ""
+*da.HPBookletPageSize w612h935/8.5x13: ""
+*de.HPBookletPageSize w612h935/8.5x13: ""
+*es.HPBookletPageSize w612h935/8.5x13: ""
+*fi.HPBookletPageSize w612h935/8.5x13: ""
+*fr.HPBookletPageSize w612h935/8.5x13: ""
+*it.HPBookletPageSize w612h935/8.5x13: ""
+*ja.HPBookletPageSize w612h935/8.5x13: ""
+*ko.HPBookletPageSize w612h935/8.5x13: ""
+*nl.HPBookletPageSize w612h935/8.5x13: ""
+*nb.HPBookletPageSize w612h935/8.5x13: ""
+*pt.HPBookletPageSize w612h935/8.5x13: ""
+*sv.HPBookletPageSize w612h935/8.5x13: ""
+*zh_CN.HPBookletPageSize w612h935/8.5x13: ""
+*zh_TW.HPBookletPageSize w612h935/8.5x13: ""
+
+*HPBookletPageSize Tabloid/11x17: ""
+*da.HPBookletPageSize Tabloid/11x17: ""
+*de.HPBookletPageSize Tabloid/11x17 Zoll: ""
+*es.HPBookletPageSize Tabloid/11x17: ""
+*fi.HPBookletPageSize Tabloid/11x17: ""
+*fr.HPBookletPageSize Tabloid/11 x 17 pouces: ""
+*it.HPBookletPageSize Tabloid/11x17: ""
+*ja.HPBookletPageSize Tabloid/11x17: ""
+*ko.HPBookletPageSize Tabloid/11x17: ""
+*nl.HPBookletPageSize Tabloid/11x17: ""
+*nb.HPBookletPageSize Tabloid/11x17: ""
+*pt.HPBookletPageSize Tabloid/11x17: ""
+*sv.HPBookletPageSize Tabloid/11x17: ""
+*zh_CN.HPBookletPageSize Tabloid/11x17: ""
+*zh_TW.HPBookletPageSize Tabloid/11x17 : ""
+
+*HPBookletPageSize 12X18/12x18: ""
+*da.HPBookletPageSize 12X18/12x18: ""
+*de.HPBookletPageSize 12X18/12x18: ""
+*es.HPBookletPageSize 12X18/12x18: ""
+*fi.HPBookletPageSize 12X18/12x18: ""
+*fr.HPBookletPageSize 12X18/12x18: ""
+*it.HPBookletPageSize 12X18/12x18: ""
+*ja.HPBookletPageSize 12X18/12x18: ""
+*ko.HPBookletPageSize 12X18/12x18: ""
+*nl.HPBookletPageSize 12X18/12x18: ""
+*nb.HPBookletPageSize 12X18/12x18: ""
+*pt.HPBookletPageSize 12X18/12x18: ""
+*sv.HPBookletPageSize 12X18/12x18: ""
+*zh_CN.HPBookletPageSize 12X18/12x18: ""
+*zh_TW.HPBookletPageSize 12X18/12x18: ""
+
+*HPBookletPageSize A3/A3: ""
+*da.HPBookletPageSize A3/A3: ""
+*de.HPBookletPageSize A3/A3: ""
+*es.HPBookletPageSize A3/A3: ""
+*fi.HPBookletPageSize A3/A3: ""
+*fr.HPBookletPageSize A3/A3: ""
+*it.HPBookletPageSize A3/A3: ""
+*ja.HPBookletPageSize A3/A3: ""
+*ko.HPBookletPageSize A3/A3: ""
+*nl.HPBookletPageSize A3/A3: ""
+*nb.HPBookletPageSize A3/A3: ""
+*pt.HPBookletPageSize A3/A3: ""
+*sv.HPBookletPageSize A3/A3: ""
+*zh_CN.HPBookletPageSize A3/A3: ""
+*zh_TW.HPBookletPageSize A3/A3: ""
+
+*HPBookletPageSize RA3/RA3: ""
+*da.HPBookletPageSize RA3/RA3: ""
+*de.HPBookletPageSize RA3/RA3: ""
+*es.HPBookletPageSize RA3/RA3: ""
+*fi.HPBookletPageSize RA3/RA3: ""
+*fr.HPBookletPageSize RA3/RA3: ""
+*it.HPBookletPageSize RA3/RA3: ""
+*ja.HPBookletPageSize RA3/RA3: ""
+*ko.HPBookletPageSize RA3/RA3: ""
+*nl.HPBookletPageSize RA3/RA3: ""
+*nb.HPBookletPageSize RA3/RA3: ""
+*pt.HPBookletPageSize RA3/RA3: ""
+*sv.HPBookletPageSize RA3/RA3: ""
+*zh_CN.HPBookletPageSize RA3/RA3: ""
+*zh_TW.HPBookletPageSize RA3/RA3: ""
+
+*HPBookletPageSize A4/A4: ""
+*da.HPBookletPageSize A4/A4: ""
+*de.HPBookletPageSize A4/A4: ""
+*es.HPBookletPageSize A4/A4: ""
+*fi.HPBookletPageSize A4/A4: ""
+*fr.HPBookletPageSize A4/A4: ""
+*it.HPBookletPageSize A4/A4: ""
+*ja.HPBookletPageSize A4/A4: ""
+*ko.HPBookletPageSize A4/A4: ""
+*nl.HPBookletPageSize A4/A4: ""
+*nb.HPBookletPageSize A4/A4: ""
+*pt.HPBookletPageSize A4/A4: ""
+*sv.HPBookletPageSize A4/A4: ""
+*zh_CN.HPBookletPageSize A4/A4: ""
+*zh_TW.HPBookletPageSize A4/A4: ""
+
+*HPBookletPageSize A4Small/A4 (Small): ""
+*da.HPBookletPageSize A4Small/A4 (lille): ""
+*de.HPBookletPageSize A4Small/A4 (Klein): ""
+*es.HPBookletPageSize A4Small/A4 (pequeño): ""
+*fi.HPBookletPageSize A4Small/A4 (pieni): ""
+*fr.HPBookletPageSize A4Small/A4 (petit): ""
+*it.HPBookletPageSize A4Small/A4 (ridotta): ""
+*ja.HPBookletPageSize A4Small/A4 (小): ""
+*ko.HPBookletPageSize A4Small/A4 (소): ""
+*nl.HPBookletPageSize A4Small/A4 (klein): ""
+*nb.HPBookletPageSize A4Small/A4 (lite): ""
+*pt.HPBookletPageSize A4Small/A4 (pequeno): ""
+*sv.HPBookletPageSize A4Small/A4 (litet): ""
+*zh_CN.HPBookletPageSize A4Small/A4 (小): ""
+*zh_TW.HPBookletPageSize A4Small/A4 (小): ""
+
+*HPBookletPageSize A5/A5: ""
+*da.HPBookletPageSize A5/A5: ""
+*de.HPBookletPageSize A5/A5: ""
+*es.HPBookletPageSize A5/A5: ""
+*fi.HPBookletPageSize A5/A5: ""
+*fr.HPBookletPageSize A5/A5: ""
+*it.HPBookletPageSize A5/A5: ""
+*ja.HPBookletPageSize A5/A5: ""
+*ko.HPBookletPageSize A5/A5: ""
+*nl.HPBookletPageSize A5/A5: ""
+*nb.HPBookletPageSize A5/A5: ""
+*pt.HPBookletPageSize A5/A5: ""
+*sv.HPBookletPageSize A5/A5: ""
+*zh_CN.HPBookletPageSize A5/A5: ""
+*zh_TW.HPBookletPageSize A5/A5: ""
+
+*HPBookletPageSize B5/B5 (JIS): ""
+*da.HPBookletPageSize B5/JIS B5: ""
+*de.HPBookletPageSize B5/B5 (JIS): ""
+*es.HPBookletPageSize B5/JIS B5: ""
+*fi.HPBookletPageSize B5/JIS B5: ""
+*fr.HPBookletPageSize B5/JIS B5: ""
+*it.HPBookletPageSize B5/JIS B5: ""
+*ja.HPBookletPageSize B5/B5 (JIS): ""
+*ko.HPBookletPageSize B5/JIS B5: ""
+*nl.HPBookletPageSize B5/JIS B5: ""
+*nb.HPBookletPageSize B5/JIS B5: ""
+*pt.HPBookletPageSize B5/B5 JIS: ""
+*sv.HPBookletPageSize B5/JIS B5: ""
+*zh_CN.HPBookletPageSize B5/JIS B5: ""
+*zh_TW.HPBookletPageSize B5/JIS B5: ""
+
+*HPBookletPageSize B4/B4 (JIS): ""
+*da.HPBookletPageSize B4/JIS B4: ""
+*de.HPBookletPageSize B4/B4 (JIS): ""
+*es.HPBookletPageSize B4/JIS B4: ""
+*fi.HPBookletPageSize B4/JIS B4: ""
+*fr.HPBookletPageSize B4/JIS B4: ""
+*it.HPBookletPageSize B4/JIS B4: ""
+*ja.HPBookletPageSize B4/B4 (JIS): ""
+*ko.HPBookletPageSize B4/JIS B4: ""
+*nl.HPBookletPageSize B4/JIS B4: ""
+*nb.HPBookletPageSize B4/JIS B4: ""
+*pt.HPBookletPageSize B4/B4 JIS: ""
+*sv.HPBookletPageSize B4/JIS B4: ""
+*zh_CN.HPBookletPageSize B4/JIS B4: ""
+*zh_TW.HPBookletPageSize B4/JIS B4: ""
+
+*HPBookletPageSize w612h936/Executive (JIS): ""
+*da.HPBookletPageSize w612h936/Executive (JIS): ""
+*de.HPBookletPageSize w612h936/Executive (JIS): ""
+*es.HPBookletPageSize w612h936/Ejecutivo (JIS): ""
+*fi.HPBookletPageSize w612h936/Executive (JIS): ""
+*fr.HPBookletPageSize w612h936/Exécutif (JIS): ""
+*it.HPBookletPageSize w612h936/Executive (JIS): ""
+*ja.HPBookletPageSize w612h936/エグゼクティブ (JIS): ""
+*ko.HPBookletPageSize w612h936/Executive(JIS): ""
+*nl.HPBookletPageSize w612h936/Executive (JIS): ""
+*nb.HPBookletPageSize w612h936/Executive (JIS): ""
+*pt.HPBookletPageSize w612h936/Executivo (JIS): ""
+*sv.HPBookletPageSize w612h936/Executive (JIS): ""
+*zh_CN.HPBookletPageSize w612h936/Executive (JIS): ""
+*zh_TW.HPBookletPageSize w612h936/Executive (JIS): ""
+
+*HPBookletPageSize w774h1116/8K: ""
+*da.HPBookletPageSize w774h1116/8K: ""
+*de.HPBookletPageSize w774h1116/8K: ""
+*es.HPBookletPageSize w774h1116/8K: ""
+*fi.HPBookletPageSize w774h1116/8K: ""
+*fr.HPBookletPageSize w774h1116/8K: ""
+*it.HPBookletPageSize w774h1116/8K: ""
+*ja.HPBookletPageSize w774h1116/8K: ""
+*ko.HPBookletPageSize w774h1116/8K: ""
+*nl.HPBookletPageSize w774h1116/8K: ""
+*nb.HPBookletPageSize w774h1116/8K: ""
+*pt.HPBookletPageSize w774h1116/8K: ""
+*sv.HPBookletPageSize w774h1116/8K: ""
+*zh_CN.HPBookletPageSize w774h1116/8K: ""
+*zh_TW.HPBookletPageSize w774h1116/8K: ""
+
+*HPBookletPageSize w558h774/16K: ""
+*da.HPBookletPageSize w558h774/16K: ""
+*de.HPBookletPageSize w558h774/16K: ""
+*es.HPBookletPageSize w558h774/16K: ""
+*fi.HPBookletPageSize w558h774/16K: ""
+*fr.HPBookletPageSize w558h774/16K: ""
+*it.HPBookletPageSize w558h774/16K: ""
+*ja.HPBookletPageSize w558h774/16K: ""
+*ko.HPBookletPageSize w558h774/16K: ""
+*nl.HPBookletPageSize w558h774/16K: ""
+*nb.HPBookletPageSize w558h774/16K: ""
+*pt.HPBookletPageSize w558h774/16K: ""
+*sv.HPBookletPageSize w558h774/16K: ""
+*zh_CN.HPBookletPageSize w558h774/16K: ""
+*zh_TW.HPBookletPageSize w558h774/16K: ""
+
+*CloseUI: *HPBookletPageSize
+
+*%Constraints on HPBookletPageSize
+*%=============================================
+*UIConstraints: *HPBookletPageSize 12X18       *InputSlot Tray2
+*UIConstraints: *HPBookletPageSize 12X18       *InputSlot Tray3
+*UIConstraints: *HPBookletPageSize RA3       *InputSlot Tray2
+*UIConstraints: *HPBookletPageSize RA3       *InputSlot Tray3
+*UIConstraints: *InputSlot Tray2	  *HPBookletPageSize 12X18
+*UIConstraints: *InputSlot Tray3	  *HPBookletPageSize 12X18
+*UIConstraints: *InputSlot Tray2	  *HPBookletPageSize RA3
+*UIConstraints: *InputSlot Tray3	  *HPBookletPageSize RA3
+*UIConstraints: *HPBookletPageSize HalfLetter      *InputSlot Tray4Optional
+*UIConstraints: *HPBookletPageSize 12X18        	*InputSlot Tray4Optional
+*UIConstraints: *HPBookletPageSize RA3        	*InputSlot Tray4Optional
+*UIConstraints: *HPBookletPageSize A5        	*InputSlot Tray4Optional
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize HalfLetter
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize 12X18
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize A3
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize RA3
+*UIConstraints: *InputSlot Tray4Optional	*HPBookletPageSize A5
+*UIConstraints: *HPBookletPageSize Executive   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize HalfLetter   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w612h935   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize 12X18   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize A5   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize RA3   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize B5   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w612h936   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w558h774   *OutputBin HPBooklet
+*UIConstraints: *HPBookletPageSize w774h1116   *OutputBin HPBooklet
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize Executive
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize HalfLetter
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w612h935
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize 12X18
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize A5
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize RA3
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize B5
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w612h936
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w558h774
+*UIConstraints: *OutputBin HPBooklet *HPBookletPageSize w774h1116
+
+*OpenUI *OutputBin/Output Bin: PickOne
+*OrderDependency: 100 AnySetup *OutputBin
+*DefaultOutputBin: PrinterDefault
+*da.Translation OutputBin/Udskriftsbakke: ""
+*de.Translation OutputBin/Ausgabefach: ""
+*es.Translation OutputBin/Bandeja de salida: ""
+*fi.Translation OutputBin/Tulostelokero: ""
+*fr.Translation OutputBin/Bac de sortie: ""
+*it.Translation OutputBin/Scomparto di uscita: ""
+*ja.Translation OutputBin/排紙トレイ: ""
+*ko.Translation OutputBin/출력 용지함: ""
+*nl.Translation OutputBin/Uitvoerbak: ""
+*nb.Translation OutputBin/Utskuff: ""
+*pt.Translation OutputBin/Compartimento de saída: ""
+*sv.Translation OutputBin/Utmatningsfack: ""
+*zh_CN.Translation OutputBin/出纸槽: ""
+*zh_TW.Translation OutputBin/出紙槽: ""
+
+*OutputBin PrinterDefault/Printer's Current Setting: ""
+*da.OutputBin PrinterDefault/Printerens aktuelle indstilling: ""
+*de.OutputBin PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.OutputBin PrinterDefault/Configuración actual de la impresora: ""
+*fi.OutputBin PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.OutputBin PrinterDefault/Paramétrage actuel de l’imprimante: ""
+*it.OutputBin PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.OutputBin PrinterDefault/プリンタの現在の設定: ""
+*ko.OutputBin PrinterDefault/프린터의 현재 설정: ""
+*nl.OutputBin PrinterDefault/Huidige instelling van de printer: ""
+*nb.OutputBin PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.OutputBin PrinterDefault/Configuração atual da impressora: ""
+*sv.OutputBin PrinterDefault/Skrivarens inställning: ""
+*zh_CN.OutputBin PrinterDefault/打印机的当前设置: ""
+*zh_TW.OutputBin PrinterDefault/印表機目前的設定值: ""
+
+*OutputBin Upper/Top Bin: "<</Staple 0 /OutputType (TOP OUTPUT BIN)>> setpagedevice"
+*da.OutputBin Upper/ÿverste (forside nedad): ""
+*de.OutputBin Upper/Linkes (unten): ""
+*es.OutputBin Upper/Superior (boca abajo): ""
+*fi.OutputBin Upper/Ylälokero (tulostuspuoli lokero): ""
+*fr.OutputBin Upper/Bac supérieur (Verso): ""
+*it.OutputBin Upper/Vassoio superiore (verso il basso): ""
+*ja.OutputBin Upper/上部トレイ (下向き): ""
+*ko.OutputBin Upper/위쪽 용지함 (페이스다운): ""
+*nl.OutputBin Upper/Bovenbak (afdrukzijde naar beneden): ""
+*nb.OutputBin Upper/Øvre skuff (fors ned): ""
+*pt.OutputBin Upper/Bandeja superior (Voltado para baixo): ""
+*sv.OutputBin Upper/Övre (texten nedåt): ""
+*zh_CN.OutputBin Upper/上层纸盒 (下）): ""
+*zh_TW.OutputBin Upper/上層紙匣 (列印面向下): ""
+
+*OutputBin Left/Left Output Bin (Face Up): "
+   currentpagedevice /MediaProcessingDetails known
+   {   currentpagedevice /MediaProcessingDetails get /DeviceID known
+       {   currentpagedevice /MediaProcessingDetails get /DeviceID get (multifunction) search
+           { currentpagedevice /OutputAttributes get
+                {
+                pop pop pop
+                <</MediaProcessing (FACE_UP) /MediaProcessingDetails
+                <</MediaProcessingOption (FACE_UP) /MediaProcessingBoundary 0 /Type 8>> >> setpagedevice
+           		}
+           	}
+       } <</MediaProcessing (FACE_UP) /MediaProcessingDetails
+                <</MediaProcessingOption (FACE_UP) /MediaProcessingBoundary 0 /Type 8>> >> setpagedevice 
+   }
+   {<</Staple 0 /OutputType (FACE UP BIN)>> setpagedevice} ifelse   	
+"
+*End
+*da.OutputBin Left/Venstre (forside opad): ""
+*de.OutputBin Left/Oberes (oben): ""
+*es.OutputBin Left/Izquierda (boca arriba): ""
+*fi.OutputBin Left/Vasen (tulostuspuoli ylös): ""
+*fr.OutputBin Left/Bac gauche (Recto): ""
+*it.OutputBin Left/Scomparto di uscita sinistro (verso l’alto): ""
+*ja.OutputBin Left/左排紙トレイ (上向き): ""
+*ko.OutputBin Left/왼쪽 용지함 (페이스업): ""
+*nl.OutputBin Left/Linker uitvoerbak (afdrukzijde naar boven): ""
+*nb.OutputBin Left/Øvre venstre skuff (fors opp): ""
+*pt.OutputBin Left/Compartimento esquerdo (Voltado para cima): ""
+*sv.OutputBin Left/Vänster fack (texten uppåt): ""
+*zh_CN.OutputBin Left/左侧出纸槽 (上）): ""
+*zh_TW.OutputBin Left/左出紙槽 (列印面向上): ""
+
+*OutputBin StackerFaceUp/Stacker (Face-UP): "
+currentpagedevice /MediaProcessing known
+  { << /MediaProcessing (FACE_UP) /MediaProcessingDetails<<
+						  /MediaProcessingOption (FACE_UP)
+						  /MedaiProcessingBoundary 0 /ImageOrientation 0 /Type 8 >> >> setpagedevice
+  }
+  {
+  currentpagedevice /OutputAttributes get
+   4 known
+         {<</Staple 0 /OutputType (FACE UP BIN)>> setpagedevice}
+         {<</Staple 0 /OutputType (LEFT OUTPUT BIN)>> setpagedevice}
+       ifelse
+} ifelse"
+*End
+*da.OutputBin StackerFaceUp/Stabler (forside opad): ""
+*de.OutputBin StackerFaceUp/Stapel (Druckseite oben): ""
+*es.OutputBin StackerFaceUp/Apilador (boca arriba): ""
+*fi.OutputBin StackerFaceUp/Pinoaja (tulostuspuoli ylös): ""
+*fr.OutputBin StackerFaceUp/Récepteur (Recto): ""
+*it.OutputBin StackerFaceUp/Accumulatore (verso l’alto): ""
+*ja.OutputBin StackerFaceUp/スタッカ (上向き): ""
+*ko.OutputBin StackerFaceUp/스태커(페이스업): ""
+*nl.OutputBin StackerFaceUp/Stapelaar (afdrukzijde naar boven): ""
+*nb.OutputBin StackerFaceUp/Magasin (fors opp): ""
+*pt.OutputBin StackerFaceUp/Empilhador (Voltado para cima): ""
+*sv.OutputBin StackerFaceUp/Stapling (texten uppåt): ""
+*zh_CN.OutputBin StackerFaceUp/堆栈器（面朝上）: ""
+*zh_TW.OutputBin StackerFaceUp/堆疊器（列印面向上）: ""
+
+*OutputBin Stacker/Stacker (Face-Down): "
+  currentpagedevice /MediaProcessingDetails known{
+	currentpagedevice /MediaProcessingDetails get /ModelID get
+	(C8088B) search {<< /MediaProcessing (FACE_DOWN) /MediaProcessingDetails
+	<</MediaProcessingOption (FACE_DOWN)/MedaiProcessingBoundary 0
+	/ImageOrientation 0 /Type 8 >> >> setpagedevice put }
+            {<</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice} ifelse }
+  {<</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice} ifelse "
+*End
+*da.OutputBin Stacker/Stabler (forside nedad): ""
+*de.OutputBin Stacker/Stapel (Druckseite unten): ""
+*es.OutputBin Stacker/Apilador (boca abajo): ""
+*fi.OutputBin Stacker/Pinoaja (tulostuspuoli alas): ""
+*fr.OutputBin Stacker/Récepteur (Verso): ""
+*it.OutputBin Stacker/Accumulatore (verso il basso): ""
+*ja.OutputBin Stacker/スタッカ (下向き): ""
+*ko.OutputBin Stacker/스태커(페이스다운): ""
+*nl.OutputBin Stacker/Stapelaar (afdrukzijde naar beneden): ""
+*nb.OutputBin Stacker/Magasin (fors ned): ""
+*pt.OutputBin Stacker/Empilhador (Voltado para baixo): ""
+*sv.OutputBin Stacker/Stapling (texten nedåt): ""
+*zh_CN.OutputBin Stacker/堆栈器（面朝下）: ""
+*zh_TW.OutputBin Stacker/堆疊器（列印面向下）: ""
+
+*OutputBin HP8BinMB/8-Bin Mailbox: ""
+*da.OutputBin HP8BinMB/Postkasse med 8 bakker: ""
+*de.OutputBin HP8BinMB/Mailbox mit 8 Fächern: ""
+*es.OutputBin HP8BinMB/Buzón de 8 bandejas: ""
+*fi.OutputBin HP8BinMB/8 lokeron postilaatikko: ""
+*fr.OutputBin HP8BinMB/Trieuse à 8 bacs: ""
+*it.OutputBin HP8BinMB/Casella a 8 scomparti: ""
+*ja.OutputBin HP8BinMB/8 トレイメールボックス: ""
+*ko.OutputBin HP8BinMB/8단 우편함: ""
+*nl.OutputBin HP8BinMB/Postbus met 8 bakken: ""
+*nb.OutputBin HP8BinMB/Postkasse med 8 lommer: ""
+*pt.OutputBin HP8BinMB/Caixa de correio com oito compartimentos: ""
+*sv.OutputBin HP8BinMB/Sorterare med 8 fack: ""
+*zh_CN.OutputBin HP8BinMB/8 槽信箱: ""
+*zh_TW.OutputBin HP8BinMB/8 槽式信箱: ""
+
+*OutputBin UStapler/Stapler: ""
+*da.OutputBin UStapler/Hæfter: ""
+*de.OutputBin UStapler/Hefter: ""
+*es.OutputBin UStapler/Grapadora: ""
+*fi.OutputBin UStapler/Nitoja: ""
+*fr.OutputBin UStapler/Agrafeuse: ""
+*it.OutputBin UStapler/Cucitrice: ""
+*ja.OutputBin UStapler/ホチキス: ""
+*ko.OutputBin UStapler/스테이플러: ""
+*nl.OutputBin UStapler/Nietmachine: ""
+*nb.OutputBin UStapler/Stifteenhet : ""
+*pt.OutputBin UStapler/Grampeador: ""
+*sv.OutputBin UStapler/Häftning: ""
+*zh_CN.OutputBin UStapler/装订器: ""
+*zh_TW.OutputBin UStapler/裝訂機: ""
+
+*OutputBin HPBooklet/Booklet Bin: "
+  << /MediaProcessing (BOOKLET_MAKER) /MediaProcessingDetails <<
+  /MediaProcessingOption (BOOKLET_MAKER) /MedaiProcessingBoundary 0
+  /ImageOrientation 0 /Type 8 >> >> setpagedevice
+  << /Staple 0 /OutputType (OPTIONAL OUTBIN 2) >> setpagedevice
+"
+*End
+*da.OutputBin HPBooklet/Brochurebakke: ""
+*de.OutputBin HPBooklet/Broschürenfach: ""
+*es.OutputBin HPBooklet/Apiladora de folletos: ""
+*fi.OutputBin HPBooklet/Vihkon lokero: ""
+*fr.OutputBin HPBooklet/Bac à brochures: ""
+*it.OutputBin HPBooklet/Scomparto opuscoli: ""
+*ja.OutputBin HPBooklet/ブックレット ビン: ""
+*ko.OutputBin HPBooklet/소책자 용지함: ""
+*nl.OutputBin HPBooklet/Brochurebak: ""
+*nb.OutputBin HPBooklet/Hefteutskuff: ""
+*pt.OutputBin HPBooklet/Compartimento de folheto: ""
+*sv.OutputBin HPBooklet/Fack för broschyr: ""
+*zh_CN.OutputBin HPBooklet/小册子纸槽: ""
+*zh_TW.OutputBin HPBooklet/書冊出紙槽: ""
+
+*?OutputBin: "save
+ currentpagedevice /OutputAttributes get dup
+ 5 known
+ {/Priority get 0 get
+    [(Upper) (Left) (Reserved1) (Reserved2) (OutputBin1)
+     (OutputBin2) (OutputBin3) (OutputBin4) (OutputBin5) (OutputBin6) (OutputBin7) (OutputBin8)] exch get = flush}
+ {/Priority get 0 get
+    [(Upper) (Left)  (Reserved1) (Reserved2) (Stacker)] exch get = flush} ifelse
+restore
+"
+*End
+*CloseUI: *OutputBin
+
+*%=== 3000 Sheet Stacker/Stapler Stapler Options =========================
+*OpenUI *HPStaplerOptions/Finishing Options: PickOne
+*OrderDependency: 45 AnySetup *HPStaplerOptions
+*DefaultHPStaplerOptions: PrintersDefault
+*da.Translation HPStaplerOptions/Hæftningsvalg/Foldning: ""
+*de.Translation HPStaplerOptions/Heftoptionen: ""
+*es.Translation HPStaplerOptions/Opción Grapadora: ""
+*fi.Translation HPStaplerOptions/Nitoja-asetus: ""
+*fr.Translation HPStaplerOptions/Option de l’agrafeuse: ""
+*it.Translation HPStaplerOptions/Opzione di cucitura: ""
+*ja.Translation HPStaplerOptions/ステイプル留め/折り畳み: ""
+*ko.Translation HPStaplerOptions/스테이플러 선택사항: ""
+*nl.Translation HPStaplerOptions/Nietmethode: ""
+*nb.Translation HPStaplerOptions/Stiftealternativ: ""
+*pt.Translation HPStaplerOptions/Opção de Grampeador: ""
+*sv.Translation HPStaplerOptions/Häftningsalternativ: ""
+*zh_CN.Translation HPStaplerOptions/装订器选项: ""
+*zh_TW.Translation HPStaplerOptions/裝訂機選項: ""
+
+*HPStaplerOptions PrintersDefault/Printer's Current Setting: "
+  <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (NONE) /MediaProcessingBoundary 0
+    /ImageOrientation 1 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions PrintersDefault/Ingen: ""
+*de.HPStaplerOptions PrintersDefault/Aktuelle Einstellung des Druckers: ""
+*es.HPStaplerOptions PrintersDefault/Configuración actual de la impresora: ""
+*fi.HPStaplerOptions PrintersDefault/Kirjoittimen nykyinen asetus: ""
+*fr.HPStaplerOptions PrintersDefault/Paramétrage actuel de l’imprimante: ""
+*it.HPStaplerOptions PrintersDefault/Impostazione corrente stampante: ""
+*ja.HPStaplerOptions PrintersDefault/なし: ""
+*ko.HPStaplerOptions PrintersDefault/프린터의 현재 설정: ""
+*nl.HPStaplerOptions PrintersDefault/Huidige printerinstellingen: ""
+*nb.HPStaplerOptions PrintersDefault/Skriverens gjeldende innstilling: ""
+*pt.HPStaplerOptions PrintersDefault/Configuração atual da Impressora: ""
+*sv.HPStaplerOptions PrintersDefault/Skrivarens inställning: ""
+*zh_CN.HPStaplerOptions PrintersDefault/打印机当前设定值: ""
+*zh_TW.HPStaplerOptions PrintersDefault/印表機目前設定值: ""
+
+*HPStaplerOptions 1diagonal/1 Staple, diagonal: "
+  <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (ANGLED_STAPLE) /MediaProcessingBoundary 0
+    /ImageOrientation 0 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 1diagonal/En hæfteklamme, diagonal: ""
+*de.HPStaplerOptions 1diagonal/Eine Heftklammer, diagonal: ""
+*es.HPStaplerOptions 1diagonal/Una grapa, diagonal: ""
+*fi.HPStaplerOptions 1diagonal/Yksi niitti, vino: ""
+*fr.HPStaplerOptions 1diagonal/Une agrafe, diagonal: ""
+*it.HPStaplerOptions 1diagonal/Un punto, diagonale: ""
+*ja.HPStaplerOptions 1diagonal/ステイプル, 斜め: ""
+*ko.HPStaplerOptions 1diagonal/스테이플러 1개, 대각선: ""
+*nl.HPStaplerOptions 1diagonal/Eén nietje diagonal: ""
+*nb.HPStaplerOptions 1diagonal/Én stift, diagonalt: ""
+*pt.HPStaplerOptions 1diagonal/Um grampo á diagonal: ""
+*sv.HPStaplerOptions 1diagonal/1 häftklammer, diagonal: ""
+*zh_CN.HPStaplerOptions 1diagonal/一个订书钉, 对角: ""
+*zh_TW.HPStaplerOptions 1diagonal/1個訂書釘: ""
+
+*HPStaplerOptions 1parallel/1 Staple, parallel: "
+   <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (ONE_STAPLE) /MediaProcessingBoundary 0
+    /ImageOrientation 0 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 1parallel/En hæfteklamme, parallel: ""
+*de.HPStaplerOptions 1parallel/Eine Heftklammer, parallel: ""
+*es.HPStaplerOptions 1parallel/Una grapa, paralelo: ""
+*fi.HPStaplerOptions 1parallel/Yksi niitti, rinnakkainen: ""
+*fr.HPStaplerOptions 1parallel/Une agrafe, paralléle: ""
+*it.HPStaplerOptions 1parallel/Un punto, parallela: ""
+*ja.HPStaplerOptions 1parallel/1 箇所, パラレル: ""
+*ko.HPStaplerOptions 1parallel/스테이플러 1개, 병렬: ""
+*nl.HPStaplerOptions 1parallel/Eén nietje parallel: ""
+*nb.HPStaplerOptions 1parallel/Én stift, parallell: ""
+*pt.HPStaplerOptions 1parallel/Um grampo á paralela: ""
+*sv.HPStaplerOptions 1parallel/1 häftklammer, parallel: ""
+*zh_CN.HPStaplerOptions 1parallel/一个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 1parallel/1枚釘書針: ""
+
+*HPStaplerOptions 2parallel/2 Staples, parallel: "
+  <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (TWO_STAPLES) /MediaProcessingBoundary 0
+    /ImageOrientation 1 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 2parallel/To hæfteklammer, parallel: ""
+*de.HPStaplerOptions 2parallel/Zwei Heftklammern, parallel: ""
+*es.HPStaplerOptions 2parallel/Dos grapas, paralelo: ""
+*fi.HPStaplerOptions 2parallel/Kaksi niittiä, rinnakkainen: ""
+*fr.HPStaplerOptions 2parallel/Deux agrafes, paralléle: ""
+*it.HPStaplerOptions 2parallel/Due punti, parallela: ""
+*ja.HPStaplerOptions 2parallel/2 箇所, パラレル: ""
+*ko.HPStaplerOptions 2parallel/스테이플러 2개, 병렬: ""
+*nl.HPStaplerOptions 2parallel/Twee nietjes parallel: ""
+*nb.HPStaplerOptions 2parallel/To stifter, parallell: ""
+*pt.HPStaplerOptions 2parallel/Dois grampos á paralela: ""
+*sv.HPStaplerOptions 2parallel/2 häftklamrar, parallel: ""
+*zh_CN.HPStaplerOptions 2parallel/2个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 2parallel/2枚釘書針: ""
+
+*HPStaplerOptions 3parallel/3 Staples, parallel: "
+ <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (THREE_STAPLES) /MediaProcessingBoundary 0
+    /ImageOrientation 0 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 3parallel/Tre hæfteklammer, parallel: ""
+*de.HPStaplerOptions 3parallel/Drei Heftklammern, parallel: ""
+*es.HPStaplerOptions 3parallel/Tres grapas, paralelo: ""
+*fi.HPStaplerOptions 3parallel/Kolme niittiä, rinnakkainen: ""
+*fr.HPStaplerOptions 3parallel/Trois agrafes, paralléle: ""
+*it.HPStaplerOptions 3parallel/Tre punti, parallela: ""
+*ja.HPStaplerOptions 3parallel/3 箇所, パラレル: ""
+*ko.HPStaplerOptions 3parallel/스테이플러 3개, 병렬: ""
+*nl.HPStaplerOptions 3parallel/Drie nietjes parallel: ""
+*nb.HPStaplerOptions 3parallel/Tre stifter, parallell: ""
+*pt.HPStaplerOptions 3parallel/TrÍs grampos do paralela: ""
+*sv.HPStaplerOptions 3parallel/3 häftklamrar, parallel: ""
+*zh_CN.HPStaplerOptions 3parallel/三个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 3parallel/三枚釘書針, 平行: ""
+
+*HPStaplerOptions 6parallel/6 Staples, parallel: "
+   <</MediaProcessing (STAPLING) /MediaProcessingDetails<<
+    /MediaProcessingOption (SIX_STAPLES) /MediaProcessingBoundary 0
+    /ImageOrientation 1 /Type 8 >> >> setpagedevice"
+*End
+*da.HPStaplerOptions 6parallel/Seks hæfteklammer, parallel: ""
+*de.HPStaplerOptions 6parallel/Sechs Heftklammern, parallel: ""
+*es.HPStaplerOptions 6parallel/Seis grapas, paralelo: ""
+*fi.HPStaplerOptions 6parallel/Kuusi niittiä, rinnakkainen: ""
+*fr.HPStaplerOptions 6parallel/Six agrafes, paralléle: ""
+*it.HPStaplerOptions 6parallel/Sei punti, parallela: ""
+*ja.HPStaplerOptions 6parallel/6 箇所, パラレル: ""
+*ko.HPStaplerOptions 6parallel/스테이플러 6개, 병렬: ""
+*nl.HPStaplerOptions 6parallel/Zes nietjes parallel: ""
+*nb.HPStaplerOptions 6parallel/Seks stifter, parallell: ""
+*pt.HPStaplerOptions 6parallel/Seis grampos do paralela: ""
+*sv.HPStaplerOptions 6parallel/6 häftklamrar, parallel: ""
+*zh_CN.HPStaplerOptions 6parallel/六个订书钉, 并行: ""
+*zh_TW.HPStaplerOptions 6parallel/六枚釘書針, 平行: ""
+
+*%*HPStaplerOptions HPBooklet/Fold & Saddle Stitch: "
+*%  << /MediaProcessing (BOOKLET_MAKER) /MediaProcessingDetails <<
+*%  /MediaProcessingOption (BOOKLET_MAKER) /MedaiProcessingBoundary 0
+*%  /ImageOrientation 0 /Type 8 >> >> setpagedevice
+*%  << /Staple 0 /OutputType (OPTIONAL OUTBIN 2) >> setpagedevice"
+*%*End
+*CloseUI: *HPStaplerOptions
+
+*%=== 8 Bin MultiBin MailBox Options =========================
+*OpenUI *HPMailboxOptions/Mailbox Options: PickOne
+*OrderDependency: 46 AnySetup *HPMailboxOptions
+*DefaultHPMailboxOptions: PrintersDefault
+*da.Translation HPMailboxOptions/Finisher-indstillinger: ""
+*de.Translation HPMailboxOptions/Fertigstellung: ""
+*es.Translation HPMailboxOptions/Acabado: ""
+*fi.Translation HPMailboxOptions/Viimeistelyasetukset: ""
+*fr.Translation HPMailboxOptions/Options de finition: ""
+*it.Translation HPMailboxOptions/Opzioni di finitura: ""
+*ja.Translation HPMailboxOptions/仕上げオプション: ""
+*ko.Translation HPMailboxOptions/마감장치 옵션: ""
+*nl.Translation HPMailboxOptions/Afwerkingsopties: ""
+*nb.Translation HPMailboxOptions/Etterbehandling: ""
+*pt.Translation HPMailboxOptions/Acabamento: ""
+*sv.Translation HPMailboxOptions/Efterbehandling: ""
+*zh_CN.Translation HPMailboxOptions/完成选项: ""
+*zh_TW.Translation HPMailboxOptions/外觀選項: ""
+
+*HPMailboxOptions PrintersDefault/Printer's Current Setting: ""
+*da.HPMailboxOptions PrintersDefault/Ingen: ""
+*de.HPMailboxOptions PrintersDefault/Aktuelle Einstellung: ""
+*es.HPMailboxOptions PrintersDefault/Valor actual: ""
+*fi.HPMailboxOptions PrintersDefault/Nykyinen asetus: ""
+*fr.HPMailboxOptions PrintersDefault/Paramétrage actuel de l’imprimante: ""
+*it.HPMailboxOptions PrintersDefault/Impostazione corrente: ""
+*ja.HPMailboxOptions PrintersDefault/現在の設定: ""
+*ko.HPMailboxOptions PrintersDefault/현재 설정: ""
+*nl.HPMailboxOptions PrintersDefault/Huidige instelling: ""
+*nb.HPMailboxOptions PrintersDefault/Ingen: ""
+*pt.HPMailboxOptions PrintersDefault/Configuração atual: ""
+*sv.HPMailboxOptions PrintersDefault/Aktuell inställning: ""
+*zh_CN.HPMailboxOptions PrintersDefault/当前设置: ""
+*zh_TW.HPMailboxOptions PrintersDefault/目前設定值: ""
+
+*HPMailboxOptions Bin1/Output Bin 1: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin1/Postkasse 1: ""
+*de.HPMailboxOptions Bin1/Ausgabefach 1: ""
+*es.HPMailboxOptions Bin1/Buzón 1: ""
+*fi.HPMailboxOptions Bin1/Lokero 1: ""
+*fr.HPMailboxOptions Bin1/Trieuse 1: ""
+*it.HPMailboxOptions Bin1/Casella 1: ""
+*ja.HPMailboxOptions Bin1/メールボックス 1: ""
+*ko.HPMailboxOptions Bin1/용지함 1: ""
+*nl.HPMailboxOptions Bin1/Bak 1: ""
+*nb.HPMailboxOptions Bin1/Utskuff 1: ""
+*pt.HPMailboxOptions Bin1/Caixa de correio 1: ""
+*sv.HPMailboxOptions Bin1/Fack 1: ""
+*zh_CN.HPMailboxOptions Bin1/信箱 1: ""
+*zh_TW.HPMailboxOptions Bin1/1 號信箱: ""
+
+*HPMailboxOptions Bin2/Output Bin 2: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 3)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin2/Postkasse 2: ""
+*de.HPMailboxOptions Bin2/Ausgabefach 2: ""
+*es.HPMailboxOptions Bin2/Buzón 2: ""
+*fi.HPMailboxOptions Bin2/Lokero 2: ""
+*fr.HPMailboxOptions Bin2/Trieuse 2: ""
+*it.HPMailboxOptions Bin2/Casella 2: ""
+*ja.HPMailboxOptions Bin2/メールボックス 2: ""
+*ko.HPMailboxOptions Bin2/용지함 2: ""
+*nl.HPMailboxOptions Bin2/Bak 2: ""
+*nb.HPMailboxOptions Bin2/Utskuff 2: ""
+*pt.HPMailboxOptions Bin2/Caixa de correio 2: ""
+*sv.HPMailboxOptions Bin2/Fack 2: ""
+*zh_CN.HPMailboxOptions Bin2/信箱 2: ""
+*zh_TW.HPMailboxOptions Bin2/2 號信箱: ""
+
+*HPMailboxOptions Bin3/Output Bin 3: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 4)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin3/Postkasse 3: ""
+*de.HPMailboxOptions Bin3/Ausgabefach 3: ""
+*es.HPMailboxOptions Bin3/Buzón 3: ""
+*fi.HPMailboxOptions Bin3/Lokero 3: ""
+*fr.HPMailboxOptions Bin3/Trieuse 3: ""
+*it.HPMailboxOptions Bin3/Casella 3: ""
+*ja.HPMailboxOptions Bin3/メールボックス 3: ""
+*ko.HPMailboxOptions Bin3/용지함 3: ""
+*nl.HPMailboxOptions Bin3/Bak 3: ""
+*nb.HPMailboxOptions Bin3/Utskuff 3: ""
+*pt.HPMailboxOptions Bin3/Caixa de correio 3: ""
+*sv.HPMailboxOptions Bin3/Fack 3: ""
+*zh_CN.HPMailboxOptions Bin3/信箱 3: ""
+*zh_TW.HPMailboxOptions Bin3/3 號信箱: ""
+
+*HPMailboxOptions Bin4/Output Bin 4: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 5)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin4/Postkasse 4: ""
+*de.HPMailboxOptions Bin4/Ausgabefach 4: ""
+*es.HPMailboxOptions Bin4/Buzón 4: ""
+*fi.HPMailboxOptions Bin4/Lokero 4: ""
+*fr.HPMailboxOptions Bin4/Trieuse 4: ""
+*it.HPMailboxOptions Bin4/Casella 4: ""
+*ja.HPMailboxOptions Bin4/メールボックス 4: ""
+*ko.HPMailboxOptions Bin4/용지함 4: ""
+*nl.HPMailboxOptions Bin4/Bak 4: ""
+*nb.HPMailboxOptions Bin4/Utskuff 4: ""
+*pt.HPMailboxOptions Bin4/Caixa de correio 4: ""
+*sv.HPMailboxOptions Bin4/Fack 4: ""
+*zh_CN.HPMailboxOptions Bin4/信箱 4: ""
+*zh_TW.HPMailboxOptions Bin4/4 號信箱: ""
+
+*HPMailboxOptions Bin5/Output Bin 5: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 6)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin5/Postkasse 5: ""
+*de.HPMailboxOptions Bin5/Ausgabefach 5: ""
+*es.HPMailboxOptions Bin5/Buzón 5: ""
+*fi.HPMailboxOptions Bin5/Lokero 5: ""
+*fr.HPMailboxOptions Bin5/Trieuse 5: ""
+*it.HPMailboxOptions Bin5/Casella 5: ""
+*ja.HPMailboxOptions Bin5/メールボックス 5: ""
+*ko.HPMailboxOptions Bin5/용지함 5: ""
+*nl.HPMailboxOptions Bin5/Bak 5: ""
+*nb.HPMailboxOptions Bin5/Utskuff 5: ""
+*pt.HPMailboxOptions Bin5/Caixa de correio 5: ""
+*sv.HPMailboxOptions Bin5/Fack 5: ""
+*zh_CN.HPMailboxOptions Bin5/信箱 5: ""
+*zh_TW.HPMailboxOptions Bin5/5 號信箱: ""
+
+*HPMailboxOptions Bin6/Output Bin 6: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 7)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin6/Postkasse 6: ""
+*de.HPMailboxOptions Bin6/Ausgabefach 6: ""
+*es.HPMailboxOptions Bin6/Buzón 6: ""
+*fi.HPMailboxOptions Bin6/Lokero 6: ""
+*fr.HPMailboxOptions Bin6/Trieuse 6: ""
+*it.HPMailboxOptions Bin6/Casella 6: ""
+*ja.HPMailboxOptions Bin6/メールボックス 6: ""
+*ko.HPMailboxOptions Bin6/용지함 6: ""
+*nl.HPMailboxOptions Bin6/Bak 6: ""
+*nb.HPMailboxOptions Bin6/Utskuff 6: ""
+*pt.HPMailboxOptions Bin6/Caixa de correio 6: ""
+*sv.HPMailboxOptions Bin6/Fack 6: ""
+*zh_CN.HPMailboxOptions Bin6/信箱 6: ""
+*zh_TW.HPMailboxOptions Bin6/6 號信箱: ""
+
+*HPMailboxOptions Bin7/Output Bin 7: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 8)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin7/Postkasse 7: ""
+*de.HPMailboxOptions Bin7/Ausgabefach 7: ""
+*es.HPMailboxOptions Bin7/Buzón 7: ""
+*fi.HPMailboxOptions Bin7/Lokero 7: ""
+*fr.HPMailboxOptions Bin7/Trieuse 7: ""
+*it.HPMailboxOptions Bin7/Casella 7: ""
+*ja.HPMailboxOptions Bin7/メールボックス 7: ""
+*ko.HPMailboxOptions Bin7/용지함 7: ""
+*nl.HPMailboxOptions Bin7/Bak 7: ""
+*nb.HPMailboxOptions Bin7/Utskuff 7: ""
+*pt.HPMailboxOptions Bin7/Caixa de correio 7: ""
+*sv.HPMailboxOptions Bin7/Fack 7: ""
+*zh_CN.HPMailboxOptions Bin7/信箱 7: ""
+*zh_TW.HPMailboxOptions Bin7/7 號信箱: ""
+
+*HPMailboxOptions Bin8/Output Bin 8: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 9)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin8/Postkasse 8: ""
+*de.HPMailboxOptions Bin8/Ausgabefach 8: ""
+*es.HPMailboxOptions Bin8/Buzón 8: ""
+*fi.HPMailboxOptions Bin8/Lokero 8: ""
+*fr.HPMailboxOptions Bin8/Trieuse 8: ""
+*it.HPMailboxOptions Bin8/Casella 8: ""
+*ja.HPMailboxOptions Bin8/メールボックス 8: ""
+*ko.HPMailboxOptions Bin8/용지함 8: ""
+*nl.HPMailboxOptions Bin8/Bak 8: ""
+*nb.HPMailboxOptions Bin8/Utskuff 8: ""
+*pt.HPMailboxOptions Bin8/Caixa de correio 8: ""
+*sv.HPMailboxOptions Bin8/Fack 8: ""
+*zh_CN.HPMailboxOptions Bin8/信箱 8: ""
+*zh_TW.HPMailboxOptions Bin8/8 號信箱: ""
+
+*HPMailboxOptions Bin1_8/Output Bins 1-8: "
+  <</Staple 0 /OutputType (OPTIONAL OUTBIN 2)>> setpagedevice"
+*End
+*da.HPMailboxOptions Bin1_8/Postkasse 1-8: ""
+*de.HPMailboxOptions Bin1_8/Ausgabefachs 1-8: ""
+*es.HPMailboxOptions Bin1_8/Buzón 1-8: ""
+*fi.HPMailboxOptions Bin1_8/Lokeros 1-8: ""
+*fr.HPMailboxOptions Bin1_8/Trieuse 1-8: ""
+*it.HPMailboxOptions Bin1_8/Casella 1-8: ""
+*ja.HPMailboxOptions Bin1_8/メールボックス 1-8: ""
+*ko.HPMailboxOptions Bin1_8/용지함 1-8: ""
+*nl.HPMailboxOptions Bin1_8/Bak 1-8: ""
+*nb.HPMailboxOptions Bin1_8/Utskuff 1-8: ""
+*pt.HPMailboxOptions Bin1_8/Caixa de correio 1-8: ""
+*sv.HPMailboxOptions Bin1_8/Fack 1-8: ""
+*zh_CN.HPMailboxOptions Bin1_8/信箱 1-8: ""
+*zh_TW.HPMailboxOptions Bin1_8/1-8 號信箱: ""
+
+*CloseUI: *HPMailboxOptions
+
+*%=================================================
+*%		 Edge-to-Edge Printing
+*%=================================================
+*OpenUI *HPEdgeToEdge/Edge-To-Edge Printing: Boolean
+*OrderDependency: 10 AnySetup *HPEdgeToEdge
+*DefaultHPEdgeToEdge: False
+*da.Translation HPEdgeToEdge/Kant-til-kant: ""
+*de.Translation HPEdgeToEdge/Randlos: ""
+*es.Translation HPEdgeToEdge/De borde a borde: ""
+*fi.Translation HPEdgeToEdge/Reunasta reunaan: ""
+*fr.Translation HPEdgeToEdge/Bord à bord: ""
+*it.Translation HPEdgeToEdge/Bordo a bordo: ""
+*ja.Translation HPEdgeToEdge/最小マージン: ""
+*ko.Translation HPEdgeToEdge/가장자리까지 인쇄: ""
+*nl.Translation HPEdgeToEdge/Aflopend: ""
+*nb.Translation HPEdgeToEdge/Kant til kant: ""
+*pt.Translation HPEdgeToEdge/Margem a margem: ""
+*sv.Translation HPEdgeToEdge/Kant till kant: ""
+*zh_CN.Translation HPEdgeToEdge/边到边: ""
+*zh_TW.Translation HPEdgeToEdge/邊到邊: ""
+
+*HPEdgeToEdge False/Off: "<</EdgeToEdge false>> setpagedevice"
+*da.HPEdgeToEdge False/Aus: ""
+*de.HPEdgeToEdge False/Aus: ""
+*es.HPEdgeToEdge False/Desactivado: ""
+*fi.HPEdgeToEdge False/Ei: ""
+*fr.HPEdgeToEdge False/Désactivé: ""
+*it.HPEdgeToEdge False/Disattivata: ""
+*ja.HPEdgeToEdge False/オフ: ""
+*ko.HPEdgeToEdge False/끔: ""
+*nl.HPEdgeToEdge False/Uit: ""
+*nb.HPEdgeToEdge False/Av: ""
+*pt.HPEdgeToEdge False/Desativado: ""
+*sv.HPEdgeToEdge False/Av: ""
+*zh_CN.HPEdgeToEdge False/关: ""
+*zh_TW.HPEdgeToEdge False/關閉: ""
+
+*HPEdgeToEdge True/On: "<</EdgeToEdge true>> setpagedevice"
+*da.HPEdgeToEdge True/Ein: ""
+*de.HPEdgeToEdge True/Ein: ""
+*es.HPEdgeToEdge True/Activado: ""
+*fi.HPEdgeToEdge True/Kyllä: ""
+*fr.HPEdgeToEdge True/Activé: ""
+*it.HPEdgeToEdge True/Attivata: ""
+*ja.HPEdgeToEdge True/オン: ""
+*ko.HPEdgeToEdge True/켜짐: ""
+*nl.HPEdgeToEdge True/Aan: ""
+*nb.HPEdgeToEdge True/På: ""
+*pt.HPEdgeToEdge True/Ativado: ""
+*sv.HPEdgeToEdge True/På: ""
+*zh_CN.HPEdgeToEdge True/开: ""
+*zh_TW.HPEdgeToEdge True/開啟: ""
+
+*?HPEdgeToEdge: "
+  save
+    currentpagedevice /EdgeToEdge get
+      {(True)}{(False)}ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPEdgeToEdge
+
+*OpenUI *HPRotate180/Rotate Page 180 deg: Boolean
+*OrderDependency: 48 AnySetup *HPRotate180
+*DefaultHPRotate180: False
+*da.Translation HPRotate180/Roter 180 grader: ""
+*de.Translation HPRotate180/Um 180 Grad drehen: ""
+*es.Translation HPRotate180/Girar 180 grados: ""
+*fi.Translation HPRotate180/Kierrä 180 astetta: ""
+*fr.Translation HPRotate180/Faire pivoter de 180˚: ""
+*it.Translation HPRotate180/Ruota di 180 gradi: ""
+*ja.Translation HPRotate180/印刷の向きを 180°回転: ""
+*ko.Translation HPRotate180/180도 회전된 방향: ""
+*nl.Translation HPRotate180/Draaien met 180 graden: ""
+*nb.Translation HPRotate180/Roter 180 grader: ""
+*pt.Translation HPRotate180/Girar em 180 graus: ""
+*sv.Translation HPRotate180/Rotera sedan 180 grader: ""
+*zh_CN.Translation HPRotate180/方向旋转 180 度: ""
+*zh_TW.Translation HPRotate180/旋轉 180 度: ""
+
+*HPRotate180 False/Off:  ""
+*da.HPRotate180 False/Fra: ""
+*de.HPRotate180 False/Aus: ""
+*es.HPRotate180 False/Desactivado: ""
+*fi.HPRotate180 False/Ei käytössä: ""
+*fr.HPRotate180 False/Désactivé: ""
+*it.HPRotate180 False/Disattivata: ""
+*ja.HPRotate180 False/オフ: ""
+*ko.HPRotate180 False/꺼짐: ""
+*nl.HPRotate180 False/Uit: ""
+*nb.HPRotate180 False/Av: ""
+*pt.HPRotate180 False/Desativado: ""
+*sv.HPRotate180 False/Av: ""
+*zh_CN.HPRotate180 False/关: ""
+*zh_TW.HPRotate180 False/關閉: ""
+
+*HPRotate180 True/On: "
+<<	/BeginPage
+	{ userdict begin
+		pop
+		currentpagedevice /PageSize get dup 0 get exch 1 get translate
+		0 0 moveto
+		180 rotate
+	end } bind
+>> setpagedevice"
+*End
+*da.HPRotate180 True/På: ""
+*de.HPRotate180 True/Ein: ""
+*es.HPRotate180 True/Activado: ""
+*fi.HPRotate180 True/käytössä: ""
+*fr.HPRotate180 True/Activé: ""
+*it.HPRotate180 True/Attiva: ""
+*ja.HPRotate180 True/オン: ""
+*ko.HPRotate180 True/켜짐: ""
+*nl.HPRotate180 True/Aan: ""
+*nb.HPRotate180 True/På: ""
+*pt.HPRotate180 True/Ativado: ""
+*sv.HPRotate180 True/På: ""
+*zh_CN.HPRotate180 True/开: ""
+*zh_TW.HPRotate180 True/開啟: ""
+
+*CloseUI: *HPRotate180
+
+*CloseGroup: HPFinishing
+
+*%=================================================
+*%		 Enable/Disable Collate via PostScript
+*%=================================================
+*OpenUI *Collate/Collate:  Boolean
+*OrderDependency: 12 AnySetup *Collate
+*DefaultCollate: False
+*da.Translation Collate/Sætvis: ""
+*de.Translation Collate/Sortieren: ""
+*es.Translation Collate/Clasificar: ""
+*fi.Translation Collate/Lajittele: ""
+*fr.Translation Collate/Assembler: ""
+*it.Translation Collate/Fascicola: ""
+*ja.Translation Collate/照合: ""
+*ko.Translation Collate/한 부씩 인쇄: ""
+*nl.Translation Collate/Sorteren: ""
+*nb.Translation Collate/Sorter: ""
+*pt.Translation Collate/Intercalar: ""
+*sv.Translation Collate/Sortera: ""
+*zh_CN.Translation Collate/分页: ""
+*zh_TW.Translation Collate/自動分頁: ""
+
+*Collate True/On (turn off in application): "<</Collate true>> setpagedevice"
+*da.Collate True/Til (deaktiver i programmet): ""
+*de.Collate True/Ein (in der Anwendung deaktivieren): ""
+*es.Collate True/Activado (desactivar en la aplicación): ""
+*fi.Collate True/Kyllä (poista valinta sovelluksesta): ""
+*fr.Collate True/Activé (désactiver dans l’applic.): ""
+*it.Collate True/Attivata (disattivare in applicazione): ""
+*ja.Collate True/オン (アプリケーションではオフに): ""
+*ko.Collate True/켬(응용 프로그램에서 마치기): ""
+*nl.Collate True/Aan (uitzetten in toepassingsprogramma): ""
+*nb.Collate True/På (slå av i programmet): ""
+*pt.Collate True/Ligado (desligar no aplicativo): ""
+*sv.Collate True/På (stäng av i programmet): ""
+*zh_CN.Collate True/开 (在应用程序关闭): ""
+*zh_TW.Collate True/開 (從應用程式關閉): ""
+
+*Collate False/Off: "<</Collate false>> setpagedevice"
+*da.Collate False/Fra: ""
+*de.Collate False/Aus: ""
+*es.Collate False/Desactivado: ""
+*fi.Collate False/Ei: ""
+*fr.Collate False/Désactivé: ""
+*it.Collate False/Disattivata: ""
+*ja.Collate False/オフ: ""
+*ko.Collate False/끔: ""
+*nl.Collate False/Uit: ""
+*nb.Collate False/Av: ""
+*pt.Collate False/Desligado: ""
+*sv.Collate False/Av: ""
+*zh_CN.Collate False/关: ""
+*zh_TW.Collate False/關: ""
+
+*?Collate: "
+   save
+      currentpagedevice /Collate get
+      {(True)}{(False)}ifelse = flush
+   restore
+"
+*End
+*CloseUI: *Collate
+
+*OpenGroup: HPImagingOptions/Image Quality
+*da.Translation HPImagingOptions/Billedindstillinger: ""
+*de.Translation HPImagingOptions/Abbildungsoptionen: ""
+*es.Translation HPImagingOptions/Opciones de imagen: ""
+*fi.Translation HPImagingOptions/Kuvanmuodostusasetukset: ""
+*fr.Translation HPImagingOptions/Options d'image: ""
+*it.Translation HPImagingOptions/Opzioni di immagine: ""
+*ja.Translation HPImagingOptions/画質オプション: ""
+*ko.Translation HPImagingOptions/이미지 옵션: ""
+*nl.Translation HPImagingOptions/Afbeeldingen-opties: ""
+*nb.Translation HPImagingOptions/Valg for bildebehandling: ""
+*pt.Translation HPImagingOptions/Opções de imagem: ""
+*sv.Translation HPImagingOptions/Alternativ för kvalitet: ""
+*zh_CN.Translation HPImagingOptions/图象选项: ""
+*zh_TW.Translation HPImagingOptions/影像選項: ""
+
+
+*%=================================================
+*%		 Halftone Information
+*%=================================================
+*ScreenFreq:  "106.0"
+*ScreenAngle: "45.0"
+
+*ResScreenFreq 300dpi/300 dpi:  "60.0"
+*da.ResScreenFreq 300dpi/300 dpi: ""
+*de.ResScreenFreq 300dpi/300 dpi: ""
+*es.ResScreenFreq 300dpi/300 dpi: ""
+*fi.ResScreenFreq 300dpi/300 dpi: ""
+*fr.ResScreenFreq 300dpi/300 dpi: ""
+*it.ResScreenFreq 300dpi/300 dpi: ""
+*ja.ResScreenFreq 300dpi/300 dpi: ""
+*ko.ResScreenFreq 300dpi/300 dpi: ""
+*nl.ResScreenFreq 300dpi/300 dpi: ""
+*nb.ResScreenFreq 300dpi/300 dpi: ""
+*pt.ResScreenFreq 300dpi/300 dpi: ""
+*sv.ResScreenFreq 300dpi/300 dpi: ""
+*zh_CN.ResScreenFreq 300dpi/300 dpi: ""
+*zh_TW.ResScreenFreq 300dpi/300 dpi: ""
+
+*ResScreenAngle 300dpi/300 dpi: "45.0"
+*da.ResScreenAngle 300dpi/300 dpi: ""
+*de.ResScreenAngle 300dpi/300 dpi: ""
+*es.ResScreenAngle 300dpi/300 dpi: ""
+*fi.ResScreenAngle 300dpi/300 dpi: ""
+*fr.ResScreenAngle 300dpi/300 dpi: ""
+*it.ResScreenAngle 300dpi/300 dpi: ""
+*ja.ResScreenAngle 300dpi/300 dpi: ""
+*ko.ResScreenAngle 300dpi/300 dpi: ""
+*nl.ResScreenAngle 300dpi/300 dpi: ""
+*nb.ResScreenAngle 300dpi/300 dpi: ""
+*pt.ResScreenAngle 300dpi/300 dpi: ""
+*sv.ResScreenAngle 300dpi/300 dpi: ""
+*zh_CN.ResScreenAngle 300dpi/300 dpi: ""
+*zh_TW.ResScreenAngle 300dpi/300 dpi: ""
+
+*ResScreenFreq 600dpi/600 dpi:  "106.0"
+*da.ResScreenFreq 600dpi/600 dpi: ""
+*de.ResScreenFreq 600dpi/600 dpi: ""
+*es.ResScreenFreq 600dpi/600 dpi: ""
+*fi.ResScreenFreq 600dpi/600 dpi: ""
+*fr.ResScreenFreq 600dpi/600 dpi: ""
+*it.ResScreenFreq 600dpi/600 dpi: ""
+*ja.ResScreenFreq 600dpi/600 dpi: ""
+*ko.ResScreenFreq 600dpi/600 dpi: ""
+*nl.ResScreenFreq 600dpi/600 dpi: ""
+*nb.ResScreenFreq 600dpi/600 dpi: ""
+*pt.ResScreenFreq 600dpi/600 dpi: ""
+*sv.ResScreenFreq 600dpi/600 dpi: ""
+*zh_CN.ResScreenFreq 600dpi/600 dpi: ""
+*zh_TW.ResScreenFreq 600dpi/600 dpi: ""
+
+*ResScreenAngle 600dpi/600 dpi: "45.0"
+*da.ResScreenAngle 600dpi/600 dpi: ""
+*de.ResScreenAngle 600dpi/600 dpi: ""
+*es.ResScreenAngle 600dpi/600 dpi: ""
+*fi.ResScreenAngle 600dpi/600 dpi: ""
+*fr.ResScreenAngle 600dpi/600 dpi: ""
+*it.ResScreenAngle 600dpi/600 dpi: ""
+*ja.ResScreenAngle 600dpi/600 dpi: ""
+*ko.ResScreenAngle 600dpi/600 dpi: ""
+*nl.ResScreenAngle 600dpi/600 dpi: ""
+*nb.ResScreenAngle 600dpi/600 dpi: ""
+*pt.ResScreenAngle 600dpi/600 dpi: ""
+*sv.ResScreenAngle 600dpi/600 dpi: ""
+*zh_CN.ResScreenAngle 600dpi/600 dpi: ""
+*zh_TW.ResScreenAngle 600dpi/600 dpi: ""
+
+
+*DefaultScreenProc: Dot
+*ScreenProc HPEnhanced: "
+	{ /EnhancedHalftone /Halftone findresource }"
+*End
+*ScreenProc Dot: "
+        {abs exch abs 2 copy add 1 gt {1 sub dup mul exch 1 sub dup mul add 1
+        sub }{dup mul exch dup mul add 1 exch sub }ifelse }
+"
+*End
+*ScreenProc Line: "{ pop }"
+*ScreenProc Ellipse: "{ dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub }"
+
+*DefaultTransfer: Null
+*Transfer Null: "{ }"
+*Transfer Null.Inverse: "{ 1 exch sub }"
+
+*DefaultHalftoneType:    9
+*AccurateScreensSupport: False
+
+*OpenUI *HPHalftone/Levels of Gray: PickOne
+*OrderDependency: 10 DocumentSetup *HPHalftone
+*DefaultHPHalftone: PrinterDefault
+*da.Translation HPHalftone/Halvtone: ""
+*de.Translation HPHalftone/Halbton: ""
+*es.Translation HPHalftone/Medios tonos: ""
+*fi.Translation HPHalftone/Puolisävy: ""
+*fr.Translation HPHalftone/Demi-teinte: ""
+*it.Translation HPHalftone/Mezzitoni: ""
+*ja.Translation HPHalftone/ハーフトーン: ""
+*ko.Translation HPHalftone/중간 색조: ""
+*nl.Translation HPHalftone/Halftonen: ""
+*nb.Translation HPHalftone/Halvtone: ""
+*pt.Translation HPHalftone/Meio-tom: ""
+*sv.Translation HPHalftone/Halvton: ""
+*zh_CN.Translation HPHalftone/半色调: ""
+*zh_TW.Translation HPHalftone/半色調: ""
+
+*HPHalftone PrinterDefault/Printer's Current Setting: ""
+*da.HPHalftone PrinterDefault/Aktuelle Druckereinstellung: ""
+*de.HPHalftone PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.HPHalftone PrinterDefault/Configuración actual de la impresora: ""
+*fi.HPHalftone PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.HPHalftone PrinterDefault/Paramétrage actuel de l'imprimante: ""
+*it.HPHalftone PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.HPHalftone PrinterDefault/プリンタの現在の設定: ""
+*ko.HPHalftone PrinterDefault/프린터 기본값: ""
+*nl.HPHalftone PrinterDefault/Huidige instelling van de printer: ""
+*nb.HPHalftone PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.HPHalftone PrinterDefault/Configuração atual da impressora: ""
+*sv.HPHalftone PrinterDefault/Skrivarens inställning: ""
+*zh_CN.HPHalftone PrinterDefault/打印机的当前设置: ""
+*zh_TW.HPHalftone PrinterDefault/印表機目前的設定值: ""
+
+*HPHalftone Enhanced/Enhanced: "
+   << /Install {
+     currentpagedevice /HWResolution get
+     dup 0 get 600 eq exch 1 get 600 eq and
+     { /EnhancedColorRendering600 } { /EnhancedColorRendering } ifelse
+     /ColorRendering findresource setcolorrendering
+     /EnhancedHalftone /Halftone findresource sethalftone
+     { } settransfer false setstrokeadjust
+   }
+   >> setpagedevice
+   currentpagedevice /HWResolution get dup 0 get 600 eq exch 1 get 600 eq and
+   {
+       << /PostRenderingEnhance true
+            /PostRenderingEnhanceDetails << /REValue 0 /Type 8 >>
+       >> setpagedevice
+   } if
+   /setscreen { pop pop pop } def
+   /setcolorscreen { pop pop pop pop pop pop pop pop pop pop pop pop } def
+   /sethalftone { pop } def
+"
+*End
+*da.HPHalftone Enhanced/Forbedret: ""
+*de.HPHalftone Enhanced/Erhöhen: ""
+*es.HPHalftone Enhanced/Mejorada: ""
+*fi.HPHalftone Enhanced/Parantaminen: ""
+*fr.HPHalftone Enhanced/Rehausser: ""
+*it.HPHalftone Enhanced/Valorizzare: ""
+*ja.HPHalftone Enhanced/拡張: ""
+*ko.HPHalftone Enhanced/해상도 향상: ""
+*nl.HPHalftone Enhanced/Gecombineerd: ""
+*nb.HPHalftone Enhanced/Sammenslått: ""
+*pt.HPHalftone Enhanced/Melhoria: ""
+*sv.HPHalftone Enhanced/Höja: ""
+*zh_CN.HPHalftone Enhanced/分辨率增强: ""
+*zh_TW.HPHalftone Enhanced/解析度增強: ""
+
+*HPHalftone Standard/Standard: "
+   << /Install {
+     currentpagedevice /HWResolution get
+     dup 0 get 600 eq exch 1 get 600 eq and dup
+     currentpagedevice /PostRenderingEnhance get
+     currentpagedevice /PostRenderingEnhanceDetails get /REValue get 0 ne and
+     { {/DefaultColorRenderingRE600} {/DefaultColorRenderingRE} ifelse}
+     { {/DefaultColorRendering600} {/DefaultColorRendering} ifelse} ifelse
+     /ColorRendering findresource setcolorrendering
+     { /DefaultHalftone600 } {/DefaultHalftone} ifelse
+     /Halftone findresource sethalftone
+     {} settransfer false setstrokeadjust
+   } >> setpagedevice
+   currentpagedevice /HWResolution get dup 0 get 600 eq exch 1 get 600 eq and
+   {
+     << /PostRenderingEnhance true /PostRenderingEnhanceDetails
+     << /REValue 0 /Type 8 >> >> setpagedevice
+   } if
+"
+*End
+*da.HPHalftone Standard/Standard: ""
+*de.HPHalftone Standard/Standard: ""
+*es.HPHalftone Standard/Estandarte: ""
+*fi.HPHalftone Standard/Normaali: ""
+*fr.HPHalftone Standard/Standard: ""
+*it.HPHalftone Standard/Standard: ""
+*ja.HPHalftone Standard/標準: ""
+*ko.HPHalftone Standard/역호환성: ""
+*nl.HPHalftone Standard/Standaard: ""
+*nb.HPHalftone Standard/Bakoverkompatibilitet: ""
+*pt.HPHalftone Standard/Padrão: ""
+*sv.HPHalftone Standard/Standard: ""
+*zh_CN.HPHalftone Standard/标准: ""
+*zh_TW.HPHalftone Standard/標準: ""
+
+*?HPHalftone: "
+   save
+      currenthalftone /HalftoneType get 9 eq
+     {(Enhanced)} {(Standard)} ifelse = flush
+   restore
+"
+*End
+*CloseUI: *HPHalftone
+
+*%=================================================
+*%		Resolution
+*%=================================================
+*% Select Printer Resolution
+*OpenUI *Resolution/Printer Resolution: PickOne
+*DefaultResolution: 1200dpi
+*da.Translation Resolution/Opløsning: ""
+*de.Translation Resolution/Druckerauflösung: ""
+*es.Translation Resolution/Resol. de la impresora: ""
+*fi.Translation Resolution/Kirjoittimen tarkkuus: ""
+*fr.Translation Resolution/Résolution d’imprimante: ""
+*it.Translation Resolution/Risoluzione: ""
+*ja.Translation Resolution/プリンタの解像度: ""
+*ko.Translation Resolution/프린터 해상도: ""
+*nl.Translation Resolution/Printer-resolutie: ""
+*nb.Translation Resolution/Skriveroppløsning: ""
+*pt.Translation Resolution/Resolução da impressora: ""
+*sv.Translation Resolution/Skrivarupplösning: ""
+*zh_CN.Translation Resolution/打印机分辨率: ""
+*zh_TW.Translation Resolution/印表機解析度: ""
+
+*OrderDependency: 5 DocumentSetup  *Resolution
+*Resolution 600x600dpi/600 dpi: "
+    <</HWResolution [600 600] /PreRenderingEnhance false>> setpagedevice"
+*End
+*da.Resolution 600x600dpi/600 dpi: ""
+*de.Resolution 600x600dpi/600 dpi: ""
+*es.Resolution 600x600dpi/600 dpi: ""
+*fi.Resolution 600x600dpi/600 dpi: ""
+*fr.Resolution 600x600dpi/600 dpi: ""
+*it.Resolution 600x600dpi/600 dpi: ""
+*ja.Resolution 600x600dpi/600 dpi: ""
+*ko.Resolution 600x600dpi/600 dpi: ""
+*nl.Resolution 600x600dpi/600 dpi: ""
+*nb.Resolution 600x600dpi/600 dpi: ""
+*pt.Resolution 600x600dpi/600 dpi: ""
+*sv.Resolution 600x600dpi/600 dpi: ""
+*zh_CN.Resolution 600x600dpi/600 dpi: ""
+*zh_TW.Resolution 600x600dpi/600 dpi: ""
+
+*Resolution 1200dpi/FastRes 1200: "
+	<</HWResolution [600 600] /PreRenderingEnhance true>> setpagedevice"
+*End
+*da.Resolution 1200dpi/FastRes 1200: ""
+*de.Resolution 1200dpi/FastRes 1200: ""
+*es.Resolution 1200dpi/FastRes 1200: ""
+*fi.Resolution 1200dpi/FastRes 1200: ""
+*fr.Resolution 1200dpi/FastRes 1200: ""
+*it.Resolution 1200dpi/FastRes 1200: ""
+*ja.Resolution 1200dpi/FastRes 1200: ""
+*ko.Resolution 1200dpi/FastRes 1200: ""
+*nl.Resolution 1200dpi/FastRes 1200: ""
+*nb.Resolution 1200dpi/FastRes 1200: ""
+*pt.Resolution 1200dpi/FastRes 1200: ""
+*sv.Resolution 1200dpi/FastRes 1200: ""
+*zh_CN.Resolution 1200dpi/FastRes 1200: ""
+*zh_TW.Resolution 1200dpi/FastRes 1200: ""
+
+*?Resolution: "
+  save
+    currentpagedevice /HWResolution get
+    0 get
+    (          ) cvs print
+    (dpi)
+    = flush
+  restore
+"
+*End
+*CloseUI: *Resolution
+
+*%=================================================
+*%          HPEconoMode
+*%=================================================
+*OpenUI *HPEconoMode/EconoMode: PickOne
+*DefaultHPEconoMode: PrinterDefault
+*da.Translation HPEconoMode/EconoMode: ""
+*de.Translation HPEconoMode/EconoMode: ""
+*es.Translation HPEconoMode/EconoMode: ""
+*fi.Translation HPEconoMode/EconoMode: ""
+*fr.Translation HPEconoMode/EconoMode: ""
+*it.Translation HPEconoMode/EconoMode: ""
+*ja.Translation HPEconoMode/EconoMode: ""
+*ko.Translation HPEconoMode/EconoMode: ""
+*nl.Translation HPEconoMode/EconoMode: ""
+*nb.Translation HPEconoMode/EconoMode: ""
+*pt.Translation HPEconoMode/EconoMode: ""
+*sv.Translation HPEconoMode/EconoMode: ""
+*zh_CN.Translation HPEconoMode/EconoMode: ""
+*zh_TW.Translation HPEconoMode/EconoMode: ""
+
+*OrderDependency: 10 AnySetup *HPEconoMode
+*HPEconoMode PrinterDefault/Printer's Current Setting: ""
+*da.HPEconoMode PrinterDefault/Printerens aktuelle indstilling: ""
+*de.HPEconoMode PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.HPEconoMode PrinterDefault/Configuración actual de la impresora: ""
+*fi.HPEconoMode PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.HPEconoMode PrinterDefault/Paramétrage actuel de l’imprimante: ""
+*it.HPEconoMode PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.HPEconoMode PrinterDefault/プリンタの現在の設定: ""
+*ko.HPEconoMode PrinterDefault/프린터의 현재 설정: ""
+*nl.HPEconoMode PrinterDefault/Huidige instelling van de printer: ""
+*nb.HPEconoMode PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.HPEconoMode PrinterDefault/Configuração atual da impressora: ""
+*sv.HPEconoMode PrinterDefault/Skrivarens inställning: ""
+*zh_CN.HPEconoMode PrinterDefault/打印机的当前设置: ""
+*zh_TW.HPEconoMode PrinterDefault/印表機目前的設定值: ""
+
+*HPEconoMode True/Save Toner: "
+    <</EconoMode true>> setpagedevice"
+*End
+*da.HPEconoMode True/Spar toner: ""
+*de.HPEconoMode True/Toner sparen: ""
+*es.HPEconoMode True/Ahorrar tóner: ""
+*fi.HPEconoMode True/Säästä väriainetta: ""
+*fr.HPEconoMode True/Economiser l’encre: ""
+*it.HPEconoMode True/Salva toner: ""
+*ja.HPEconoMode True/トナー節約: ""
+*ko.HPEconoMode True/토너 절약: ""
+*nl.HPEconoMode True/Toner besparen: ""
+*nb.HPEconoMode True/Spar toner: ""
+*pt.HPEconoMode True/Economizar toner: ""
+*sv.HPEconoMode True/Spara toner: ""
+*zh_CN.HPEconoMode True/节省碳粉: ""
+*zh_TW.HPEconoMode True/節約碳粉: ""
+
+*HPEconoMode False/Highest Quality: "
+    <</EconoMode false>> setpagedevice"
+*End
+*da.HPEconoMode False/Højeste kvalitet: ""
+*de.HPEconoMode False/Beste Qualität: ""
+*es.HPEconoMode False/Calidad óptima: ""
+*fi.HPEconoMode False/Korkein laatu: ""
+*fr.HPEconoMode False/Meilleure qualité: ""
+*it.HPEconoMode False/Qualità superiore: ""
+*ja.HPEconoMode False/最品位: ""
+*ko.HPEconoMode False/최고품질: ""
+*nl.HPEconoMode False/Beste kwaliteit: ""
+*nb.HPEconoMode False/Høyeste kvalitet: ""
+*pt.HPEconoMode False/Melhor qualidade: ""
+*sv.HPEconoMode False/Högsta kvalitet: ""
+*zh_CN.HPEconoMode False/最高质量: ""
+*zh_TW.HPEconoMode False/最高品質: ""
+
+*?HPEconoMode: "
+  save
+    currentpagedevice /EconoMode get
+    {(True)}{(False)}ifelse = flush
+  restore
+"
+*End
+*CloseUI: *HPEconoMode
+
+*%=================================================
+*%        Resolution Enhancement
+*%=================================================
+*OpenUI *Smoothing/Resolution Enhancement:  PickOne
+*OrderDependency: 20 DocumentSetup *Smoothing
+*DefaultSmoothing: PrinterDefault
+*da.Translation Smoothing/Opløsningsforbedring: ""
+*de.Translation Smoothing/Auflösungsoptimierung: ""
+*es.Translation Smoothing/Resolución Enhancement: ""
+*fi.Translation Smoothing/Tarkkuuden parannus: ""
+*fr.Translation Smoothing/Amélioration résolution: ""
+*it.Translation Smoothing/Miglioramento risoluzione: ""
+*ja.Translation Smoothing/解像度エンハンスメント: ""
+*ko.Translation Smoothing/해상도 향상: ""
+*nl.Translation Smoothing/Resolutieverbetering: ""
+*nb.Translation Smoothing/Oppløsningsfremheving: ""
+*pt.Translation Smoothing/Resolução avançada: ""
+*sv.Translation Smoothing/Förbättring av upplösning: ""
+*zh_CN.Translation Smoothing/分辨率增强: ""
+*zh_TW.Translation Smoothing/解析度增強: ""
+
+*Smoothing PrinterDefault/Printer's Current Setting: ""
+*da.Smoothing PrinterDefault/Aktuelle Druckereinstellung: ""
+*de.Smoothing PrinterDefault/Aktuelle Druckereinstellung: ""
+*es.Smoothing PrinterDefault/Configuración actual de la impresora: ""
+*fi.Smoothing PrinterDefault/Kirjoittimen nykyinen asetus: ""
+*fr.Smoothing PrinterDefault/Paramétrage actuel de l'imprimante: ""
+*it.Smoothing PrinterDefault/Impostazioni correnti della stampante: ""
+*ja.Smoothing PrinterDefault/プリンタの現在の設定: ""
+*ko.Smoothing PrinterDefault/프린터 기본값: ""
+*nl.Smoothing PrinterDefault/Huidige instelling van de printer: ""
+*nb.Smoothing PrinterDefault/Skriverens gjeldende innstilling: ""
+*pt.Smoothing PrinterDefault/Configuração atual da impressora: ""
+*sv.Smoothing PrinterDefault/Skrivarens inställning: ""
+*zh_CN.Smoothing PrinterDefault/打印机的当前设置: ""
+*zh_TW.Smoothing PrinterDefault/印表機目前的設定值: ""
+
+*Smoothing None/Off: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 0 /Type 8 >>
+>>  setpagedevice"
+*End
+*da.Smoothing None/Ingen: ""
+*de.Smoothing None/Aus: ""
+*es.Smoothing None/Desactivado: ""
+*fi.Smoothing None/Ei: ""
+*fr.Smoothing None/Désactivé: ""
+*it.Smoothing None/Disattivata: ""
+*ja.Smoothing None/オフ: ""
+*ko.Smoothing None/꺼짐: ""
+*nl.Smoothing None/Uit: ""
+*nb.Smoothing None/Av: ""
+*pt.Smoothing None/Desativado: ""
+*sv.Smoothing None/Av: ""
+*zh_CN.Smoothing None/关: ""
+*zh_TW.Smoothing None/關閉: ""
+
+*Smoothing Light/Light: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 1 /Type 8 >>
+>>  setpagedevice"
+*End
+*da.Smoothing Light/Lys: ""
+*de.Smoothing Light/Hell: ""
+*es.Smoothing Light/Claro: ""
+*fi.Smoothing Light/Vaalea: ""
+*fr.Smoothing Light/Clair: ""
+*it.Smoothing Light/Chiaro: ""
+*ja.Smoothing Light/薄い: ""
+*ko.Smoothing Light/밝게: ""
+*nl.Smoothing Light/Licht: ""
+*nb.Smoothing Light/Lys: ""
+*pt.Smoothing Light/Claro: ""
+*sv.Smoothing Light/Ljus: ""
+*zh_CN.Smoothing Light/淡: ""
+*zh_TW.Smoothing Light/淡: ""
+
+*Smoothing Medium/Medium: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 2 /Type 8 >>
+>>  setpagedevice"
+*End
+*da.Smoothing Medium/Middel: ""
+*de.Smoothing Medium/Mittel: ""
+*es.Smoothing Medium/Medio: ""
+*fi.Smoothing Medium/Keskitaso: ""
+*fr.Smoothing Medium/Moyen: ""
+*it.Smoothing Medium/Medio: ""
+*ja.Smoothing Medium/標準: ""
+*ko.Smoothing Medium/중간: ""
+*nl.Smoothing Medium/Middel: ""
+*nb.Smoothing Medium/Middels: ""
+*pt.Smoothing Medium/Médio: ""
+*sv.Smoothing Medium/Medium: ""
+*zh_CN.Smoothing Medium/中等: ""
+*zh_TW.Smoothing Medium/中等: ""
+
+*Smoothing Dark/Dark: "
+<< /PostRenderingEnhance true
+    /PostRenderingEnhanceDetails << /REValue 3 /Type 8 >>
+>> setpagedevice"
+*End
+*da.Smoothing Dark/Mørk: ""
+*de.Smoothing Dark/Dunkel: ""
+*es.Smoothing Dark/Oscuro: ""
+*fi.Smoothing Dark/Tumma: ""
+*fr.Smoothing Dark/Foncé: ""
+*it.Smoothing Dark/Scuro: ""
+*ja.Smoothing Dark/濃い: ""
+*ko.Smoothing Dark/어둡게: ""
+*nl.Smoothing Dark/Donker: ""
+*nb.Smoothing Dark/Mørk: ""
+*pt.Smoothing Dark/Escuro: ""
+*sv.Smoothing Dark/Mörk: ""
+*zh_CN.Smoothing Dark/深: ""
+*zh_TW.Smoothing Dark/深: ""
+
+*?Smoothing: "
+  save
+    currentpagedevice /PostRenderingEnhanceDetails get /REValue get
+    [(Off) (Light) (Medium) (Dark)]  exch get print
+  restore
+"
+*End
+*CloseUI: *Smoothing
+
+*CloseGroup: HPImagingOptions
+
+*FreeVM: "6291456"
+*VMOption 64-127MB/64 - 127 MB: "6291456"
+*da.VMOption 64-127MB/64 - 127 MB: ""
+*de.VMOption 64-127MB/64 - 127 MB: ""
+*es.VMOption 64-127MB/64 - 127 MB: ""
+*fi.VMOption 64-127MB/64 - 127 MB: ""
+*fr.VMOption 64-127MB/64 - 127 MB: ""
+*it.VMOption 64-127MB/64 - 127 MB: ""
+*ja.VMOption 64-127MB/64 - 127 MB: ""
+*ko.VMOption 64-127MB/64 - 127 MB: ""
+*nl.VMOption 64-127MB/64 - 127 MB: ""
+*nb.VMOption 64-127MB/64 - 127 MB: ""
+*pt.VMOption 64-127MB/64 - 127 MB: ""
+*sv.VMOption 64-127MB/64 - 127 MB: ""
+*zh_CN.VMOption 64-127MB/64 - 127 MB: ""
+*zh_TW.VMOption 64-127MB/64 - 127 MB: ""
+
+*VMOption 128-255MB/128 - 255 MB: "56623104"
+*da.VMOption 128-255MB/128 - 255 MB: ""
+*de.VMOption 128-255MB/128 - 255 MB: ""
+*es.VMOption 128-255MB/128 - 255 MB: ""
+*fi.VMOption 128-255MB/128 - 255 MB: ""
+*fr.VMOption 128-255MB/128 - 255 MB: ""
+*it.VMOption 128-255MB/128 - 255 MB: ""
+*ja.VMOption 128-255MB/128 - 255 MB: ""
+*ko.VMOption 128-255MB/128 - 255 MB: ""
+*nl.VMOption 128-255MB/128 - 255 MB: ""
+*nb.VMOption 128-255MB/128 - 255 MB: ""
+*pt.VMOption 128-255MB/128 - 255 MB: ""
+*sv.VMOption 128-255MB/128 - 255 MB: ""
+*zh_CN.VMOption 128-255MB/128 - 255 MB: ""
+*zh_TW.VMOption 128-255MB/128 - 255 MB: ""
+
+*VMOption 256-383MB/256 - 383 MB: "123731968"
+*da.VMOption 256-383MB/256 - 383 MB: ""
+*de.VMOption 256-383MB/256 - 383 MB: ""
+*es.VMOption 256-383MB/256 - 383 MB: ""
+*fi.VMOption 256-383MB/256 - 383 MB: ""
+*fr.VMOption 256-383MB/256 - 383 MB: ""
+*it.VMOption 256-383MB/256 - 383 MB: ""
+*ja.VMOption 256-383MB/256 - 383 MB: ""
+*ko.VMOption 256-383MB/256 - 383 MB: ""
+*nl.VMOption 256-383MB/256 - 383 MB: ""
+*nb.VMOption 256-383MB/256 - 383 MB: ""
+*pt.VMOption 256-383MB/256 - 383 MB: ""
+*sv.VMOption 256-383MB/256 - 383 MB: ""
+*zh_CN.VMOption 256-383MB/256 - 383 MB: ""
+*zh_TW.VMOption 256-383MB/256 - 383 MB: ""
+
+*VMOption 384-512MB/384 - 512 MB: "123731968"
+*da.VMOption 384-512MB/384 - 512 MB: ""
+*de.VMOption 384-512MB/384 - 512 MB: ""
+*es.VMOption 384-512MB/384 - 512 MB: ""
+*fi.VMOption 384-512MB/384 - 512 MB: ""
+*fr.VMOption 384-512MB/384 - 512 MB: ""
+*it.VMOption 384-512MB/384 - 512 MB: ""
+*ja.VMOption 384-512MB/384 - 512 MB: ""
+*ko.VMOption 384-512MB/384 - 512 MB: ""
+*nl.VMOption 384-512MB/384 - 512 MB: ""
+*nb.VMOption 384-512MB/384 - 512 MB: ""
+*pt.VMOption 384-512MB/384 - 512 MB: ""
+*sv.VMOption 384-512MB/384 - 512 MB: ""
+*zh_CN.VMOption 384-512MB/384 - 512 MB: ""
+*zh_TW.VMOption 384-512MB/384 - 512 MB: ""
+
+
+*% =================================
+*% Paper Sizes
+*% =================================
+
+*LandscapeOrientation: Plus90
+*VariablePaperSize: False
+*OpenUI *PageSize/Page Size: PickOne
+*OrderDependency: 30 AnySetup *PageSize
+*DefaultPageSize: Letter
+*da.Translation PageSize/Page Size: ""
+*de.Translation PageSize/Papierformat: ""
+*es.Translation PageSize/Tamaño del papel: ""
+*fi.Translation PageSize/Sivukoko: ""
+*fr.Translation PageSize/Format de page: ""
+*it.Translation PageSize/Dimensioni pagina: ""
+*ja.Translation PageSize/ページサイズ: ""
+*ko.Translation PageSize/용지 크기: ""
+*nl.Translation PageSize/Papierformaat: ""
+*nb.Translation PageSize/Papirformat: ""
+*pt.Translation PageSize/Tamanho do papel: ""
+*sv.Translation PageSize/Sidstorlek: ""
+*zh_CN.Translation PageSize/页面大小: ""
+*zh_TW.Translation PageSize/頁面尺寸: ""
+
+*PageSize Letter/Letter: "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Letter/Letter: ""
+*de.PageSize Letter/Letter: ""
+*es.PageSize Letter/Letter: ""
+*fi.PageSize Letter/Letter: ""
+*fr.PageSize Letter/Lettre: ""
+*it.PageSize Letter/Letter: ""
+*ja.PageSize Letter/レター: ""
+*ko.PageSize Letter/레터: ""
+*nl.PageSize Letter/Letter: ""
+*nb.PageSize Letter/Letter: ""
+*pt.PageSize Letter/Carta: ""
+*sv.PageSize Letter/Letter: ""
+*zh_CN.PageSize Letter/信纸: ""
+*zh_TW.PageSize Letter/Letter: ""
+
+*PageSize LetterSmall/Letter (Small): "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize LetterSmall/Letter (lille): ""
+*de.PageSize LetterSmall/Letter (Klein): ""
+*es.PageSize LetterSmall/Letter (pequeño): ""
+*fi.PageSize LetterSmall/Letter (pieni): ""
+*fr.PageSize LetterSmall/Lettre (petit): ""
+*it.PageSize LetterSmall/Letter (ridotta): ""
+*ja.PageSize LetterSmall/レター (小): ""
+*ko.PageSize LetterSmall/레터 (소): ""
+*nl.PageSize LetterSmall/Letter (klein): ""
+*nb.PageSize LetterSmall/Letter (lite): ""
+*pt.PageSize LetterSmall/Carta (pequeno): ""
+*sv.PageSize LetterSmall/Letter (litet): ""
+*zh_CN.PageSize LetterSmall/信纸 (小): ""
+*zh_TW.PageSize LetterSmall/Letter (小): ""
+
+*PageSize Legal/Legal: "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Legal/Legal: ""
+*de.PageSize Legal/Legal: ""
+*es.PageSize Legal/Legal: ""
+*fi.PageSize Legal/Legal: ""
+*fr.PageSize Legal/Légal: ""
+*it.PageSize Legal/Legal: ""
+*ja.PageSize Legal/リーガル: ""
+*ko.PageSize Legal/리갈: ""
+*nl.PageSize Legal/Legal: ""
+*nb.PageSize Legal/Legal: ""
+*pt.PageSize Legal/Legal: ""
+*sv.PageSize Legal/Legal: ""
+*zh_CN.PageSize Legal/Legal: ""
+*zh_TW.PageSize Legal/Legal: ""
+
+*PageSize LegalSmall/Legal (Small): "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize LegalSmall/Legal (lille): ""
+*de.PageSize LegalSmall/Legal (Klein): ""
+*es.PageSize LegalSmall/Legal (pequeño): ""
+*fi.PageSize LegalSmall/Legal (pieni): ""
+*fr.PageSize LegalSmall/Légal (petit): ""
+*it.PageSize LegalSmall/Legal (ridotto): ""
+*ja.PageSize LegalSmall/リーガル (小): ""
+*ko.PageSize LegalSmall/리갈 (소): ""
+*nl.PageSize LegalSmall/Legal (klein): ""
+*nb.PageSize LegalSmall/Legal (lite): ""
+*pt.PageSize LegalSmall/Legal (pequeno): ""
+*sv.PageSize LegalSmall/Legal (litet): ""
+*zh_CN.PageSize LegalSmall/Legal (小): ""
+*zh_TW.PageSize LegalSmall/Legal (小): ""
+
+*PageSize Executive/Executive: "
+	<</DeferredMediaSelection true /PageSize [522 756] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Executive/Executive: ""
+*de.PageSize Executive/Executive: ""
+*es.PageSize Executive/Ejecutivo: ""
+*fi.PageSize Executive/Executive: ""
+*fr.PageSize Executive/Exécutif: ""
+*it.PageSize Executive/Executive: ""
+*ja.PageSize Executive/エグゼクティブ: ""
+*ko.PageSize Executive/Executive: ""
+*nl.PageSize Executive/Executive: ""
+*nb.PageSize Executive/Executive: ""
+*pt.PageSize Executive/Executivo: ""
+*sv.PageSize Executive/Executive: ""
+*zh_CN.PageSize Executive/Executive: ""
+*zh_TW.PageSize Executive/Executive: ""
+
+*PageSize HalfLetter/Statement: "
+    <</DeferredMediaSelection true /PageSize [396 612] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize HalfLetter/Statement: ""
+*de.PageSize HalfLetter/Statement: ""
+*es.PageSize HalfLetter/Declaración: ""
+*fi.PageSize HalfLetter/Statement: ""
+*fr.PageSize HalfLetter/1/2 Lettre: ""
+*it.PageSize HalfLetter/Dichiarazione: ""
+*ja.PageSize HalfLetter/Statement: ""
+*ko.PageSize HalfLetter/2절 레터: ""
+*nl.PageSize HalfLetter/1/2 Letter : ""
+*nb.PageSize HalfLetter/1/2 Letter: ""
+*pt.PageSize HalfLetter/Statement: ""
+*sv.PageSize HalfLetter/Statement: ""
+*zh_CN.PageSize HalfLetter/结算单: ""
+*zh_TW.PageSize HalfLetter/Statement: ""
+
+*PageSize w612h935/8.5x13: "
+  	<</DeferredMediaSelection true /PageSize [612 935] /ImagingBBox null /MediaClass (8.5X13)>> setpagedevice"
+*End
+*da.PageSize w612h935/8.5x13: ""
+*de.PageSize w612h935/8.5x13: ""
+*es.PageSize w612h935/8.5x13: ""
+*fi.PageSize w612h935/8.5x13: ""
+*fr.PageSize w612h935/8.5x13: ""
+*it.PageSize w612h935/8.5x13: ""
+*ja.PageSize w612h935/8.5x13: ""
+*ko.PageSize w612h935/8.5x13: ""
+*nl.PageSize w612h935/8.5x13: ""
+*nb.PageSize w612h935/8.5x13: ""
+*pt.PageSize w612h935/8.5x13: ""
+*sv.PageSize w612h935/8.5x13: ""
+*zh_CN.PageSize w612h935/8.5x13: ""
+*zh_TW.PageSize w612h935/8.5x13: ""
+
+*PageSize Tabloid/11x17: "
+    <</DeferredMediaSelection true /PageSize [792 1224] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Tabloid/11x17: ""
+*de.PageSize Tabloid/11x17 Zoll: ""
+*es.PageSize Tabloid/11x17: ""
+*fi.PageSize Tabloid/11x17: ""
+*fr.PageSize Tabloid/11 x 17 pouces: ""
+*it.PageSize Tabloid/11x17: ""
+*ja.PageSize Tabloid/11x17: ""
+*ko.PageSize Tabloid/11x17: ""
+*nl.PageSize Tabloid/11x17: ""
+*nb.PageSize Tabloid/11x17: ""
+*pt.PageSize Tabloid/11x17: ""
+*sv.PageSize Tabloid/11x17: ""
+*zh_CN.PageSize Tabloid/11x17: ""
+*zh_TW.PageSize Tabloid/11x17 : ""
+
+*PageSize 12X18/12x18: "
+    <</DeferredMediaSelection true /PageSize [864 1296] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize 12X18/12x18: ""
+*de.PageSize 12X18/12x18: ""
+*es.PageSize 12X18/12x18: ""
+*fi.PageSize 12X18/12x18: ""
+*fr.PageSize 12X18/12x18: ""
+*it.PageSize 12X18/12x18: ""
+*ja.PageSize 12X18/12x18: ""
+*ko.PageSize 12X18/12x18: ""
+*nl.PageSize 12X18/12x18: ""
+*nb.PageSize 12X18/12x18: ""
+*pt.PageSize 12X18/12x18: ""
+*sv.PageSize 12X18/12x18: ""
+*zh_CN.PageSize 12X18/12x18: ""
+*zh_TW.PageSize 12X18/12x18: ""
+
+*PageSize A3/A3: "
+    <</DeferredMediaSelection true /PageSize [842 1191] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A3/A3: ""
+*de.PageSize A3/A3: ""
+*es.PageSize A3/A3: ""
+*fi.PageSize A3/A3: ""
+*fr.PageSize A3/A3: ""
+*it.PageSize A3/A3: ""
+*ja.PageSize A3/A3: ""
+*ko.PageSize A3/A3: ""
+*nl.PageSize A3/A3: ""
+*nb.PageSize A3/A3: ""
+*pt.PageSize A3/A3: ""
+*sv.PageSize A3/A3: ""
+*zh_CN.PageSize A3/A3: ""
+*zh_TW.PageSize A3/A3: ""
+
+*PageSize RA3/RA3: "
+    <</DeferredMediaSelection true /PageSize [865 1219] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize RA3/RA3: ""
+*de.PageSize RA3/RA3: ""
+*es.PageSize RA3/RA3: ""
+*fi.PageSize RA3/RA3: ""
+*fr.PageSize RA3/RA3: ""
+*it.PageSize RA3/RA3: ""
+*ja.PageSize RA3/RA3: ""
+*ko.PageSize RA3/RA3: ""
+*nl.PageSize RA3/RA3: ""
+*nb.PageSize RA3/RA3: ""
+*pt.PageSize RA3/RA3: ""
+*sv.PageSize RA3/RA3: ""
+*zh_CN.PageSize RA3/RA3: ""
+*zh_TW.PageSize RA3/RA3: ""
+
+*PageSize A4/A4: "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A4/A4: ""
+*de.PageSize A4/A4: ""
+*es.PageSize A4/A4: ""
+*fi.PageSize A4/A4: ""
+*fr.PageSize A4/A4: ""
+*it.PageSize A4/A4: ""
+*ja.PageSize A4/A4: ""
+*ko.PageSize A4/A4: ""
+*nl.PageSize A4/A4: ""
+*nb.PageSize A4/A4: ""
+*pt.PageSize A4/A4: ""
+*sv.PageSize A4/A4: ""
+*zh_CN.PageSize A4/A4: ""
+*zh_TW.PageSize A4/A4: ""
+
+*PageSize A4Small/A4 (Small): "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A4Small/A4 (lille): ""
+*de.PageSize A4Small/A4 (Klein): ""
+*es.PageSize A4Small/A4 (pequeño): ""
+*fi.PageSize A4Small/A4 (pieni): ""
+*fr.PageSize A4Small/A4 (petit): ""
+*it.PageSize A4Small/A4 (ridotta): ""
+*ja.PageSize A4Small/A4 (小): ""
+*ko.PageSize A4Small/A4 (소): ""
+*nl.PageSize A4Small/A4 (klein): ""
+*nb.PageSize A4Small/A4 (lite): ""
+*pt.PageSize A4Small/A4 (pequeno): ""
+*sv.PageSize A4Small/A4 (litet): ""
+*zh_CN.PageSize A4Small/A4 (小): ""
+*zh_TW.PageSize A4Small/A4 (小): ""
+
+*PageSize A5/A5: "
+	<</DeferredMediaSelection true /PageSize [420 595] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize A5/A5: ""
+*de.PageSize A5/A5: ""
+*es.PageSize A5/A5: ""
+*fi.PageSize A5/A5: ""
+*fr.PageSize A5/A5: ""
+*it.PageSize A5/A5: ""
+*ja.PageSize A5/A5: ""
+*ko.PageSize A5/A5: ""
+*nl.PageSize A5/A5: ""
+*nb.PageSize A5/A5: ""
+*pt.PageSize A5/A5: ""
+*sv.PageSize A5/A5: ""
+*zh_CN.PageSize A5/A5: ""
+*zh_TW.PageSize A5/A5: ""
+
+*PageSize B5/B5 (JIS): "
+	<</DeferredMediaSelection true /PageSize [516 729] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize B5/JIS B5: ""
+*de.PageSize B5/B5 (JIS): ""
+*es.PageSize B5/JIS B5: ""
+*fi.PageSize B5/JIS B5: ""
+*fr.PageSize B5/JIS B5: ""
+*it.PageSize B5/JIS B5: ""
+*ja.PageSize B5/B5 (JIS): ""
+*ko.PageSize B5/JIS B5: ""
+*nl.PageSize B5/JIS B5: ""
+*nb.PageSize B5/JIS B5: ""
+*pt.PageSize B5/B5 JIS: ""
+*sv.PageSize B5/JIS B5: ""
+*zh_CN.PageSize B5/JIS B5: ""
+*zh_TW.PageSize B5/JIS B5: ""
+
+*PageSize B4/B4 (JIS): "
+    <</DeferredMediaSelection true /PageSize [729 1032] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize B4/JIS B4: ""
+*de.PageSize B4/B4 (JIS): ""
+*es.PageSize B4/JIS B4: ""
+*fi.PageSize B4/JIS B4: ""
+*fr.PageSize B4/JIS B4: ""
+*it.PageSize B4/JIS B4: ""
+*ja.PageSize B4/B4 (JIS): ""
+*ko.PageSize B4/JIS B4: ""
+*nl.PageSize B4/JIS B4: ""
+*nb.PageSize B4/JIS B4: ""
+*pt.PageSize B4/B4 JIS: ""
+*sv.PageSize B4/JIS B4: ""
+*zh_CN.PageSize B4/JIS B4: ""
+*zh_TW.PageSize B4/JIS B4: ""
+
+*PageSize w612h936/Executive (JIS): "
+    <</DeferredMediaSelection true /PageSize [612 936] /ImagingBBox null /MediaClass (JISEXEC)>> setpagedevice"
+*End
+*da.PageSize w612h936/Executive (JIS): ""
+*de.PageSize w612h936/Executive (JIS): ""
+*es.PageSize w612h936/Ejecutivo (JIS): ""
+*fi.PageSize w612h936/Executive (JIS): ""
+*fr.PageSize w612h936/Exécutif (JIS): ""
+*it.PageSize w612h936/Executive (JIS): ""
+*ja.PageSize w612h936/エグゼクティブ (JIS): ""
+*ko.PageSize w612h936/Executive(JIS): ""
+*nl.PageSize w612h936/Executive (JIS): ""
+*nb.PageSize w612h936/Executive (JIS): ""
+*pt.PageSize w612h936/Executivo (JIS): ""
+*sv.PageSize w612h936/Executive (JIS): ""
+*zh_CN.PageSize w612h936/Executive (JIS): ""
+*zh_TW.PageSize w612h936/Executive (JIS): ""
+
+*PageSize DoublePostcard/Double Postcard (JIS): "
+    <</DeferredMediaSelection true /PageSize [419.5 567] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize DoublePostcard/Dobbelt postkort (JIS): ""
+*de.PageSize DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.PageSize DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.PageSize DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.PageSize DoublePostcard/Carte postale double (JIS): ""
+*it.PageSize DoublePostcard/Cartolina doppia (JIS): ""
+*ja.PageSize DoublePostcard/往復はがき (JIS): ""
+*ko.PageSize DoublePostcard/양면 엽서 (JIS): ""
+*nl.PageSize DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.PageSize DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.PageSize DoublePostcard/Postal duplo (JIS): ""
+*sv.PageSize DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.PageSize DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.PageSize DoublePostcard/雙面明信片 (JIS): ""
+
+*PageSize w774h1116/8K: "
+    <</DeferredMediaSelection true /PageSize [774 1116] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize w774h1116/8K: ""
+*de.PageSize w774h1116/8K: ""
+*es.PageSize w774h1116/8K: ""
+*fi.PageSize w774h1116/8K: ""
+*fr.PageSize w774h1116/8K: ""
+*it.PageSize w774h1116/8K: ""
+*ja.PageSize w774h1116/8K: ""
+*ko.PageSize w774h1116/8K: ""
+*nl.PageSize w774h1116/8K: ""
+*nb.PageSize w774h1116/8K: ""
+*pt.PageSize w774h1116/8K: ""
+*sv.PageSize w774h1116/8K: ""
+*zh_CN.PageSize w774h1116/8K: ""
+*zh_TW.PageSize w774h1116/8K: ""
+
+*PageSize w558h774/16K: "
+    <</DeferredMediaSelection true /PageSize [558 774] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize w558h774/16K: ""
+*de.PageSize w558h774/16K: ""
+*es.PageSize w558h774/16K: ""
+*fi.PageSize w558h774/16K: ""
+*fr.PageSize w558h774/16K: ""
+*it.PageSize w558h774/16K: ""
+*ja.PageSize w558h774/16K: ""
+*ko.PageSize w558h774/16K: ""
+*nl.PageSize w558h774/16K: ""
+*nb.PageSize w558h774/16K: ""
+*pt.PageSize w558h774/16K: ""
+*sv.PageSize w558h774/16K: ""
+*zh_CN.PageSize w558h774/16K: ""
+*zh_TW.PageSize w558h774/16K: ""
+
+*PageSize EnvISOB5/Env B5: "
+	<</DeferredMediaSelection true /PageSize [499 709] /ImagingBBox null /MediaClass (Envelope)>> setpagedevice"
+*End
+*da.PageSize EnvISOB5/Konv ISO B5: ""
+*de.PageSize EnvISOB5/Umschlag ISO B5: ""
+*es.PageSize EnvISOB5/Sobre ISO B5: ""
+*fi.PageSize EnvISOB5/Kirjekuori ISO B5: ""
+*fr.PageSize EnvISOB5/Enveloppe ISO B5: ""
+*it.PageSize EnvISOB5/Busta B5: ""
+*ja.PageSize EnvISOB5/封筒 ISO B5: ""
+*ko.PageSize EnvISOB5/ISO B5 봉투: ""
+*nl.PageSize EnvISOB5/ISO B5-envelop: ""
+*nb.PageSize EnvISOB5/B5-konvolutt: ""
+*pt.PageSize EnvISOB5/Envelope B5: ""
+*sv.PageSize EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.PageSize EnvISOB5/信封 ISO B5: ""
+*zh_TW.PageSize EnvISOB5/ISO B5 信封: ""
+
+*PageSize Env10/Env Comm10: "
+	<</DeferredMediaSelection true /PageSize [297 684] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize Env10/Konv Comm10: ""
+*de.PageSize Env10/Umschlag Comm10: ""
+*es.PageSize Env10/Sobre Comm10: ""
+*fi.PageSize Env10/Kirjekuori Comm10: ""
+*fr.PageSize Env10/Enveloppe Comm10: ""
+*it.PageSize Env10/Busta Comm10: ""
+*ja.PageSize Env10/封筒 Comm10: ""
+*ko.PageSize Env10/Comm10 봉투: ""
+*nl.PageSize Env10/Comm10-envelop: ""
+*nb.PageSize Env10/Comm10-konvolutt: ""
+*pt.PageSize Env10/Envelope Comm10: ""
+*sv.PageSize Env10/Comm10-kuvert: ""
+*zh_CN.PageSize Env10/信封 Comm10: ""
+*zh_TW.PageSize Env10/Comm10 信封: ""
+
+*PageSize EnvC5/Env C5: "
+	<</DeferredMediaSelection true /PageSize [459 649] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize EnvC5/Konv C5: ""
+*de.PageSize EnvC5/Umschlag C5: ""
+*es.PageSize EnvC5/Sobre C5: ""
+*fi.PageSize EnvC5/Kirjekuori C5: ""
+*fr.PageSize EnvC5/Enveloppe C5: ""
+*it.PageSize EnvC5/Busta C5: ""
+*ja.PageSize EnvC5/封筒 C5: ""
+*ko.PageSize EnvC5/C5 봉투: ""
+*nl.PageSize EnvC5/C5-envelop: ""
+*nb.PageSize EnvC5/C5-konvolutt: ""
+*pt.PageSize EnvC5/Envelope C5: ""
+*sv.PageSize EnvC5/C5-kuvert: ""
+*zh_CN.PageSize EnvC5/信封 C5: ""
+*zh_TW.PageSize EnvC5/C5 信封: ""
+
+*PageSize EnvDL/Env DL: "
+	<</DeferredMediaSelection true /PageSize [312 624] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize EnvDL/Konv DL: ""
+*de.PageSize EnvDL/Umschlag DL: ""
+*es.PageSize EnvDL/Sobre DL: ""
+*fi.PageSize EnvDL/Kirjekuori DL: ""
+*fr.PageSize EnvDL/Enveloppe DL: ""
+*it.PageSize EnvDL/Busta DL: ""
+*ja.PageSize EnvDL/封筒 DL: ""
+*ko.PageSize EnvDL/DL 봉투: ""
+*nl.PageSize EnvDL/DL-envelop: ""
+*nb.PageSize EnvDL/DL-konvolutt: ""
+*pt.PageSize EnvDL/Envelope DL: ""
+*sv.PageSize EnvDL/DL-kuvert: ""
+*zh_CN.PageSize EnvDL/信封 DL: ""
+*zh_TW.PageSize EnvDL/DL 信封: ""
+
+*PageSize EnvMonarch/Env Monarch: "
+	<</DeferredMediaSelection true /PageSize [279 540] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageSize EnvMonarch/Konv Monarch: ""
+*de.PageSize EnvMonarch/Umschlag Monarch: ""
+*es.PageSize EnvMonarch/Sobre Monarch: ""
+*fi.PageSize EnvMonarch/Kirjekuori Monarch: ""
+*fr.PageSize EnvMonarch/Enveloppe Monarch: ""
+*it.PageSize EnvMonarch/Busta Monarch: ""
+*ja.PageSize EnvMonarch/封筒 Monarch: ""
+*ko.PageSize EnvMonarch/Monarch 봉투: ""
+*nl.PageSize EnvMonarch/Monarch-envelop: ""
+*nb.PageSize EnvMonarch/Monarch-konvolutt: ""
+*pt.PageSize EnvMonarch/Envelope Monarch: ""
+*sv.PageSize EnvMonarch/Monarch-kuvert: ""
+*zh_CN.PageSize EnvMonarch/信封 Monarch: ""
+*zh_TW.PageSize EnvMonarch/Monarch 信封: ""
+
+*?PageSize: "
+ save
+   currentpagedevice /PageSize get aload pop
+   2 copy gt {exch} if
+   (Unknown)
+  22 dict
+   dup [612 792] (Letter) put
+   dup [612 1008] (Legal) put
+   dup [522 756] (Executive) put
+   dup [396 612] (HalfLetter) put
+   dup [612 936]  (w612h935) put
+   dup [792 1224] (Tabloid) put
+   dup [864 1296] (12X18) put
+   dup [842 1191] (A3) put
+   dup [865 1219] (RA3) put
+   dup [595 842] (A4) put
+   dup [420 595] (A5) put
+   dup [516 728] (B5) put
+   dup [728 1032] (B4) put
+   dup [612 936]  (w612h936) put
+   dup [419.5 567](DoublePostcard) put
+   dup [774 1116] (w774h1116) put
+   dup [558 774]  (w558h774) put
+   dup [499 709] (EnvISOB5) put
+   dup [297 684] (Env10) put
+   dup [459 649] (EnvC5) put
+   dup [312 624] (EnvDL) put
+   dup [279 540] (EnvMonarch) put
+ { exch aload pop 4 index sub abs 5 le exch
+   5 index sub abs 5 le and
+      {exch pop exit} {pop} ifelse
+   } bind forall
+   = flush pop pop
+restore
+"
+*End
+*CloseUI: *PageSize
+*OpenUI *PageRegion/Page Region:  PickOne
+*OrderDependency: 30 AnySetup *PageRegion
+*DefaultPageRegion: Letter
+*da.Translation PageRegion/Page Region: ""
+*de.Translation PageRegion/Seitenbereich: ""
+*es.Translation PageRegion/Dimensión de papel: ""
+*fi.Translation PageRegion/Sivuseutu: ""
+*fr.Translation PageRegion/Région de page: ""
+*it.Translation PageRegion/Dimensioni regione: ""
+*ja.Translation PageRegion/Page Region: ""
+*ko.Translation PageRegion/Page Region: ""
+*nl.Translation PageRegion/Page Region: ""
+*nb.Translation PageRegion/Page Region: ""
+*pt.Translation PageRegion/Região do papel: ""
+*sv.Translation PageRegion/Page Region: ""
+*zh_CN.Translation PageRegion/Page Region: ""
+*zh_TW.Translation PageRegion/Page Region: ""
+
+*PageRegion Letter/Letter: "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Letter/Letter: ""
+*de.PageRegion Letter/Letter: ""
+*es.PageRegion Letter/Letter: ""
+*fi.PageRegion Letter/Letter: ""
+*fr.PageRegion Letter/Lettre: ""
+*it.PageRegion Letter/Letter: ""
+*ja.PageRegion Letter/レター: ""
+*ko.PageRegion Letter/레터: ""
+*nl.PageRegion Letter/Letter: ""
+*nb.PageRegion Letter/Letter: ""
+*pt.PageRegion Letter/Carta: ""
+*sv.PageRegion Letter/Letter: ""
+*zh_CN.PageRegion Letter/信纸: ""
+*zh_TW.PageRegion Letter/Letter: ""
+
+*PageRegion LetterSmall/Letter (Small): "
+	<</DeferredMediaSelection true /PageSize [612 792] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion LetterSmall/Letter (lille): ""
+*de.PageRegion LetterSmall/Letter (Klein): ""
+*es.PageRegion LetterSmall/Letter (pequeño): ""
+*fi.PageRegion LetterSmall/Letter (pieni): ""
+*fr.PageRegion LetterSmall/Lettre (petit): ""
+*it.PageRegion LetterSmall/Letter (ridotta): ""
+*ja.PageRegion LetterSmall/レター (小): ""
+*ko.PageRegion LetterSmall/레터 (소): ""
+*nl.PageRegion LetterSmall/Letter (klein): ""
+*nb.PageRegion LetterSmall/Letter (lite): ""
+*pt.PageRegion LetterSmall/Carta (pequeno): ""
+*sv.PageRegion LetterSmall/Letter (litet): ""
+*zh_CN.PageRegion LetterSmall/信纸 (小): ""
+*zh_TW.PageRegion LetterSmall/Letter (小): ""
+
+*PageRegion Legal/Legal: "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Legal/Legal: ""
+*de.PageRegion Legal/Legal: ""
+*es.PageRegion Legal/Legal: ""
+*fi.PageRegion Legal/Legal: ""
+*fr.PageRegion Legal/Légal: ""
+*it.PageRegion Legal/Legal: ""
+*ja.PageRegion Legal/リーガル: ""
+*ko.PageRegion Legal/리갈: ""
+*nl.PageRegion Legal/Legal: ""
+*nb.PageRegion Legal/Legal: ""
+*pt.PageRegion Legal/Legal: ""
+*sv.PageRegion Legal/Legal: ""
+*zh_CN.PageRegion Legal/Legal: ""
+*zh_TW.PageRegion Legal/Legal: ""
+
+*PageRegion LegalSmall/Legal (Small): "
+	<</DeferredMediaSelection true /PageSize [612 1008] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion LegalSmall/Legal (lille): ""
+*de.PageRegion LegalSmall/Legal (Klein): ""
+*es.PageRegion LegalSmall/Legal (pequeño): ""
+*fi.PageRegion LegalSmall/Legal (pieni): ""
+*fr.PageRegion LegalSmall/Légal (petit): ""
+*it.PageRegion LegalSmall/Legal (ridotto): ""
+*ja.PageRegion LegalSmall/リーガル (小): ""
+*ko.PageRegion LegalSmall/리갈 (소): ""
+*nl.PageRegion LegalSmall/Legal (klein): ""
+*nb.PageRegion LegalSmall/Legal (lite): ""
+*pt.PageRegion LegalSmall/Legal (pequeno): ""
+*sv.PageRegion LegalSmall/Legal (litet): ""
+*zh_CN.PageRegion LegalSmall/Legal (小): ""
+*zh_TW.PageRegion LegalSmall/Legal (小): ""
+
+*PageRegion Executive/Executive: "
+	<</DeferredMediaSelection true /PageSize [522 756] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Executive/Executive: ""
+*de.PageRegion Executive/Executive: ""
+*es.PageRegion Executive/Ejecutivo: ""
+*fi.PageRegion Executive/Executive: ""
+*fr.PageRegion Executive/Exécutif: ""
+*it.PageRegion Executive/Executive: ""
+*ja.PageRegion Executive/エグゼクティブ: ""
+*ko.PageRegion Executive/Executive: ""
+*nl.PageRegion Executive/Executive: ""
+*nb.PageRegion Executive/Executive: ""
+*pt.PageRegion Executive/Executivo: ""
+*sv.PageRegion Executive/Executive: ""
+*zh_CN.PageRegion Executive/Executive: ""
+*zh_TW.PageRegion Executive/Executive: ""
+
+*PageRegion HalfLetter/Statement: "
+    <</DeferredMediaSelection true /PageSize [396 612] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion HalfLetter/Statement: ""
+*de.PageRegion HalfLetter/Statement: ""
+*es.PageRegion HalfLetter/Declaración: ""
+*fi.PageRegion HalfLetter/Statement: ""
+*fr.PageRegion HalfLetter/1/2 Lettre: ""
+*it.PageRegion HalfLetter/Dichiarazione: ""
+*ja.PageRegion HalfLetter/Statement: ""
+*ko.PageRegion HalfLetter/2절 레터: ""
+*nl.PageRegion HalfLetter/1/2 Letter : ""
+*nb.PageRegion HalfLetter/1/2 Letter: ""
+*pt.PageRegion HalfLetter/Statement: ""
+*sv.PageRegion HalfLetter/Statement: ""
+*zh_CN.PageRegion HalfLetter/结算单: ""
+*zh_TW.PageRegion HalfLetter/Statement: ""
+
+*PageRegion w612h935/8.5x13: "
+  	<</DeferredMediaSelection true /PageSize [612 935] /ImagingBBox null /MediaClass (8.5X13)>> setpagedevice"
+*End
+*da.PageRegion w612h935/8.5x13: ""
+*de.PageRegion w612h935/8.5x13: ""
+*es.PageRegion w612h935/8.5x13: ""
+*fi.PageRegion w612h935/8.5x13: ""
+*fr.PageRegion w612h935/8.5x13: ""
+*it.PageRegion w612h935/8.5x13: ""
+*ja.PageRegion w612h935/8.5x13: ""
+*ko.PageRegion w612h935/8.5x13: ""
+*nl.PageRegion w612h935/8.5x13: ""
+*nb.PageRegion w612h935/8.5x13: ""
+*pt.PageRegion w612h935/8.5x13: ""
+*sv.PageRegion w612h935/8.5x13: ""
+*zh_CN.PageRegion w612h935/8.5x13: ""
+*zh_TW.PageRegion w612h935/8.5x13: ""
+
+*PageRegion Tabloid/11x17: "
+    <</DeferredMediaSelection true /PageSize [792 1224] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Tabloid/11x17: ""
+*de.PageRegion Tabloid/11x17 Zoll: ""
+*es.PageRegion Tabloid/11x17: ""
+*fi.PageRegion Tabloid/11x17: ""
+*fr.PageRegion Tabloid/11 x 17 pouces: ""
+*it.PageRegion Tabloid/11x17: ""
+*ja.PageRegion Tabloid/11x17: ""
+*ko.PageRegion Tabloid/11x17: ""
+*nl.PageRegion Tabloid/11x17: ""
+*nb.PageRegion Tabloid/11x17: ""
+*pt.PageRegion Tabloid/11x17: ""
+*sv.PageRegion Tabloid/11x17: ""
+*zh_CN.PageRegion Tabloid/11x17: ""
+*zh_TW.PageRegion Tabloid/11x17 : ""
+
+*PageRegion 12X18/12x18: "
+    <</DeferredMediaSelection true /PageSize [864 1296] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion 12X18/12x18: ""
+*de.PageRegion 12X18/12x18: ""
+*es.PageRegion 12X18/12x18: ""
+*fi.PageRegion 12X18/12x18: ""
+*fr.PageRegion 12X18/12x18: ""
+*it.PageRegion 12X18/12x18: ""
+*ja.PageRegion 12X18/12x18: ""
+*ko.PageRegion 12X18/12x18: ""
+*nl.PageRegion 12X18/12x18: ""
+*nb.PageRegion 12X18/12x18: ""
+*pt.PageRegion 12X18/12x18: ""
+*sv.PageRegion 12X18/12x18: ""
+*zh_CN.PageRegion 12X18/12x18: ""
+*zh_TW.PageRegion 12X18/12x18: ""
+
+*PageRegion A3/A3: "
+    <</DeferredMediaSelection true /PageSize [842 1191] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A3/A3: ""
+*de.PageRegion A3/A3: ""
+*es.PageRegion A3/A3: ""
+*fi.PageRegion A3/A3: ""
+*fr.PageRegion A3/A3: ""
+*it.PageRegion A3/A3: ""
+*ja.PageRegion A3/A3: ""
+*ko.PageRegion A3/A3: ""
+*nl.PageRegion A3/A3: ""
+*nb.PageRegion A3/A3: ""
+*pt.PageRegion A3/A3: ""
+*sv.PageRegion A3/A3: ""
+*zh_CN.PageRegion A3/A3: ""
+*zh_TW.PageRegion A3/A3: ""
+
+*PageRegion RA3/RA3: "
+    <</DeferredMediaSelection true /PageSize [865 1219] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion RA3/RA3: ""
+*de.PageRegion RA3/RA3: ""
+*es.PageRegion RA3/RA3: ""
+*fi.PageRegion RA3/RA3: ""
+*fr.PageRegion RA3/RA3: ""
+*it.PageRegion RA3/RA3: ""
+*ja.PageRegion RA3/RA3: ""
+*ko.PageRegion RA3/RA3: ""
+*nl.PageRegion RA3/RA3: ""
+*nb.PageRegion RA3/RA3: ""
+*pt.PageRegion RA3/RA3: ""
+*sv.PageRegion RA3/RA3: ""
+*zh_CN.PageRegion RA3/RA3: ""
+*zh_TW.PageRegion RA3/RA3: ""
+
+*PageRegion A4/A4: "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A4/A4: ""
+*de.PageRegion A4/A4: ""
+*es.PageRegion A4/A4: ""
+*fi.PageRegion A4/A4: ""
+*fr.PageRegion A4/A4: ""
+*it.PageRegion A4/A4: ""
+*ja.PageRegion A4/A4: ""
+*ko.PageRegion A4/A4: ""
+*nl.PageRegion A4/A4: ""
+*nb.PageRegion A4/A4: ""
+*pt.PageRegion A4/A4: ""
+*sv.PageRegion A4/A4: ""
+*zh_CN.PageRegion A4/A4: ""
+*zh_TW.PageRegion A4/A4: ""
+
+*PageRegion A4Small/A4 (Small): "
+	<</DeferredMediaSelection true /PageSize [595 842] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A4Small/A4 (lille): ""
+*de.PageRegion A4Small/A4 (Klein): ""
+*es.PageRegion A4Small/A4 (pequeño): ""
+*fi.PageRegion A4Small/A4 (pieni): ""
+*fr.PageRegion A4Small/A4 (petit): ""
+*it.PageRegion A4Small/A4 (ridotta): ""
+*ja.PageRegion A4Small/A4 (小): ""
+*ko.PageRegion A4Small/A4 (소): ""
+*nl.PageRegion A4Small/A4 (klein): ""
+*nb.PageRegion A4Small/A4 (lite): ""
+*pt.PageRegion A4Small/A4 (pequeno): ""
+*sv.PageRegion A4Small/A4 (litet): ""
+*zh_CN.PageRegion A4Small/A4 (小): ""
+*zh_TW.PageRegion A4Small/A4 (小): ""
+
+*PageRegion A5/A5: "
+	<</DeferredMediaSelection true /PageSize [420 595] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion A5/A5: ""
+*de.PageRegion A5/A5: ""
+*es.PageRegion A5/A5: ""
+*fi.PageRegion A5/A5: ""
+*fr.PageRegion A5/A5: ""
+*it.PageRegion A5/A5: ""
+*ja.PageRegion A5/A5: ""
+*ko.PageRegion A5/A5: ""
+*nl.PageRegion A5/A5: ""
+*nb.PageRegion A5/A5: ""
+*pt.PageRegion A5/A5: ""
+*sv.PageRegion A5/A5: ""
+*zh_CN.PageRegion A5/A5: ""
+*zh_TW.PageRegion A5/A5: ""
+
+*PageRegion B5/B5 (JIS): "
+	<</DeferredMediaSelection true /PageSize [516 729] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion B5/JIS B5: ""
+*de.PageRegion B5/B5 (JIS): ""
+*es.PageRegion B5/JIS B5: ""
+*fi.PageRegion B5/JIS B5: ""
+*fr.PageRegion B5/JIS B5: ""
+*it.PageRegion B5/JIS B5: ""
+*ja.PageRegion B5/B5 (JIS): ""
+*ko.PageRegion B5/JIS B5: ""
+*nl.PageRegion B5/JIS B5: ""
+*nb.PageRegion B5/JIS B5: ""
+*pt.PageRegion B5/B5 JIS: ""
+*sv.PageRegion B5/JIS B5: ""
+*zh_CN.PageRegion B5/JIS B5: ""
+*zh_TW.PageRegion B5/JIS B5: ""
+
+*PageRegion B4/B4 (JIS): "
+    <</DeferredMediaSelection true /PageSize [729 1032] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion B4/JIS B4: ""
+*de.PageRegion B4/B4 (JIS): ""
+*es.PageRegion B4/JIS B4: ""
+*fi.PageRegion B4/JIS B4: ""
+*fr.PageRegion B4/JIS B4: ""
+*it.PageRegion B4/JIS B4: ""
+*ja.PageRegion B4/B4 (JIS): ""
+*ko.PageRegion B4/JIS B4: ""
+*nl.PageRegion B4/JIS B4: ""
+*nb.PageRegion B4/JIS B4: ""
+*pt.PageRegion B4/B4 JIS: ""
+*sv.PageRegion B4/JIS B4: ""
+*zh_CN.PageRegion B4/JIS B4: ""
+*zh_TW.PageRegion B4/JIS B4: ""
+
+*PageRegion w612h936/Executive (JIS): "
+    <</DeferredMediaSelection true /PageSize [612 936] /ImagingBBox null /MediaClass (JISEXEC)>> setpagedevice"
+*End
+*da.PageRegion w612h936/Executive (JIS): ""
+*de.PageRegion w612h936/Executive (JIS): ""
+*es.PageRegion w612h936/Ejecutivo (JIS): ""
+*fi.PageRegion w612h936/Executive (JIS): ""
+*fr.PageRegion w612h936/Exécutif (JIS): ""
+*it.PageRegion w612h936/Executive (JIS): ""
+*ja.PageRegion w612h936/エグゼクティブ (JIS): ""
+*ko.PageRegion w612h936/Executive(JIS): ""
+*nl.PageRegion w612h936/Executive (JIS): ""
+*nb.PageRegion w612h936/Executive (JIS): ""
+*pt.PageRegion w612h936/Executivo (JIS): ""
+*sv.PageRegion w612h936/Executive (JIS): ""
+*zh_CN.PageRegion w612h936/Executive (JIS): ""
+*zh_TW.PageRegion w612h936/Executive (JIS): ""
+
+*PageRegion DoublePostcard/Double Postcard (JIS): "
+    <</DeferredMediaSelection true /PageSize [419.5 567] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion DoublePostcard/Dobbelt postkort (JIS): ""
+*de.PageRegion DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.PageRegion DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.PageRegion DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.PageRegion DoublePostcard/Carte postale double (JIS): ""
+*it.PageRegion DoublePostcard/Cartolina doppia (JIS): ""
+*ja.PageRegion DoublePostcard/往復はがき (JIS): ""
+*ko.PageRegion DoublePostcard/양면 엽서 (JIS): ""
+*nl.PageRegion DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.PageRegion DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.PageRegion DoublePostcard/Postal duplo (JIS): ""
+*sv.PageRegion DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.PageRegion DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.PageRegion DoublePostcard/雙面明信片 (JIS): ""
+
+*PageRegion w774h1116/8K: "
+    <</DeferredMediaSelection true /PageSize [774 1116] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion w774h1116/8K: ""
+*de.PageRegion w774h1116/8K: ""
+*es.PageRegion w774h1116/8K: ""
+*fi.PageRegion w774h1116/8K: ""
+*fr.PageRegion w774h1116/8K: ""
+*it.PageRegion w774h1116/8K: ""
+*ja.PageRegion w774h1116/8K: ""
+*ko.PageRegion w774h1116/8K: ""
+*nl.PageRegion w774h1116/8K: ""
+*nb.PageRegion w774h1116/8K: ""
+*pt.PageRegion w774h1116/8K: ""
+*sv.PageRegion w774h1116/8K: ""
+*zh_CN.PageRegion w774h1116/8K: ""
+*zh_TW.PageRegion w774h1116/8K: ""
+
+*PageRegion w558h774/16K: "
+    <</DeferredMediaSelection true /PageSize [558 774] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion w558h774/16K: ""
+*de.PageRegion w558h774/16K: ""
+*es.PageRegion w558h774/16K: ""
+*fi.PageRegion w558h774/16K: ""
+*fr.PageRegion w558h774/16K: ""
+*it.PageRegion w558h774/16K: ""
+*ja.PageRegion w558h774/16K: ""
+*ko.PageRegion w558h774/16K: ""
+*nl.PageRegion w558h774/16K: ""
+*nb.PageRegion w558h774/16K: ""
+*pt.PageRegion w558h774/16K: ""
+*sv.PageRegion w558h774/16K: ""
+*zh_CN.PageRegion w558h774/16K: ""
+*zh_TW.PageRegion w558h774/16K: ""
+
+*PageRegion EnvISOB5/Env B5: "
+	<</DeferredMediaSelection true /PageSize [499 709] /ImagingBBox null /MediaClass (Envelope)>> setpagedevice"
+*End
+*da.PageRegion EnvISOB5/Konv ISO B5: ""
+*de.PageRegion EnvISOB5/Umschlag ISO B5: ""
+*es.PageRegion EnvISOB5/Sobre ISO B5: ""
+*fi.PageRegion EnvISOB5/Kirjekuori ISO B5: ""
+*fr.PageRegion EnvISOB5/Enveloppe ISO B5: ""
+*it.PageRegion EnvISOB5/Busta ISO B5: ""
+*ja.PageRegion EnvISOB5/封筒 B5 (ISO): ""
+*ko.PageRegion EnvISOB5/ISO B5 봉투: ""
+*nl.PageRegion EnvISOB5/ISO B5-envelop: ""
+*nb.PageRegion EnvISOB5/B5-konvolutt: ""
+*pt.PageRegion EnvISOB5/Envelope B5: ""
+*sv.PageRegion EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.PageRegion EnvISOB5/信封 ISO B5: ""
+*zh_TW.PageRegion EnvISOB5/ISO B5 信封: ""
+
+*PageRegion Env10/Env Comm10: "
+	<</DeferredMediaSelection true /PageSize [297 684] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion Env10/Konv Comm10: ""
+*de.PageRegion Env10/Umschlag Comm10: ""
+*es.PageRegion Env10/Sobre Comm10: ""
+*fi.PageRegion Env10/Kirjekuori Comm10: ""
+*fr.PageRegion Env10/Enveloppe Comm10: ""
+*it.PageRegion Env10/Busta Comm10: ""
+*ja.PageRegion Env10/封筒 Comm10: ""
+*ko.PageRegion Env10/Comm10 봉투: ""
+*nl.PageRegion Env10/Comm10-envelop: ""
+*nb.PageRegion Env10/Comm10-konvolutt: ""
+*pt.PageRegion Env10/Envelope Comm10: ""
+*sv.PageRegion Env10/Comm10-kuvert: ""
+*zh_CN.PageRegion Env10/信封 Comm10: ""
+*zh_TW.PageRegion Env10/Comm10 信封: ""
+
+*PageRegion EnvC5/Env C5: "
+	<</DeferredMediaSelection true /PageSize [459 649] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion EnvC5/Konv C5: ""
+*de.PageRegion EnvC5/Umschlag C5: ""
+*es.PageRegion EnvC5/Sobre C5: ""
+*fi.PageRegion EnvC5/Kirjekuori C5: ""
+*fr.PageRegion EnvC5/Enveloppe C5: ""
+*it.PageRegion EnvC5/Busta C5: ""
+*ja.PageRegion EnvC5/封筒 C5: ""
+*ko.PageRegion EnvC5/C5 봉투: ""
+*nl.PageRegion EnvC5/C5-envelop: ""
+*nb.PageRegion EnvC5/C5-konvolutt: ""
+*pt.PageRegion EnvC5/Envelope C5: ""
+*sv.PageRegion EnvC5/C5-kuvert: ""
+*zh_CN.PageRegion EnvC5/信封 C5: ""
+*zh_TW.PageRegion EnvC5/C5 信封: ""
+
+*PageRegion EnvDL/Env DL: "
+	<</DeferredMediaSelection true /PageSize [312 624] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion EnvDL/Konv DL: ""
+*de.PageRegion EnvDL/Umschlag DL: ""
+*es.PageRegion EnvDL/Sobre DL: ""
+*fi.PageRegion EnvDL/Kirjekuori DL: ""
+*fr.PageRegion EnvDL/Enveloppe DL: ""
+*it.PageRegion EnvDL/Busta DL: ""
+*ja.PageRegion EnvDL/封筒 DL: ""
+*ko.PageRegion EnvDL/DL 봉투: ""
+*nl.PageRegion EnvDL/DL-envelop: ""
+*nb.PageRegion EnvDL/DL-konvolutt: ""
+*pt.PageRegion EnvDL/Envelope DL: ""
+*sv.PageRegion EnvDL/DL-kuvert: ""
+*zh_CN.PageRegion EnvDL/信封 DL: ""
+*zh_TW.PageRegion EnvDL/DL 信封: ""
+
+*PageRegion EnvMonarch/Env Monarch: "
+	<</DeferredMediaSelection true /PageSize [279 540] /ImagingBBox null /MediaClass null>> setpagedevice"
+*End
+*da.PageRegion EnvMonarch/Konv Monarch: ""
+*de.PageRegion EnvMonarch/Umschlag Monarch: ""
+*es.PageRegion EnvMonarch/Sobre Monarch: ""
+*fi.PageRegion EnvMonarch/Kirjekuori Monarch: ""
+*fr.PageRegion EnvMonarch/Enveloppe Monarch: ""
+*it.PageRegion EnvMonarch/Busta Monarch: ""
+*ja.PageRegion EnvMonarch/封筒 Monarch: ""
+*ko.PageRegion EnvMonarch/Monarch 봉투: ""
+*nl.PageRegion EnvMonarch/Monarch-envelop: ""
+*nb.PageRegion EnvMonarch/Monarch-konvolutt: ""
+*pt.PageRegion EnvMonarch/Envelope Monarch: ""
+*sv.PageRegion EnvMonarch/Monarch-kuvert: ""
+*zh_CN.PageRegion EnvMonarch/信封 Monarch: ""
+*zh_TW.PageRegion EnvMonarch/Monarch 信封: ""
+
+*CloseUI: *PageRegion
+
+*% The following entries provide information about specific paper keywords.
+*DefaultImageableArea: Letter
+*ImageableArea Letter/Letter: 					"12.00 12.12 599.88 780.00"
+*da.ImageableArea Letter/Letter: ""
+*de.ImageableArea Letter/Letter: ""
+*es.ImageableArea Letter/Letter: ""
+*fi.ImageableArea Letter/Letter: ""
+*fr.ImageableArea Letter/Lettre: ""
+*it.ImageableArea Letter/Letter: ""
+*ja.ImageableArea Letter/レター: ""
+*ko.ImageableArea Letter/레터: ""
+*nl.ImageableArea Letter/Letter: ""
+*nb.ImageableArea Letter/Letter: ""
+*pt.ImageableArea Letter/Carta: ""
+*sv.ImageableArea Letter/Letter: ""
+*zh_CN.ImageableArea Letter/信纸: ""
+*zh_TW.ImageableArea Letter/Letter: ""
+
+*ImageableArea LetterSmall/Letter (Small):		"30.00 31.00 582.00 761.00"
+*da.ImageableArea LetterSmall/Letter (lille): ""
+*de.ImageableArea LetterSmall/Letter (Klein): ""
+*es.ImageableArea LetterSmall/Letter (pequeño): ""
+*fi.ImageableArea LetterSmall/Letter (pieni): ""
+*fr.ImageableArea LetterSmall/Lettre (petit): ""
+*it.ImageableArea LetterSmall/Letter (ridotta): ""
+*ja.ImageableArea LetterSmall/レター (小): ""
+*ko.ImageableArea LetterSmall/레터 (소): ""
+*nl.ImageableArea LetterSmall/Letter (klein): ""
+*nb.ImageableArea LetterSmall/Letter (lite): ""
+*pt.ImageableArea LetterSmall/Carta (pequeno): ""
+*sv.ImageableArea LetterSmall/Letter (litet): ""
+*zh_CN.ImageableArea LetterSmall/信纸 (小): ""
+*zh_TW.ImageableArea LetterSmall/Letter (小): ""
+
+*ImageableArea Legal/Legal: 					"12.00 12.12 599.88 996.00"
+*da.ImageableArea Legal/Legal: ""
+*de.ImageableArea Legal/Legal: ""
+*es.ImageableArea Legal/Legal: ""
+*fi.ImageableArea Legal/Legal: ""
+*fr.ImageableArea Legal/Légal: ""
+*it.ImageableArea Legal/Legal: ""
+*ja.ImageableArea Legal/リーガル: ""
+*ko.ImageableArea Legal/리갈: ""
+*nl.ImageableArea Legal/Legal: ""
+*nb.ImageableArea Legal/Legal: ""
+*pt.ImageableArea Legal/Legal: ""
+*sv.ImageableArea Legal/Legal: ""
+*zh_CN.ImageableArea Legal/Legal: ""
+*zh_TW.ImageableArea Legal/Legal: ""
+
+*ImageableArea LegalSmall/Legal (Small):		"64.00 54.00 548.00 954.00"
+*da.ImageableArea LegalSmall/Legal (lille): ""
+*de.ImageableArea LegalSmall/Legal (Klein): ""
+*es.ImageableArea LegalSmall/Legal (pequeño): ""
+*fi.ImageableArea LegalSmall/Legal (pieni): ""
+*fr.ImageableArea LegalSmall/Légal (petit): ""
+*it.ImageableArea LegalSmall/Legal (ridotto): ""
+*ja.ImageableArea LegalSmall/リーガル (小): ""
+*ko.ImageableArea LegalSmall/리갈 (소): ""
+*nl.ImageableArea LegalSmall/Legal (klein): ""
+*nb.ImageableArea LegalSmall/Legal (lite): ""
+*pt.ImageableArea LegalSmall/Legal (pequeno): ""
+*sv.ImageableArea LegalSmall/Legal (litet): ""
+*zh_CN.ImageableArea LegalSmall/Legal (小): ""
+*zh_TW.ImageableArea LegalSmall/Legal (小): ""
+
+*ImageableArea Executive/Executive: 			"12.00 12.00 509.88 744.00"
+*da.ImageableArea Executive/Executive: ""
+*de.ImageableArea Executive/Executive: ""
+*es.ImageableArea Executive/Ejecutivo: ""
+*fi.ImageableArea Executive/Executive: ""
+*fr.ImageableArea Executive/Exécutif: ""
+*it.ImageableArea Executive/Executive: ""
+*ja.ImageableArea Executive/エグゼクティブ: ""
+*ko.ImageableArea Executive/Executive: ""
+*nl.ImageableArea Executive/Executive: ""
+*nb.ImageableArea Executive/Executive: ""
+*pt.ImageableArea Executive/Executivo: ""
+*sv.ImageableArea Executive/Executive: ""
+*zh_CN.ImageableArea Executive/Executive: ""
+*zh_TW.ImageableArea Executive/Executive: ""
+
+*ImageableArea HalfLetter/Statement:			"12.00 12.00 384.00 599.88" 
+*da.ImageableArea HalfLetter/Statement: ""
+*de.ImageableArea HalfLetter/Statement: ""
+*es.ImageableArea HalfLetter/Declaración: ""
+*fi.ImageableArea HalfLetter/Statement: ""
+*fr.ImageableArea HalfLetter/1/2 Lettre: ""
+*it.ImageableArea HalfLetter/Dichiarazione: ""
+*ja.ImageableArea HalfLetter/Statement: ""
+*ko.ImageableArea HalfLetter/2절 레터: ""
+*nl.ImageableArea HalfLetter/1/2 Letter : ""
+*nb.ImageableArea HalfLetter/1/2 Letter: ""
+*pt.ImageableArea HalfLetter/Statement: ""
+*sv.ImageableArea HalfLetter/Statement: ""
+*zh_CN.ImageableArea HalfLetter/结算单: ""
+*zh_TW.ImageableArea HalfLetter/Statement: ""
+
+*ImageableArea w612h935/8.5x13: 				"12.00 12.00 599.76 922.76"
+*da.ImageableArea w612h935/8.5x13: ""
+*de.ImageableArea w612h935/8.5x13: ""
+*es.ImageableArea w612h935/8.5x13: ""
+*fi.ImageableArea w612h935/8.5x13: ""
+*fr.ImageableArea w612h935/8.5x13: ""
+*it.ImageableArea w612h935/8.5x13: ""
+*ja.ImageableArea w612h935/8.5x13: ""
+*ko.ImageableArea w612h935/8.5x13: ""
+*nl.ImageableArea w612h935/8.5x13: ""
+*nb.ImageableArea w612h935/8.5x13: ""
+*pt.ImageableArea w612h935/8.5x13: ""
+*sv.ImageableArea w612h935/8.5x13: ""
+*zh_CN.ImageableArea w612h935/8.5x13: ""
+*zh_TW.ImageableArea w612h935/8.5x13: ""
+
+*ImageableArea Tabloid/11x17:                   "12.00 12.00 779.88 1211.90"
+*da.ImageableArea Tabloid/11x17: ""
+*de.ImageableArea Tabloid/11x17 Zoll: ""
+*es.ImageableArea Tabloid/11x17: ""
+*fi.ImageableArea Tabloid/11x17: ""
+*fr.ImageableArea Tabloid/11 x 17 pouces: ""
+*it.ImageableArea Tabloid/11x17: ""
+*ja.ImageableArea Tabloid/11x17: ""
+*ko.ImageableArea Tabloid/11x17: ""
+*nl.ImageableArea Tabloid/11x17: ""
+*nb.ImageableArea Tabloid/11x17: ""
+*pt.ImageableArea Tabloid/11x17: ""
+*sv.ImageableArea Tabloid/11x17: ""
+*zh_CN.ImageableArea Tabloid/11x17: ""
+*zh_TW.ImageableArea Tabloid/11x17 : ""
+
+*ImageableArea 12X18/12x18:                     "12.00 12.12 851.88 1283.88"
+*da.ImageableArea 12X18/12x18: ""
+*de.ImageableArea 12X18/12x18: ""
+*es.ImageableArea 12X18/12x18: ""
+*fi.ImageableArea 12X18/12x18: ""
+*fr.ImageableArea 12X18/12x18: ""
+*it.ImageableArea 12X18/12x18: ""
+*ja.ImageableArea 12X18/12x18: ""
+*ko.ImageableArea 12X18/12x18: ""
+*nl.ImageableArea 12X18/12x18: ""
+*nb.ImageableArea 12X18/12x18: ""
+*pt.ImageableArea 12X18/12x18: ""
+*sv.ImageableArea 12X18/12x18: ""
+*zh_CN.ImageableArea 12X18/12x18: ""
+*zh_TW.ImageableArea 12X18/12x18: ""
+
+*ImageableArea A3/A3:                           "12.00 12.00 829.88 1178.90"
+*da.ImageableArea A3/A3: ""
+*de.ImageableArea A3/A3: ""
+*es.ImageableArea A3/A3: ""
+*fi.ImageableArea A3/A3: ""
+*fr.ImageableArea A3/A3: ""
+*it.ImageableArea A3/A3: ""
+*ja.ImageableArea A3/A3: ""
+*ko.ImageableArea A3/A3: ""
+*nl.ImageableArea A3/A3: ""
+*nb.ImageableArea A3/A3: ""
+*pt.ImageableArea A3/A3: ""
+*sv.ImageableArea A3/A3: ""
+*zh_CN.ImageableArea A3/A3: ""
+*zh_TW.ImageableArea A3/A3: ""
+
+*ImageableArea RA3/RA3:                         "12.00 12.12 852.60 1206.86"
+*da.ImageableArea RA3/RA3: ""
+*de.ImageableArea RA3/RA3: ""
+*es.ImageableArea RA3/RA3: ""
+*fi.ImageableArea RA3/RA3: ""
+*fr.ImageableArea RA3/RA3: ""
+*it.ImageableArea RA3/RA3: ""
+*ja.ImageableArea RA3/RA3: ""
+*ko.ImageableArea RA3/RA3: ""
+*nl.ImageableArea RA3/RA3: ""
+*nb.ImageableArea RA3/RA3: ""
+*pt.ImageableArea RA3/RA3: ""
+*sv.ImageableArea RA3/RA3: ""
+*zh_CN.ImageableArea RA3/RA3: ""
+*zh_TW.ImageableArea RA3/RA3: ""
+
+*ImageableArea A4/A4: 							"12.00 12.00 583.08 829.68"
+*da.ImageableArea A4/A4: ""
+*de.ImageableArea A4/A4: ""
+*es.ImageableArea A4/A4: ""
+*fi.ImageableArea A4/A4: ""
+*fr.ImageableArea A4/A4: ""
+*it.ImageableArea A4/A4: ""
+*ja.ImageableArea A4/A4: ""
+*ko.ImageableArea A4/A4: ""
+*nl.ImageableArea A4/A4: ""
+*nb.ImageableArea A4/A4: ""
+*pt.ImageableArea A4/A4: ""
+*sv.ImageableArea A4/A4: ""
+*zh_CN.ImageableArea A4/A4: ""
+*zh_TW.ImageableArea A4/A4: ""
+
+*ImageableArea A4Small/A4 (Small): 				"28.00 30.00 566.00 811.00"
+*da.ImageableArea A4Small/A4 (lille): ""
+*de.ImageableArea A4Small/A4 (Klein): ""
+*es.ImageableArea A4Small/A4 (pequeño): ""
+*fi.ImageableArea A4Small/A4 (pieni): ""
+*fr.ImageableArea A4Small/A4 (petit): ""
+*it.ImageableArea A4Small/A4 (ridotta): ""
+*ja.ImageableArea A4Small/A4 (小): ""
+*ko.ImageableArea A4Small/A4 (소): ""
+*nl.ImageableArea A4Small/A4 (klein): ""
+*nb.ImageableArea A4Small/A4 (lite): ""
+*pt.ImageableArea A4Small/A4 (pequeno): ""
+*sv.ImageableArea A4Small/A4 (litet): ""
+*zh_CN.ImageableArea A4Small/A4 (小): ""
+*zh_TW.ImageableArea A4Small/A4 (小): ""
+
+*ImageableArea A5/A5: 							"12.00 12.00 407.40 583.20"
+*da.ImageableArea A5/A5: ""
+*de.ImageableArea A5/A5: ""
+*es.ImageableArea A5/A5: ""
+*fi.ImageableArea A5/A5: ""
+*fr.ImageableArea A5/A5: ""
+*it.ImageableArea A5/A5: ""
+*ja.ImageableArea A5/A5: ""
+*ko.ImageableArea A5/A5: ""
+*nl.ImageableArea A5/A5: ""
+*nb.ImageableArea A5/A5: ""
+*pt.ImageableArea A5/A5: ""
+*sv.ImageableArea A5/A5: ""
+*zh_CN.ImageableArea A5/A5: ""
+*zh_TW.ImageableArea A5/A5: ""
+
+*ImageableArea B5/B5 (JIS): 					"12.00 12.00 503.88 715.92"
+*da.ImageableArea B5/JIS B5: ""
+*de.ImageableArea B5/B5 (JIS): ""
+*es.ImageableArea B5/JIS B5: ""
+*fi.ImageableArea B5/JIS B5: ""
+*fr.ImageableArea B5/JIS B5: ""
+*it.ImageableArea B5/JIS B5: ""
+*ja.ImageableArea B5/B5 (JIS): ""
+*ko.ImageableArea B5/JIS B5: ""
+*nl.ImageableArea B5/JIS B5: ""
+*nb.ImageableArea B5/JIS B5: ""
+*pt.ImageableArea B5/B5 JIS: ""
+*sv.ImageableArea B5/JIS B5: ""
+*zh_CN.ImageableArea B5/JIS B5: ""
+*zh_TW.ImageableArea B5/JIS B5: ""
+
+*ImageableArea B4/B4 (JIS):                     "12.00 12.00 716.88 1019.90"
+*da.ImageableArea B4/JIS B4: ""
+*de.ImageableArea B4/B4 (JIS): ""
+*es.ImageableArea B4/JIS B4: ""
+*fi.ImageableArea B4/JIS B4: ""
+*fr.ImageableArea B4/JIS B4: ""
+*it.ImageableArea B4/JIS B4: ""
+*ja.ImageableArea B4/B4 (JIS): ""
+*ko.ImageableArea B4/JIS B4: ""
+*nl.ImageableArea B4/JIS B4: ""
+*nb.ImageableArea B4/JIS B4: ""
+*pt.ImageableArea B4/B4 JIS: ""
+*sv.ImageableArea B4/JIS B4: ""
+*zh_CN.ImageableArea B4/JIS B4: ""
+*zh_TW.ImageableArea B4/JIS B4: ""
+
+*ImageableArea w612h936/Executive (JIS): 		"12.00 12.00 599.76 923.76"
+*da.ImageableArea w612h936/Executive (JIS): ""
+*de.ImageableArea w612h936/Executive (JIS): ""
+*es.ImageableArea w612h936/Ejecutivo (JIS): ""
+*fi.ImageableArea w612h936/Executive (JIS): ""
+*fr.ImageableArea w612h936/Exécutif (JIS): ""
+*it.ImageableArea w612h936/Executive (JIS): ""
+*ja.ImageableArea w612h936/エグゼクティブ (JIS): ""
+*ko.ImageableArea w612h936/Executive(JIS): ""
+*nl.ImageableArea w612h936/Executive (JIS): ""
+*nb.ImageableArea w612h936/Executive (JIS): ""
+*pt.ImageableArea w612h936/Executivo (JIS): ""
+*sv.ImageableArea w612h936/Executive (JIS): ""
+*zh_CN.ImageableArea w612h936/Executive (JIS): ""
+*zh_TW.ImageableArea w612h936/Executive (JIS): ""
+
+*ImageableArea DoublePostcard/Double Postcard (JIS):  "12.12 12.00 407.28 554.64"
+*da.ImageableArea DoublePostcard/Dobbelt postkort (JIS): ""
+*de.ImageableArea DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.ImageableArea DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.ImageableArea DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.ImageableArea DoublePostcard/Carte postale double (JIS): ""
+*it.ImageableArea DoublePostcard/Cartolina doppia (JIS): ""
+*ja.ImageableArea DoublePostcard/往復はがき (JIS): ""
+*ko.ImageableArea DoublePostcard/양면 엽서 (JIS): ""
+*nl.ImageableArea DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.ImageableArea DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.ImageableArea DoublePostcard/Postal duplo (JIS): ""
+*sv.ImageableArea DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.ImageableArea DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.ImageableArea DoublePostcard/雙面明信片 (JIS): ""
+
+*ImageableArea w774h1116/8K:                    "12.00 12.00 761.88 1103.90"
+*da.ImageableArea w774h1116/8K: ""
+*de.ImageableArea w774h1116/8K: ""
+*es.ImageableArea w774h1116/8K: ""
+*fi.ImageableArea w774h1116/8K: ""
+*fr.ImageableArea w774h1116/8K: ""
+*it.ImageableArea w774h1116/8K: ""
+*ja.ImageableArea w774h1116/8K: ""
+*ko.ImageableArea w774h1116/8K: ""
+*nl.ImageableArea w774h1116/8K: ""
+*nb.ImageableArea w774h1116/8K: ""
+*pt.ImageableArea w774h1116/8K: ""
+*sv.ImageableArea w774h1116/8K: ""
+*zh_CN.ImageableArea w774h1116/8K: ""
+*zh_TW.ImageableArea w774h1116/8K: ""
+
+*ImageableArea w558h774/16K: 					"12.00 12.12 545.76 761.76"
+*da.ImageableArea w558h774/16K: ""
+*de.ImageableArea w558h774/16K: ""
+*es.ImageableArea w558h774/16K: ""
+*fi.ImageableArea w558h774/16K: ""
+*fr.ImageableArea w558h774/16K: ""
+*it.ImageableArea w558h774/16K: ""
+*ja.ImageableArea w558h774/16K: ""
+*ko.ImageableArea w558h774/16K: ""
+*nl.ImageableArea w558h774/16K: ""
+*nb.ImageableArea w558h774/16K: ""
+*pt.ImageableArea w558h774/16K: ""
+*sv.ImageableArea w558h774/16K: ""
+*zh_CN.ImageableArea w558h774/16K: ""
+*zh_TW.ImageableArea w558h774/16K: ""
+
+*ImageableArea EnvISOB5/Env B5:				    "12.00 12.12 486.60 696.48"
+*da.ImageableArea EnvISOB5/Konv ISO B5: ""
+*de.ImageableArea EnvISOB5/Umschlag ISO B5: ""
+*es.ImageableArea EnvISOB5/Sobre ISO B5: ""
+*fi.ImageableArea EnvISOB5/Kirjekuori ISO B5: ""
+*fr.ImageableArea EnvISOB5/Enveloppe ISO B5: ""
+*it.ImageableArea EnvISOB5/Busta ISO B5: ""
+*ja.ImageableArea EnvISOB5/封筒 ISO B5: ""
+*ko.ImageableArea EnvISOB5/ISO B5 봉투: ""
+*nl.ImageableArea EnvISOB5/ISO B5-envelop: ""
+*nb.ImageableArea EnvISOB5/B5-konvolutt: ""
+*pt.ImageableArea EnvISOB5/Envelope B5: ""
+*sv.ImageableArea EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.ImageableArea EnvISOB5/信封 ISO B5: ""
+*zh_TW.ImageableArea EnvISOB5/ISO B5 信封: ""
+
+*ImageableArea Env10/Env Comm10:				"12.00 12.12 284.76 672.00"
+*da.ImageableArea Env10/Konv Comm10: ""
+*de.ImageableArea Env10/Umschlag Comm10: ""
+*es.ImageableArea Env10/Sobre Comm10: ""
+*fi.ImageableArea Env10/Kirjekuori Comm10: ""
+*fr.ImageableArea Env10/Enveloppe Comm10: ""
+*it.ImageableArea Env10/Busta Comm10: ""
+*ja.ImageableArea Env10/封筒 Comm10: ""
+*ko.ImageableArea Env10/Comm10 봉투: ""
+*nl.ImageableArea Env10/Comm10-envelop: ""
+*nb.ImageableArea Env10/Comm10-konvolutt: ""
+*pt.ImageableArea Env10/Envelope Comm10: ""
+*sv.ImageableArea Env10/Comm10-kuvert: ""
+*zh_CN.ImageableArea Env10/信封 Comm10: ""
+*zh_TW.ImageableArea Env10/Comm10 信封: ""
+
+*ImageableArea EnvC5/Env C5:					"12.00 12.12 447.00 636.96"
+*da.ImageableArea EnvC5/Konv C5: ""
+*de.ImageableArea EnvC5/Umschlag C5: ""
+*es.ImageableArea EnvC5/Sobre C5: ""
+*fi.ImageableArea EnvC5/Kirjekuori C5: ""
+*fr.ImageableArea EnvC5/Enveloppe C5: ""
+*it.ImageableArea EnvC5/Busta C5: ""
+*ja.ImageableArea EnvC5/封筒 C5: ""
+*ko.ImageableArea EnvC5/C5 봉투: ""
+*nl.ImageableArea EnvC5/C5-envelop: ""
+*nb.ImageableArea EnvC5/C5-konvolutt: ""
+*pt.ImageableArea EnvC5/Envelope C5: ""
+*sv.ImageableArea EnvC5/C5-kuvert: ""
+*zh_CN.ImageableArea EnvC5/信封 C5: ""
+*zh_TW.ImageableArea EnvC5/C5 信封: ""
+
+*ImageableArea EnvDL/Env DL:					"12.00 12.12 299.64 611.52"
+*da.ImageableArea EnvDL/Konv DL: ""
+*de.ImageableArea EnvDL/Umschlag DL: ""
+*es.ImageableArea EnvDL/Sobre DL: ""
+*fi.ImageableArea EnvDL/Kirjekuori DL: ""
+*fr.ImageableArea EnvDL/Enveloppe DL: ""
+*it.ImageableArea EnvDL/Busta DL: ""
+*ja.ImageableArea EnvDL/封筒 DL: ""
+*ko.ImageableArea EnvDL/DL 봉투: ""
+*nl.ImageableArea EnvDL/DL-envelop: ""
+*nb.ImageableArea EnvDL/DL-konvolutt: ""
+*pt.ImageableArea EnvDL/Envelope DL: ""
+*sv.ImageableArea EnvDL/DL-kuvert: ""
+*zh_CN.ImageableArea EnvDL/信封 DL: ""
+*zh_TW.ImageableArea EnvDL/DL 信封: ""
+
+*ImageableArea EnvMonarch/Env Monarch:			"12.00 12.12 266.76 528.00"
+*da.ImageableArea EnvMonarch/Konv Monarch: ""
+*de.ImageableArea EnvMonarch/Umschlag Monarch: ""
+*es.ImageableArea EnvMonarch/Sobre Monarch: ""
+*fi.ImageableArea EnvMonarch/Kirjekuori Monarch: ""
+*fr.ImageableArea EnvMonarch/Enveloppe Monarch: ""
+*it.ImageableArea EnvMonarch/Busta Monarch: ""
+*ja.ImageableArea EnvMonarch/封筒 Monarch: ""
+*ko.ImageableArea EnvMonarch/Monarch 봉투: ""
+*nl.ImageableArea EnvMonarch/Monarch-envelop: ""
+*nb.ImageableArea EnvMonarch/Monarch-konvolutt: ""
+*pt.ImageableArea EnvMonarch/Envelope Monarch: ""
+*sv.ImageableArea EnvMonarch/Monarch-kuvert: ""
+*zh_CN.ImageableArea EnvMonarch/信封 Monarch: ""
+*zh_TW.ImageableArea EnvMonarch/Monarch 信封: ""
+
+*?ImageableArea: "
+ save
+   /cvp { (                ) cvs print ( ) print } bind def
+   /upperright {10000 mul floor 10000 div} bind def
+   /lowerleft {10000 mul ceiling 10000 div} bind def
+   newpath clippath pathbbox
+   4 -2 roll exch 2 {Tray3left cvp} repeat
+   exch 2 {Tray1right cvp} repeat flush
+ restore
+"
+*End
+
+*% These provide the physical dimensions of the paper (by keyword)
+*DefaultPaperDimension: Letter
+*PaperDimension Letter/Letter: 					"612 792"
+*da.PaperDimension Letter/Letter: ""
+*de.PaperDimension Letter/Letter: ""
+*es.PaperDimension Letter/Letter: ""
+*fi.PaperDimension Letter/Letter: ""
+*fr.PaperDimension Letter/Lettre: ""
+*it.PaperDimension Letter/Letter: ""
+*ja.PaperDimension Letter/レター: ""
+*ko.PaperDimension Letter/레터: ""
+*nl.PaperDimension Letter/Letter: ""
+*nb.PaperDimension Letter/Letter: ""
+*pt.PaperDimension Letter/Carta: ""
+*sv.PaperDimension Letter/Letter: ""
+*zh_CN.PaperDimension Letter/信纸: ""
+*zh_TW.PaperDimension Letter/Letter: ""
+
+*PaperDimension LetterSmall/Letter (Small):		"612 792"
+*da.PaperDimension LetterSmall/Letter (lille): ""
+*de.PaperDimension LetterSmall/Letter (Klein): ""
+*es.PaperDimension LetterSmall/Letter (pequeño): ""
+*fi.PaperDimension LetterSmall/Letter (pieni): ""
+*fr.PaperDimension LetterSmall/Lettre (petit): ""
+*it.PaperDimension LetterSmall/Letter (ridotto): ""
+*ja.PaperDimension LetterSmall/レター (小): ""
+*ko.PaperDimension LetterSmall/레터 (소): ""
+*nl.PaperDimension LetterSmall/Letter (klein): ""
+*nb.PaperDimension LetterSmall/Letter (lite): ""
+*pt.PaperDimension LetterSmall/Carta (pequeno): ""
+*sv.PaperDimension LetterSmall/Letter (litet): ""
+*zh_CN.PaperDimension LetterSmall/信纸 (小): ""
+*zh_TW.PaperDimension LetterSmall/Letter (小): ""
+
+*PaperDimension Legal/Legal: 					"612 1008"
+*da.PaperDimension Legal/Legal: ""
+*de.PaperDimension Legal/Legal: ""
+*es.PaperDimension Legal/Legal: ""
+*fi.PaperDimension Legal/Legal: ""
+*fr.PaperDimension Legal/Légal: ""
+*it.PaperDimension Legal/Legal: ""
+*ja.PaperDimension Legal/リーガル: ""
+*ko.PaperDimension Legal/리갈: ""
+*nl.PaperDimension Legal/Legal: ""
+*nb.PaperDimension Legal/Legal: ""
+*pt.PaperDimension Legal/Legal: ""
+*sv.PaperDimension Legal/Legal: ""
+*zh_CN.PaperDimension Legal/Legal: ""
+*zh_TW.PaperDimension Legal/Legal: ""
+
+*PaperDimension LegalSmall/Legal (Small): 		"612 1008"
+*da.PaperDimension LegalSmall/Legal (lille): ""
+*de.PaperDimension LegalSmall/Legal (Klein): ""
+*es.PaperDimension LegalSmall/Legal (pequeño): ""
+*fi.PaperDimension LegalSmall/Legal (pieni): ""
+*fr.PaperDimension LegalSmall/Légal (petit): ""
+*it.PaperDimension LegalSmall/Legal (ridotto): ""
+*ja.PaperDimension LegalSmall/リーガル (小): ""
+*ko.PaperDimension LegalSmall/리갈 (소): ""
+*nl.PaperDimension LegalSmall/Legal (klein): ""
+*nb.PaperDimension LegalSmall/Legal (lite): ""
+*pt.PaperDimension LegalSmall/Legal (pequeno): ""
+*sv.PaperDimension LegalSmall/Legal (litet): ""
+*zh_CN.PaperDimension LegalSmall/Legal (小): ""
+*zh_TW.PaperDimension LegalSmall/Legal (小): ""
+
+*PaperDimension Executive/Executive: 			"522 756"
+*da.PaperDimension Executive/Executive: ""
+*de.PaperDimension Executive/Executive: ""
+*es.PaperDimension Executive/Ejecutivo: ""
+*fi.PaperDimension Executive/Executive: ""
+*fr.PaperDimension Executive/Exécutif: ""
+*it.PaperDimension Executive/Executive: ""
+*ja.PaperDimension Executive/エグゼクティブ: ""
+*ko.PaperDimension Executive/Executive: ""
+*nl.PaperDimension Executive/Executive: ""
+*nb.PaperDimension Executive/Executive: ""
+*pt.PaperDimension Executive/Executivo: ""
+*sv.PaperDimension Executive/Executive: ""
+*zh_CN.PaperDimension Executive/Executive: ""
+*zh_TW.PaperDimension Executive/Executive: ""
+
+*PaperDimension HalfLetter/Statement:			"396 612"
+*da.PaperDimension HalfLetter/Statement: ""
+*de.PaperDimension HalfLetter/Statement: ""
+*es.PaperDimension HalfLetter/Declaración: ""
+*fi.PaperDimension HalfLetter/Statement: ""
+*fr.PaperDimension HalfLetter/1/2 Lettre: ""
+*it.PaperDimension HalfLetter/Dichiarazione: ""
+*ja.PaperDimension HalfLetter/Statement: ""
+*ko.PaperDimension HalfLetter/2절 레터: ""
+*nl.PaperDimension HalfLetter/1/2 Letter : ""
+*nb.PaperDimension HalfLetter/1/2 Letter: ""
+*pt.PaperDimension HalfLetter/Statement: ""
+*sv.PaperDimension HalfLetter/Statement: ""
+*zh_CN.PaperDimension HalfLetter/结算单: ""
+*zh_TW.PaperDimension HalfLetter/Statement: ""
+
+*PaperDimension w612h935/8.5x13: 				"612 935"
+*da.PaperDimension w612h935/8.5x13: ""
+*de.PaperDimension w612h935/8.5x13: ""
+*es.PaperDimension w612h935/8.5x13: ""
+*fi.PaperDimension w612h935/8.5x13: ""
+*fr.PaperDimension w612h935/8.5x13: ""
+*it.PaperDimension w612h935/8.5x13: ""
+*ja.PaperDimension w612h935/8.5x13: ""
+*ko.PaperDimension w612h935/8.5x13: ""
+*nl.PaperDimension w612h935/8.5x13: ""
+*nb.PaperDimension w612h935/8.5x13: ""
+*pt.PaperDimension w612h935/8.5x13: ""
+*sv.PaperDimension w612h935/8.5x13: ""
+*zh_CN.PaperDimension w612h935/8.5x13: ""
+*zh_TW.PaperDimension w612h935/8.5x13: ""
+
+*PaperDimension Tabloid/11x17:                  "792 1224"
+*da.PaperDimension Tabloid/11x17: ""
+*de.PaperDimension Tabloid/11x17 Zoll: ""
+*es.PaperDimension Tabloid/11x17: ""
+*fi.PaperDimension Tabloid/11x17: ""
+*fr.PaperDimension Tabloid/11 x 17 pouces: ""
+*it.PaperDimension Tabloid/11x17: ""
+*ja.PaperDimension Tabloid/11x17: ""
+*ko.PaperDimension Tabloid/11x17: ""
+*nl.PaperDimension Tabloid/11x17: ""
+*nb.PaperDimension Tabloid/11x17: ""
+*pt.PaperDimension Tabloid/11x17: ""
+*sv.PaperDimension Tabloid/11x17: ""
+*zh_CN.PaperDimension Tabloid/11x17: ""
+*zh_TW.PaperDimension Tabloid/11x17 : ""
+
+*PaperDimension 12X18/12x18:                   	"864 1296"
+*da.PaperDimension 12X18/12x18: ""
+*de.PaperDimension 12X18/12x18: ""
+*es.PaperDimension 12X18/12x18: ""
+*fi.PaperDimension 12X18/12x18: ""
+*fr.PaperDimension 12X18/12x18: ""
+*it.PaperDimension 12X18/12x18: ""
+*ja.PaperDimension 12X18/12x18: ""
+*ko.PaperDimension 12X18/12x18: ""
+*nl.PaperDimension 12X18/12x18: ""
+*nb.PaperDimension 12X18/12x18: ""
+*pt.PaperDimension 12X18/12x18: ""
+*sv.PaperDimension 12X18/12x18: ""
+*zh_CN.PaperDimension 12X18/12x18: ""
+*zh_TW.PaperDimension 12X18/12x18: ""
+
+*PaperDimension A3/A3:                          "842 1191"
+*da.PaperDimension A3/A3: ""
+*de.PaperDimension A3/A3: ""
+*es.PaperDimension A3/A3: ""
+*fi.PaperDimension A3/A3: ""
+*fr.PaperDimension A3/A3: ""
+*it.PaperDimension A3/A3: ""
+*ja.PaperDimension A3/A3: ""
+*ko.PaperDimension A3/A3: ""
+*nl.PaperDimension A3/A3: ""
+*nb.PaperDimension A3/A3: ""
+*pt.PaperDimension A3/A3: ""
+*sv.PaperDimension A3/A3: ""
+*zh_CN.PaperDimension A3/A3: ""
+*zh_TW.PaperDimension A3/A3: ""
+
+*PaperDimension RA3/RA3:                        "865 1219"
+*da.PaperDimension RA3/RA3: ""
+*de.PaperDimension RA3/RA3: ""
+*es.PaperDimension RA3/RA3: ""
+*fi.PaperDimension RA3/RA3: ""
+*fr.PaperDimension RA3/RA3: ""
+*it.PaperDimension RA3/RA3: ""
+*ja.PaperDimension RA3/RA3: ""
+*ko.PaperDimension RA3/RA3: ""
+*nl.PaperDimension RA3/RA3: ""
+*nb.PaperDimension RA3/RA3: ""
+*pt.PaperDimension RA3/RA3: ""
+*sv.PaperDimension RA3/RA3: ""
+*zh_CN.PaperDimension RA3/RA3: ""
+*zh_TW.PaperDimension RA3/RA3: ""
+
+*PaperDimension A4/A4: 							"595 842"
+*da.PaperDimension A4/A4: ""
+*de.PaperDimension A4/A4: ""
+*es.PaperDimension A4/A4: ""
+*fi.PaperDimension A4/A4: ""
+*fr.PaperDimension A4/A4: ""
+*it.PaperDimension A4/A4: ""
+*ja.PaperDimension A4/A4: ""
+*ko.PaperDimension A4/A4: ""
+*nl.PaperDimension A4/A4: ""
+*nb.PaperDimension A4/A4: ""
+*pt.PaperDimension A4/A4: ""
+*sv.PaperDimension A4/A4: ""
+*zh_CN.PaperDimension A4/A4: ""
+*zh_TW.PaperDimension A4/A4: ""
+
+*PaperDimension A4Small/A4 (Small): 			"595 842"
+*da.PaperDimension A4Small/A4 (lille): ""
+*de.PaperDimension A4Small/A4 (Klein): ""
+*es.PaperDimension A4Small/A4 (pequeño): ""
+*fi.PaperDimension A4Small/A4 (pieni): ""
+*fr.PaperDimension A4Small/A4 (petit): ""
+*it.PaperDimension A4Small/A4 (ridotta): ""
+*ja.PaperDimension A4Small/A4 (小): ""
+*ko.PaperDimension A4Small/A4 (소): ""
+*nl.PaperDimension A4Small/A4 (klein): ""
+*nb.PaperDimension A4Small/A4 (lite): ""
+*pt.PaperDimension A4Small/A4 (pequeno): ""
+*sv.PaperDimension A4Small/A4 (litet): ""
+*zh_CN.PaperDimension A4Small/A4 (小): ""
+*zh_TW.PaperDimension A4Small/A4 (小): ""
+
+*PaperDimension A5/A5: 							"420 595"
+*da.PaperDimension A5/A5: ""
+*de.PaperDimension A5/A5: ""
+*es.PaperDimension A5/A5: ""
+*fi.PaperDimension A5/A5: ""
+*fr.PaperDimension A5/A5: ""
+*it.PaperDimension A5/A5: ""
+*ja.PaperDimension A5/A5: ""
+*ko.PaperDimension A5/A5: ""
+*nl.PaperDimension A5/A5: ""
+*nb.PaperDimension A5/A5: ""
+*pt.PaperDimension A5/A5: ""
+*sv.PaperDimension A5/A5: ""
+*zh_CN.PaperDimension A5/A5: ""
+*zh_TW.PaperDimension A5/A5: ""
+
+*PaperDimension B5/B5 (JIS): 					"516 729"
+*da.PaperDimension B5/JIS B5: ""
+*de.PaperDimension B5/B5 (JIS): ""
+*es.PaperDimension B5/JIS B5: ""
+*fi.PaperDimension B5/JIS B5: ""
+*fr.PaperDimension B5/JIS B5: ""
+*it.PaperDimension B5/B5 JIS: ""
+*ja.PaperDimension B5/B5 (JIS): ""
+*ko.PaperDimension B5/JIS B5: ""
+*nl.PaperDimension B5/JIS B5: ""
+*nb.PaperDimension B5/JIS B5: ""
+*pt.PaperDimension B5/B5 JIS: ""
+*sv.PaperDimension B5/JIS B5: ""
+*zh_CN.PaperDimension B5/JIS B5: ""
+*zh_TW.PaperDimension B5/JIS B5: ""
+
+*PaperDimension B4/B4 (JIS):                    "729 1032"
+*da.PaperDimension B4/JIS B4: ""
+*de.PaperDimension B4/B4 (JIS): ""
+*es.PaperDimension B4/JIS B4: ""
+*fi.PaperDimension B4/JIS B4: ""
+*fr.PaperDimension B4/JIS B4: ""
+*it.PaperDimension B4/B4 JIS: ""
+*ja.PaperDimension B4/B4 (JIS): ""
+*ko.PaperDimension B4/JIS B4: ""
+*nl.PaperDimension B4/JIS B4: ""
+*nb.PaperDimension B4/JIS B4: ""
+*pt.PaperDimension B4/B4 JIS: ""
+*sv.PaperDimension B4/JIS B4: ""
+*zh_CN.PaperDimension B4/JIS B4: ""
+*zh_TW.PaperDimension B4/JIS B4: ""
+
+*PaperDimension w612h936/Executive (JIS): 		"612 936"
+*da.PaperDimension w612h936/Executive (JIS): ""
+*de.PaperDimension w612h936/Executive (JIS): ""
+*es.PaperDimension w612h936/Ejecutivo (JIS): ""
+*fi.PaperDimension w612h936/Executive (JIS): ""
+*fr.PaperDimension w612h936/Exécutif (JIS): ""
+*it.PaperDimension w612h936/Executive (JIS): ""
+*ja.PaperDimension w612h936/エグゼクティブ (JIS): ""
+*ko.PaperDimension w612h936/Executive(JIS): ""
+*nl.PaperDimension w612h936/Executive (JIS): ""
+*nb.PaperDimension w612h936/Executive (JIS): ""
+*pt.PaperDimension w612h936/Executivo (JIS): ""
+*sv.PaperDimension w612h936/Executive (JIS): ""
+*zh_CN.PaperDimension w612h936/Executive (JIS): ""
+*zh_TW.PaperDimension w612h936/Executive (JIS): ""
+
+*PaperDimension DoublePostcard/Double Postcard (JIS): "419.5 567"
+*da.PaperDimension DoublePostcard/Dobbelt postkort (JIS): ""
+*de.PaperDimension DoublePostcard/Doppelte Postkarte (JIS): ""
+*es.PaperDimension DoublePostcard/Tarjeta postal doble (JIS): ""
+*fi.PaperDimension DoublePostcard/Kaksinkert. postikortti (JIS): ""
+*fr.PaperDimension DoublePostcard/Carte postale double (JIS): ""
+*it.PaperDimension DoublePostcard/Cartolina doppia (JIS): ""
+*ja.PaperDimension DoublePostcard/往復はがき (JIS): ""
+*ko.PaperDimension DoublePostcard/양면 엽서 (JIS): ""
+*nl.PaperDimension DoublePostcard/Dubbele briefkaart (JIS): ""
+*nb.PaperDimension DoublePostcard/Dobbelt postkort (JIS): ""
+*pt.PaperDimension DoublePostcard/Postal duplo (JIS): ""
+*sv.PaperDimension DoublePostcard/Dubbelt brevkort (JIS): ""
+*zh_CN.PaperDimension DoublePostcard/大号明信片 (JIS): ""
+*zh_TW.PaperDimension DoublePostcard/雙面明信片 (JIS): ""
+
+*PaperDimension w774h1116/8K:                   "774 1116"
+*da.PaperDimension w774h1116/8K: ""
+*de.PaperDimension w774h1116/8K: ""
+*es.PaperDimension w774h1116/8K: ""
+*fi.PaperDimension w774h1116/8 K: ""
+*fr.PaperDimension w774h1116/8K: ""
+*it.PaperDimension w774h1116/8K: ""
+*ja.PaperDimension w774h1116/8K: ""
+*ko.PaperDimension w774h1116/8K: ""
+*nl.PaperDimension w774h1116/8K: ""
+*nb.PaperDimension w774h1116/8K: ""
+*pt.PaperDimension w774h1116/8K: ""
+*sv.PaperDimension w774h1116/8K: ""
+*zh_CN.PaperDimension w774h1116/8K: ""
+*zh_TW.PaperDimension w774h1116/8K: ""
+
+*PaperDimension w558h774/16K:					"558 774"
+*da.PaperDimension w558h774/16K: ""
+*de.PaperDimension w558h774/16K: ""
+*es.PaperDimension w558h774/16K: ""
+*fi.PaperDimension w558h774/16 K: ""
+*fr.PaperDimension w558h774/16K: ""
+*it.PaperDimension w558h774/16K: ""
+*ja.PaperDimension w558h774/16K: ""
+*ko.PaperDimension w558h774/16K: ""
+*nl.PaperDimension w558h774/16K: ""
+*nb.PaperDimension w558h774/16K: ""
+*pt.PaperDimension w558h774/16K: ""
+*sv.PaperDimension w558h774/16K: ""
+*zh_CN.PaperDimension w558h774/16K: ""
+*zh_TW.PaperDimension w558h774/16K: ""
+
+*PaperDimension EnvISOB5/Env B5: 				"499 709"
+*da.PaperDimension EnvISOB5/Konv ISO B5: ""
+*de.PaperDimension EnvISOB5/Umschlag ISO B5: ""
+*es.PaperDimension EnvISOB5/Sobre ISO B5: ""
+*fi.PaperDimension EnvISOB5/Kirjekuori ISO B5: ""
+*fr.PaperDimension EnvISOB5/Enveloppe ISO B5: ""
+*it.PaperDimension EnvISOB5/Busta ISO B5: ""
+*ja.PaperDimension EnvISOB5/封筒 ISO B5: ""
+*ko.PaperDimension EnvISOB5/ISO B5 봉투: ""
+*nl.PaperDimension EnvISOB5/ISO B5-envelop: ""
+*nb.PaperDimension EnvISOB5/B5-konvolutt: ""
+*pt.PaperDimension EnvISOB5/Envelope B5: ""
+*sv.PaperDimension EnvISOB5/ISO B5-kuvert: ""
+*zh_CN.PaperDimension EnvISOB5/信封 ISO B5: ""
+*zh_TW.PaperDimension EnvISOB5/ISO B5 信封: ""
+
+*PaperDimension Env10/Env Comm10:				"297 684"
+*da.PaperDimension Env10/Konv Comm10: ""
+*de.PaperDimension Env10/Umschlag Comm10: ""
+*es.PaperDimension Env10/Sobre Comm10: ""
+*fi.PaperDimension Env10/Kirjekuori Comm10: ""
+*fr.PaperDimension Env10/Enveloppe Comm10: ""
+*it.PaperDimension Env10/Busta Comm10: ""
+*ja.PaperDimension Env10/封筒 Comm10: ""
+*ko.PaperDimension Env10/Comm10 봉투: ""
+*nl.PaperDimension Env10/Comm10-envelop: ""
+*nb.PaperDimension Env10/Comm10-konvolutt: ""
+*pt.PaperDimension Env10/Envelope Comm10: ""
+*sv.PaperDimension Env10/Comm10-kuvert: ""
+*zh_CN.PaperDimension Env10/信封 Comm10: ""
+*zh_TW.PaperDimension Env10/Comm10 信封: ""
+
+*PaperDimension EnvC5/Env C5: 					"459 649"
+*da.PaperDimension EnvC5/Konv C5: ""
+*de.PaperDimension EnvC5/Umschlag C5: ""
+*es.PaperDimension EnvC5/Sobre C5: ""
+*fi.PaperDimension EnvC5/Kirjekuori C5: ""
+*fr.PaperDimension EnvC5/Enveloppe C5: ""
+*it.PaperDimension EnvC5/Busta C5: ""
+*ja.PaperDimension EnvC5/封筒 C5: ""
+*ko.PaperDimension EnvC5/C5 봉투: ""
+*nl.PaperDimension EnvC5/C5-envelop: ""
+*nb.PaperDimension EnvC5/C5-konvolutt: ""
+*pt.PaperDimension EnvC5/Envelope C5: ""
+*sv.PaperDimension EnvC5/C5-kuvert: ""
+*zh_CN.PaperDimension EnvC5/信封 C5: ""
+*zh_TW.PaperDimension EnvC5/C5 信封: ""
+
+*PaperDimension EnvDL/Env DL: 					"312 624"
+*da.PaperDimension EnvDL/Konv DL: ""
+*de.PaperDimension EnvDL/Umschlag DL: ""
+*es.PaperDimension EnvDL/Sobre DL: ""
+*fi.PaperDimension EnvDL/Kirjekuori DL: ""
+*fr.PaperDimension EnvDL/Enveloppe DL: ""
+*it.PaperDimension EnvDL/Busta DL: ""
+*ja.PaperDimension EnvDL/封筒 DL: ""
+*ko.PaperDimension EnvDL/DL 봉투: ""
+*nl.PaperDimension EnvDL/DL-envelop: ""
+*nb.PaperDimension EnvDL/DL-konvolutt: ""
+*pt.PaperDimension EnvDL/Envelope DL: ""
+*sv.PaperDimension EnvDL/DL-kuvert: ""
+*zh_CN.PaperDimension EnvDL/信封 DL: ""
+*zh_TW.PaperDimension EnvDL/DL 信封: ""
+
+*PaperDimension EnvMonarch/Env Monarch: 		"279 540"
+*da.PaperDimension EnvMonarch/Konv Monarch: ""
+*de.PaperDimension EnvMonarch/Umschlag Monarch: ""
+*es.PaperDimension EnvMonarch/Sobre Monarch: ""
+*fi.PaperDimension EnvMonarch/Kirjekuori Monarch: ""
+*fr.PaperDimension EnvMonarch/Enveloppe Monarch: ""
+*it.PaperDimension EnvMonarch/Busta Monarch: ""
+*ja.PaperDimension EnvMonarch/封筒 Monarch: ""
+*ko.PaperDimension EnvMonarch/Monarch 봉투: ""
+*nl.PaperDimension EnvMonarch/Monarch-envelop: ""
+*nb.PaperDimension EnvMonarch/Monarch-konvolutt: ""
+*pt.PaperDimension EnvMonarch/Envelope Monarch: ""
+*sv.PaperDimension EnvMonarch/Monarch-kuvert: ""
+*zh_CN.PaperDimension EnvMonarch/信封 Monarch: ""
+*zh_TW.PaperDimension EnvMonarch/Monarch 信封: ""
+
+
+*RequiresPageRegion All: True
+
+
+*%=================================================
+*%		 Custom Paper Support
+*%=================================================
+*%Orientation and Margin (offsets) values are not utilized
+
+*VariablePaperSize: True
+
+*LeadingEdge PreferLong: ""
+*DefaultLeadingEdge: PreferLong
+
+*% Smallest = 3.67x7.5, Largest = 11.7 x 17.7
+*MaxMediaWidth:  "884"
+*MaxMediaHeight: "1332"
+*HWMargins:      12 12 12 12
+*%CustomPageRegion True: ""
+*CustomPageSize True: "
+  pop pop pop
+  <</DeferredMediaSelection true /PageSize [ 7 -2 roll ] /ImagingBBox null >>
+  setpagedevice
+"
+*End
+
+
+*ParamCustomPageSize Width:        1 points 264 842
+*ParamCustomPageSize Height:       2 points 540 1274
+*ParamCustomPageSize WidthOffset:  3 points 0 0
+*ParamCustomPageSize HeightOffset: 4 points 0 0
+*ParamCustomPageSize Orientation:  5 int 0 0
+
+*RequiresPageRegion All: True
+
+*%=================================================
+*%		 Paper Sources
+*%=================================================
+*OpenUI *InputSlot/Paper Source: PickOne
+*OrderDependency: 20 AnySetup *InputSlot
+*DefaultInputSlot: Auto
+*InputSlot Auto/Automatic: "
+	<</ManualFeed false /MediaPosition 7>> setpagedevice"
+*End
+*da.InputSlot Auto/Automatisk: ""
+*de.InputSlot Auto/Automatisch: ""
+*es.InputSlot Auto/Automático: ""
+*fi.InputSlot Auto/Automaattinen: ""
+*fr.InputSlot Auto/Automatique: ""
+*it.InputSlot Auto/Automatico: ""
+*ja.InputSlot Auto/自動: ""
+*ko.InputSlot Auto/자동: ""
+*nl.InputSlot Auto/Automatisch: ""
+*nb.InputSlot Auto/Automatisk: ""
+*pt.InputSlot Auto/Automático: ""
+*sv.InputSlot Auto/Automatiskt: ""
+*zh_CN.InputSlot Auto/自动: ""
+*zh_TW.InputSlot Auto/自動: ""
+
+*da.Translation InputSlot/Papirkilde: ""
+*de.Translation InputSlot/Papierquelle: ""
+*es.Translation InputSlot/Alimentación de papel: ""
+*fi.Translation InputSlot/Paperilähde: ""
+*fr.Translation InputSlot/Source du papier: ""
+*it.Translation InputSlot/Alimentazione della carta: ""
+*ja.Translation InputSlot/給紙元: ""
+*ko.Translation InputSlot/용지함: ""
+*nl.Translation InputSlot/Papierbron: ""
+*nb.Translation InputSlot/Arkmating: ""
+*pt.Translation InputSlot/Fonte de papel: ""
+*sv.Translation InputSlot/Papperskälla: ""
+*zh_CN.Translation InputSlot/纸张来源: ""
+*zh_TW.Translation InputSlot/紙張來源: ""
+
+*InputSlot Tray1/Tray 1: "<</ManualFeed false /MediaPosition 3>> setpagedevice"
+*da.InputSlot Tray1/Bakke 1: ""
+*de.InputSlot Tray1/Zufuhrfach 1: ""
+*es.InputSlot Tray1/Bandeja 1: ""
+*fi.InputSlot Tray1/Lokero 1: ""
+*fr.InputSlot Tray1/Bac 1: ""
+*it.InputSlot Tray1/Cassetto 1: ""
+*ja.InputSlot Tray1/トレイ 1: ""
+*ko.InputSlot Tray1/용지함 1: ""
+*nl.InputSlot Tray1/Lade 1: ""
+*nb.InputSlot Tray1/Skuff 1: ""
+*pt.InputSlot Tray1/Bandeja 1: ""
+*sv.InputSlot Tray1/Fack 1: ""
+*zh_CN.InputSlot Tray1/纸盒 1: ""
+*zh_TW.InputSlot Tray1/1 號紙匣: ""
+
+*InputSlot Tray2/Tray 2: "<</ManualFeed false /MediaPosition 0>> setpagedevice"
+*da.InputSlot Tray2/Bakke 2: ""
+*de.InputSlot Tray2/Zufuhrfach 2: ""
+*es.InputSlot Tray2/Bandeja 2: ""
+*fi.InputSlot Tray2/Lokero 2: ""
+*fr.InputSlot Tray2/Bac 2: ""
+*it.InputSlot Tray2/Cassetto 2: ""
+*ja.InputSlot Tray2/トレイ 2: ""
+*ko.InputSlot Tray2/용지함 2: ""
+*nl.InputSlot Tray2/Lade 2: ""
+*nb.InputSlot Tray2/Skuff 2: ""
+*pt.InputSlot Tray2/Bandeja 2: ""
+*sv.InputSlot Tray2/Fack 2: ""
+*zh_CN.InputSlot Tray2/纸盒 2: ""
+*zh_TW.InputSlot Tray2/2 號紙匣: ""
+
+*InputSlot Tray3/Tray 3: "<</ManualFeed false /MediaPosition 1>> setpagedevice"
+*da.InputSlot Tray3/Bakke 3: ""
+*de.InputSlot Tray3/Zufuhrfach 3: ""
+*es.InputSlot Tray3/Bandeja 3: ""
+*fi.InputSlot Tray3/Lokero 3: ""
+*fr.InputSlot Tray3/Bac 3: ""
+*it.InputSlot Tray3/Cassetto 3: ""
+*ja.InputSlot Tray3/トレイ 3: ""
+*ko.InputSlot Tray3/용지함 3: ""
+*nl.InputSlot Tray3/Lade 3: ""
+*nb.InputSlot Tray3/Skuff 3: ""
+*pt.InputSlot Tray3/Bandeja 3: ""
+*sv.InputSlot Tray3/Fack 3: ""
+*zh_CN.InputSlot Tray3/纸盒 3: ""
+*zh_TW.InputSlot Tray3/3 號紙匣: ""
+
+*InputSlot Tray4Optional/Tray 4 (Optional): "<</ManualFeed false /MediaPosition 5>> setpagedevice"
+*da.InputSlot Tray4Optional/Bakke 4 (Ekstraudstyr): ""
+*de.InputSlot Tray4Optional/Zufuhrfach 4 (Optional): ""
+*es.InputSlot Tray4Optional/Bandeja 4 (Opcional): ""
+*fi.InputSlot Tray4Optional/Lokero 4 (valinnainen): ""
+*fr.InputSlot Tray4Optional/Bac 4 (Optionnel): ""
+*it.InputSlot Tray4Optional/Cassetto 4 (Opzionale): ""
+*ja.InputSlot Tray4Optional/トレイ 4 (ｵﾌﾟｼｮﾝ): ""
+*ko.InputSlot Tray4Optional/용지함 4 (선택사양): ""
+*nl.InputSlot Tray4Optional/Lade 4 (Optioneel): ""
+*nb.InputSlot Tray4Optional/Skuff 4 (ekstrautstyr): ""
+*pt.InputSlot Tray4Optional/Bandeja 4 (opcional): ""
+*sv.InputSlot Tray4Optional/Fack 4 (extra tillbehör): ""
+*zh_CN.InputSlot Tray4Optional/纸盒 4 (供选用): ""
+*zh_TW.InputSlot Tray4Optional/4 號紙匣（選購）: ""
+
+*?InputSlot: "
+ save
+   [(Tray1) (Tray2) (Tray3) (Tray4Optional)]
+   statusdict /papertray get exec
+   {get exec} stopped { pop pop (Unknown) } if = flush
+ restore
+"
+*End
+*CloseUI: *InputSlot
+
+*% Enable/Disable Manual Feed
+*OpenUI *ManualFeed/Tray 1 (Manual): Boolean
+*OrderDependency: 20 AnySetup *ManualFeed
+*DefaultManualFeed: False
+*da.Translation ManualFeed/Bakke 1 (manuel): ""
+*de.Translation ManualFeed/Zufuhrfach 1 (Manuell): ""
+*es.Translation ManualFeed/Bandeja 1 (Manual): ""
+*fi.Translation ManualFeed/Lokero 1 (Käsinsyöttö): ""
+*fr.Translation ManualFeed/Bac 1 (manuel): ""
+*it.Translation ManualFeed/Cassetto 1 (Manuale): ""
+*ja.Translation ManualFeed/トレイ 1 (手動): ""
+*ko.Translation ManualFeed/용지함 1(수동): ""
+*nl.Translation ManualFeed/Lade 1 (handmatig): ""
+*nb.Translation ManualFeed/Skuff 1 (manuell): ""
+*pt.Translation ManualFeed/Bandeja 1 (manual): ""
+*sv.Translation ManualFeed/Fack 1 (manuell): ""
+*zh_CN.Translation ManualFeed/纸盒1 (手工): ""
+*zh_TW.Translation ManualFeed/紙匣1 ( 手動): ""
+
+*ManualFeed True/True: "
+	<</ManualFeed true>> setpagedevice"
+*End
+*da.ManualFeed True/Sand: ""
+*de.ManualFeed True/Ja: ""
+*es.ManualFeed True/Verdadero: ""
+*fi.ManualFeed True/Käytössä: ""
+*fr.ManualFeed True/Vrai: ""
+*it.ManualFeed True/Vero: ""
+*ja.ManualFeed True/はい: ""
+*ko.ManualFeed True/참: ""
+*nl.ManualFeed True/Waar: ""
+*nb.ManualFeed True/Sann: ""
+*pt.ManualFeed True/Verdadeiro: ""
+*sv.ManualFeed True/Sant: ""
+*zh_CN.ManualFeed True/真: ""
+*zh_TW.ManualFeed True/真: ""
+
+*ManualFeed False/False: "
+	<</ManualFeed false>> setpagedevice"
+*End
+*da.ManualFeed False/Falsk: ""
+*de.ManualFeed False/Nein: ""
+*es.ManualFeed False/Falso: ""
+*fi.ManualFeed False/Ei käytössä: ""
+*fr.ManualFeed False/Faux: ""
+*it.ManualFeed False/Falso: ""
+*ja.ManualFeed False/いいえ: ""
+*ko.ManualFeed False/거짓: ""
+*nl.ManualFeed False/Onwaar: ""
+*nb.ManualFeed False/Usann: ""
+*pt.ManualFeed False/Falso: ""
+*sv.ManualFeed False/Falskt: ""
+*zh_CN.ManualFeed False/伪: ""
+*zh_TW.ManualFeed False/假: ""
+
+*?ManualFeed: "
+	save
+		currentpagedevice /ManualFeed get
+		{(True)}{(False)}ifelse = flush
+	restore
+"
+*End
+*CloseUI: *ManualFeed
+
+*%==========================================
+*%		Media Type
+*%=========================================
+*OpenUI *MediaType/Media Type: PickOne
+*OrderDependency: 20 AnySetup *MediaType
+*DefaultMediaType: Unspecified
+*da.Translation MediaType/Medietype: ""
+*de.Translation MediaType/Medientyp: ""
+*es.Translation MediaType/Tipo de sustrato: ""
+*fi.Translation MediaType/Tulostusmateriaali: ""
+*fr.Translation MediaType/Type de support: ""
+*it.Translation MediaType/Tipo di supporto: ""
+*ja.Translation MediaType/用紙の種類: ""
+*ko.Translation MediaType/용지 종류: ""
+*nl.Translation MediaType/Type afdrukmateriaal: ""
+*nb.Translation MediaType/Utskriftsmateriale: ""
+*pt.Translation MediaType/Tipo de mídia: ""
+*sv.Translation MediaType/Material: ""
+*zh_CN.Translation MediaType/介质类型: ""
+*zh_TW.Translation MediaType/媒體類型: ""
+
+*MediaType Unspecified/Unspecified:  "
+    <</ManualFeed false /MediaType null >> setpagedevice"
+*End
+*da.MediaType Unspecified/Uspecificeret: ""
+*de.MediaType Unspecified/Nicht bestimmt: ""
+*es.MediaType Unspecified/No especificado: ""
+*fi.MediaType Unspecified/Määrittämätön: ""
+*fr.MediaType Unspecified/Non spécifié: ""
+*it.MediaType Unspecified/Non specificato: ""
+*ja.MediaType Unspecified/指定なし: ""
+*ko.MediaType Unspecified/지정되지 않음: ""
+*nl.MediaType Unspecified/Onbekend: ""
+*nb.MediaType Unspecified/Uspesifisert: ""
+*pt.MediaType Unspecified/Não especificado: ""
+*sv.MediaType Unspecified/Ospecificerad: ""
+*zh_CN.MediaType Unspecified/未指定: ""
+*zh_TW.MediaType Unspecified/未指定: ""
+
+*MediaType Plain/Plain:  "
+    <</ManualFeed false /MediaType (Plain)>> setpagedevice"
+*End
+*da.MediaType Plain/Almindeligt: ""
+*de.MediaType Plain/Normalpapier: ""
+*es.MediaType Plain/Estándar: ""
+*fi.MediaType Plain/Tavallinen: ""
+*fr.MediaType Plain/Ordinaire: ""
+*it.MediaType Plain/Normale: ""
+*ja.MediaType Plain/普通用紙: ""
+*ko.MediaType Plain/일반용지: ""
+*nl.MediaType Plain/Gewoon: ""
+*nb.MediaType Plain/Vanlig: ""
+*pt.MediaType Plain/Comum: ""
+*sv.MediaType Plain/Vanligt: ""
+*zh_CN.MediaType Plain/普通纸: ""
+*zh_TW.MediaType Plain/素面紙: ""
+
+*MediaType Preprinted/Preprinted:  "
+    <</ManualFeed false /MediaType (Preprinted)>> setpagedevice"
+*End
+*da.MediaType Preprinted/Fortrykt: ""
+*de.MediaType Preprinted/Vordruckpapier: ""
+*es.MediaType Preprinted/Preimpreso: ""
+*fi.MediaType Preprinted/Esipainettu: ""
+*fr.MediaType Preprinted/Préimprimé: ""
+*it.MediaType Preprinted/Prestampata: ""
+*ja.MediaType Preprinted/印刷フォーム: ""
+*ko.MediaType Preprinted/미리 인쇄: ""
+*nl.MediaType Preprinted/Voorbedrukt: ""
+*nb.MediaType Preprinted/Forhåndstrykt: ""
+*pt.MediaType Preprinted/Pré-impresso: ""
+*sv.MediaType Preprinted/Förtryckt: ""
+*zh_CN.MediaType Preprinted/预先打印纸: ""
+*zh_TW.MediaType Preprinted/預印的: ""
+
+*MediaType Letterhead/Letterhead:  "
+    <</ManualFeed false /MediaType (Letterhead)>> setpagedevice"
+*End
+*da.MediaType Letterhead/Brevpapir: ""
+*de.MediaType Letterhead/Briefkopfpapier: ""
+*es.MediaType Letterhead/Membrete: ""
+*fi.MediaType Letterhead/Kirjelomake: ""
+*fr.MediaType Letterhead/Papier à en-tête: ""
+*it.MediaType Letterhead/Carta intestata: ""
+*ja.MediaType Letterhead/レターヘッド付き: ""
+*ko.MediaType Letterhead/레터헤드: ""
+*nl.MediaType Letterhead/Briefpapier: ""
+*nb.MediaType Letterhead/Brevhode: ""
+*pt.MediaType Letterhead/Timbrado: ""
+*sv.MediaType Letterhead/Brevpapper: ""
+*zh_CN.MediaType Letterhead/信头纸: ""
+*zh_TW.MediaType Letterhead/信頭紙: ""
+
+*MediaType Transparency/Transparency:  "
+    <</ManualFeed false /MediaType (Transparency)>> setpagedevice"
+*End
+*da.MediaType Transparency/Transparent: ""
+*de.MediaType Transparency/Transparentfolie: ""
+*es.MediaType Transparency/Transparencia: ""
+*fi.MediaType Transparency/Kalvo: ""
+*fr.MediaType Transparency/Transparent: ""
+*it.MediaType Transparency/Lucido: ""
+*ja.MediaType Transparency/OHP ﾌｨﾙﾑ: ""
+*ko.MediaType Transparency/투명 용지: ""
+*nl.MediaType Transparency/Transparant: ""
+*nb.MediaType Transparency/Transparent: ""
+*pt.MediaType Transparency/Transparência: ""
+*sv.MediaType Transparency/OH-film: ""
+*zh_CN.MediaType Transparency/透明胶片: ""
+*zh_TW.MediaType Transparency/投影片: ""
+
+*MediaType Prepunched/Prepunched:  "
+    <</ManualFeed false /MediaType (Prepunched)>> setpagedevice"
+*End
+*da.MediaType Prepunched/Hullet: ""
+*de.MediaType Prepunched/Vorgelochtes Papier: ""
+*es.MediaType Prepunched/Preperforado: ""
+*fi.MediaType Prepunched/Rei’itetty: ""
+*fr.MediaType Prepunched/Perforé: ""
+*it.MediaType Prepunched/Perforata: ""
+*ja.MediaType Prepunched/穴あき用紙: ""
+*ko.MediaType Prepunched/천공 용지: ""
+*nl.MediaType Prepunched/Geperforeerd: ""
+*nb.MediaType Prepunched/Hullark: ""
+*pt.MediaType Prepunched/Perfurado: ""
+*sv.MediaType Prepunched/Hålat: ""
+*zh_CN.MediaType Prepunched/预先打孔纸: ""
+*zh_TW.MediaType Prepunched/打孔過的: ""
+
+*MediaType Labels/Labels:  "
+    <</ManualFeed false /MediaType (Labels)>> setpagedevice"
+*End
+*da.MediaType Labels/Etiketter: ""
+*de.MediaType Labels/Etiketten: ""
+*es.MediaType Labels/Etiquetas: ""
+*fi.MediaType Labels/Tarrat: ""
+*fr.MediaType Labels/Étiquettes: ""
+*it.MediaType Labels/Etichette: ""
+*ja.MediaType Labels/ラベル: ""
+*ko.MediaType Labels/레이블: ""
+*nl.MediaType Labels/Etiketten: ""
+*nb.MediaType Labels/Etiketter: ""
+*pt.MediaType Labels/Etiquetas: ""
+*sv.MediaType Labels/Etiketter: ""
+*zh_CN.MediaType Labels/标签: ""
+*zh_TW.MediaType Labels/標籤: ""
+
+*MediaType Bond/Bond:  "
+    <</ManualFeed false /MediaType (Bond)>> setpagedevice"
+*End
+*da.MediaType Bond/Bond: ""
+*de.MediaType Bond/Briefpapier: ""
+*es.MediaType Bond/Bond: ""
+*fi.MediaType Bond/Kova asiakirjapaperi: ""
+*fr.MediaType Bond/Document: ""
+*it.MediaType Bond/Carta fine: ""
+*ja.MediaType Bond/ボンド紙: ""
+*ko.MediaType Bond/본드지: ""
+*nl.MediaType Bond/Bankpost: ""
+*nb.MediaType Bond/Bond: ""
+*pt.MediaType Bond/Superbond: ""
+*sv.MediaType Bond/Finpapper: ""
+*zh_CN.MediaType Bond/证券纸: ""
+*zh_TW.MediaType Bond/雪銅紙: ""
+
+*MediaType Recycled/Recycled:  "
+    <</ManualFeed false /MediaType (Recycled)>> setpagedevice"
+*End
+*da.MediaType Recycled/Genbrug: ""
+*de.MediaType Recycled/Recyclingpapier: ""
+*es.MediaType Recycled/Reciclado: ""
+*fi.MediaType Recycled/Uusiopaperi: ""
+*fr.MediaType Recycled/Recyclé: ""
+*it.MediaType Recycled/Riciclata: ""
+*ja.MediaType Recycled/再生紙: ""
+*ko.MediaType Recycled/재활용지: ""
+*nl.MediaType Recycled/Gerecycled: ""
+*nb.MediaType Recycled/Resirkulert: ""
+*pt.MediaType Recycled/Reciclado: ""
+*sv.MediaType Recycled/Returpapper: ""
+*zh_CN.MediaType Recycled/再生纸: ""
+*zh_TW.MediaType Recycled/再生紙: ""
+
+*MediaType Color/Color:  "
+    <</ManualFeed false /MediaType (Color)>> setpagedevice"
+*End
+*da.MediaType Color/Farvet: ""
+*de.MediaType Color/Farbpapier: ""
+*es.MediaType Color/Color: ""
+*fi.MediaType Color/Väri: ""
+*fr.MediaType Color/Couleur: ""
+*it.MediaType Color/Colorata: ""
+*ja.MediaType Color/カラー: ""
+*ko.MediaType Color/색: ""
+*nl.MediaType Color/Kleur: ""
+*nb.MediaType Color/Farge: ""
+*pt.MediaType Color/Colorido: ""
+*sv.MediaType Color/Färgat: ""
+*zh_CN.MediaType Color/颜色: ""
+*zh_TW.MediaType Color/顏色: ""
+
+*MediaType CardStock164/Cardstock (<3e>164 g/m2):  "
+    <</ManualFeed false /MediaType (Card Stock)>> setpagedevice"
+*End
+*da.MediaType CardStock164/Karton (<3e>164 g/m2): ""
+*de.MediaType CardStock164/Karton (<3e>164 g/m2): ""
+*es.MediaType CardStock164/Cardstock (<3e>164 g/m2): ""
+*fi.MediaType CardStock164/Korttipaperi (<3e>164 g/m2): ""
+*fr.MediaType CardStock164/Cartonné (<3e>164 g/m2): ""
+*it.MediaType CardStock164/Cartoncino (<3e>164 g/m2): ""
+*ja.MediaType CardStock164/カード ストック (<3e>164 g/m2): ""
+*ko.MediaType CardStock164/카드 용지 (<3e>164 g/m2): ""
+*nl.MediaType CardStock164/Kartonkaart (<3e>164 g/m2): ""
+*nb.MediaType CardStock164/Kort (<3e>164 g/m2): ""
+*pt.MediaType CardStock164/Cartolina (<3e>164 g/m2): ""
+*sv.MediaType CardStock164/Kort (<3e>164 g/m2): ""
+*zh_CN.MediaType CardStock164/卡片纸 (<3e>164 g/m2): ""
+*zh_TW.MediaType CardStock164/卡片紙 (<3e>164 g/m2): ""
+
+*MediaType Rough/Rough:  "
+    <</ManualFeed false /MediaType (Rough)>> setpagedevice"
+*End
+*da.MediaType Rough/Groft (90-105 g/m2): ""
+*de.MediaType Rough/Rauhpapier: ""
+*es.MediaType Rough/Rugoso: ""
+*fi.MediaType Rough/Karkea: ""
+*fr.MediaType Rough/Rugueux: ""
+*it.MediaType Rough/Ruvida: ""
+*ja.MediaType Rough/ざら紙: ""
+*ko.MediaType Rough/거친 용지: ""
+*nl.MediaType Rough/Ruw: ""
+*nb.MediaType Rough/Grovt: ""
+*pt.MediaType Rough/Áspero: ""
+*sv.MediaType Rough/Grovt: ""
+*zh_CN.MediaType Rough/粗糙: ""
+*zh_TW.MediaType Rough/粗糙紙: ""
+
+*MediaType Envelope/Envelope:  "
+    <</ManualFeed false /MediaType (Envelope)>> setpagedevice"
+*End
+*da.MediaType Envelope/Konvolut: ""
+*de.MediaType Envelope/Briefumschlag: ""
+*es.MediaType Envelope/Sobre: ""
+*fi.MediaType Envelope/Kirjekuori: ""
+*fr.MediaType Envelope/Enveloppe: ""
+*it.MediaType Envelope/Busta: ""
+*ja.MediaType Envelope/封筒: ""
+*ko.MediaType Envelope/봉투: ""
+*nl.MediaType Envelope/Enveloppen: ""
+*nb.MediaType Envelope/Konvolutt: ""
+*pt.MediaType Envelope/Envelope: ""
+*sv.MediaType Envelope/Kuvert: ""
+*zh_CN.MediaType Envelope/信封: ""
+*zh_TW.MediaType Envelope/信封: ""
+
+*?MediaType: "
+  save
+    currentpagedevice /MediaType get
+    dup null eq {pop (Unknown)} if
+    = flush
+  restore
+"
+*End
+*CloseUI: *MediaType
+
+
+*%=================================================
+*%		 Duplex
+*%=================================================
+*OpenUI *Duplex/Duplex:  PickOne
+*OrderDependency: 50 AnySetup *Duplex
+*DefaultDuplex: None
+*da.Translation Duplex/Dupleks: ""
+*de.Translation Duplex/Beidseitiger Druck: ""
+*es.Translation Duplex/Dúplex: ""
+*fi.Translation Duplex/Kaksipuolinen tulostus: ""
+*fr.Translation Duplex/Impression des deux côtés: ""
+*it.Translation Duplex/Duplex: ""
+*ja.Translation Duplex/両面印刷: ""
+*ko.Translation Duplex/양면인쇄: ""
+*nl.Translation Duplex/Duplex: ""
+*nb.Translation Duplex/Tosidig: ""
+*pt.Translation Duplex/Dúplex: ""
+*sv.Translation Duplex/Dubbelsidig: ""
+*zh_CN.Translation Duplex/双面打印: ""
+*zh_TW.Translation Duplex/雙面列印: ""
+
+*Duplex None/Off (1-Sided): "
+  <</Duplex false>> setpagedevice"
+*End
+*da.Duplex None/Fra (1-sidet): ""
+*de.Duplex None/Aus (einseitig): ""
+*es.Duplex None/Des (por un solo lado): ""
+*fi.Duplex None/Ei käytössä: ""
+*fr.Duplex None/Désactivé: ""
+*it.Duplex None/Disattivato (facciata singola): ""
+*ja.Duplex None/オフ (片面印刷): ""
+*ko.Duplex None/끔 (한 면): ""
+*nl.Duplex None/Uit (enkelzijdig): ""
+*nb.Duplex None/Av (1-sidig): ""
+*pt.Duplex None/Desligado (face única): ""
+*sv.Duplex None/Av (enkelsidig): ""
+*zh_CN.Duplex None/关 (1面): ""
+*zh_TW.Duplex None/關( 單面): ""
+
+*Duplex DuplexNoTumble/Flip on Long Edge (Standard): "
+  <</Duplex true /Tumble false>> setpagedevice"
+*End
+*da.Duplex DuplexNoTumble/Vend på langs: ""
+*de.Duplex DuplexNoTumble/Lange Kante spiegeln (Standard): ""
+*es.Duplex DuplexNoTumble/Dar vuelta - borde largo (estándar): ""
+*fi.Duplex DuplexNoTumble/Pitkän reunan sidonta: ""
+*fr.Duplex DuplexNoTumble/Reliure sur bord long: ""
+*it.Duplex DuplexNoTumble/Ruota sul lato lungo (Standard): ""
+*ja.Duplex DuplexNoTumble/長辺綴じ (標準): ""
+*ko.Duplex DuplexNoTumble/긴 가장자리로 뒤집기(표준): ""
+*nl.Duplex DuplexNoTumble/Over lange zijde spiegelen (standaard): ""
+*nb.Duplex DuplexNoTumble/Vend på langsiden (standard): ""
+*pt.Duplex DuplexNoTumble/Inversão na margem longa (padrão): ""
+*sv.Duplex DuplexNoTumble/Vänd längs långsidan (standard): ""
+*zh_CN.Duplex DuplexNoTumble/长边翻转（标准）: ""
+*zh_TW.Duplex DuplexNoTumble/在長邊緣倒轉( 標準): ""
+
+*Duplex DuplexTumble/Flip on Short Edge: "
+  <</Duplex true /Tumble true>> setpagedevice"
+*End
+*da.Duplex DuplexTumble/Vend på tværs: ""
+*de.Duplex DuplexTumble/Kurze Kante spiegeln: ""
+*es.Duplex DuplexTumble/Dar vuelta - borde corto: ""
+*fi.Duplex DuplexTumble/Lyhyen reunan sidonta: ""
+*fr.Duplex DuplexTumble/Reliure sur bord court: ""
+*it.Duplex DuplexTumble/Ruota sul lato corto: ""
+*ja.Duplex DuplexTumble/短辺綴じ: ""
+*ko.Duplex DuplexTumble/짧은 가장자리로 뒤집기: ""
+*nl.Duplex DuplexTumble/Over korte zijde spiegelen: ""
+*nb.Duplex DuplexTumble/Vend på kortsiden: ""
+*pt.Duplex DuplexTumble/Inversão na margem curta: ""
+*sv.Duplex DuplexTumble/Vänd längs kortsidan: ""
+*zh_CN.Duplex DuplexTumble/短边翻转: ""
+*zh_TW.Duplex DuplexTumble/在短邊緣倒轉: ""
+
+*?Duplex: "
+   save
+   currentpagedevice /Duplex known
+   false ne
+     { currentpagedevice /Duplex get
+        { currentpagedevice /Tumble get
+            {(DuplexTumble)}{(DuplexNoTumble)}ifelse
+        } { (None)}    ifelse
+     }{(None)}  ifelse = flush
+   restore
+"
+*End
+*CloseUI: *Duplex
+
+*%=================================================
+*%		 Color Control
+*%=================================================
+*DefaultColorSep: ProcessBlack.106lpi.600dpi/106 lpi / 600 dpi
+*InkName: ProcessBlack/Process Black
+*InkName: CustomColor/Custom Color
+*InkName: ProcessCyan/Process Cyan
+*InkName: ProcessMagenta/Process Magenta
+*InkName: ProcessYellow/Process Yellow
+
+*%  For 60 lpi / 300 dpi  =========================
+*ColorSepScreenAngle ProcessBlack.60lpi.300dpi/60 lpi / 300 dpi: "45"
+
+*ColorSepScreenAngle CustomColor.60lpi.300dpi/60 lpi / 300 dpi: "45"
+
+*ColorSepScreenAngle ProcessCyan.60lpi.300dpi/60 lpi / 300 dpi: "15"
+
+*ColorSepScreenAngle ProcessMagenta.60lpi.300dpi/60 lpi / 300 dpi: "75"
+
+*ColorSepScreenAngle ProcessYellow.60lpi.300dpi/60 lpi / 300 dpi: "0"
+
+
+*ColorSepScreenFreq ProcessBlack.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq CustomColor.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq ProcessCyan.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq ProcessMagenta.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+*ColorSepScreenFreq ProcessYellow.60lpi.300dpi/60 lpi / 300 dpi: "60"
+
+
+*%  For 85 lpi / 600 dpi  (5,5,2,6,6,2,20/3,0) ====
+*ColorSepScreenAngle ProcessBlack.85lpi.600dpi/85 lpi / 600 dpi: "45.0"
+
+*ColorSepScreenAngle CustomColor.85lpi.600dpi/85 lpi / 600 dpi: "45.0"
+
+*ColorSepScreenAngle ProcessCyan.85lpi.600dpi/85 lpi / 600 dpi: "71.5651"
+
+*ColorSepScreenAngle ProcessMagenta.85lpi.600dpi/85 lpi / 600 dpi: "18.4349"
+
+*ColorSepScreenAngle ProcessYellow.85lpi.600dpi/85 lpi / 600 dpi: "0.0"
+
+
+*ColorSepScreenFreq ProcessBlack.85lpi.600dpi/85 lpi / 600 dpi: "84.8528"
+
+*ColorSepScreenFreq CustomColor.85lpi.600dpi/85 lpi / 600 dpi: "84.8528"
+
+*ColorSepScreenFreq ProcessCyan.85lpi.600dpi/85 lpi / 600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessMagenta.85lpi.600dpi/85 lpi / 600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessYellow.85lpi.600dpi/85 lpi / 600 dpi: "30.0"
+
+*ColorSepScreenProc ProcessYellow.85lpi.600dpi/85 lpi / 600 dpi: "
+{1 add 2 div 3 mul dup floor sub 2 mul 1 sub exch
+1 add 2 div 3 mul dup floor sub 2 mul 1 sub exch
+abs exch abs 2 copy add 1 gt {1 sub dup mul exch 1 sub dup mul add 1
+sub }{dup mul exch dup mul add 1 exch sub }ifelse }"
+*End
+
+
+*%  For 106 lpi /300 dpi  =========================
+*ColorSepScreenAngle ProcessBlack.106lpi.300dpi/106 lpi /300 dpi: "45.0"
+
+*ColorSepScreenAngle CustomColor.106lpi.300dpi/106 lpi /300 dpi: "45.0"
+
+*ColorSepScreenAngle ProcessCyan.106lpi.300dpi/106 lpi /300 dpi: "71.5651"
+
+*ColorSepScreenAngle ProcessMagenta.106lpi.300dpi/106 lpi /300 dpi: "18.4349"
+
+*ColorSepScreenAngle ProcessYellow.106lpi.300dpi/106 lpi /300 dpi: "0.0"
+
+
+*ColorSepScreenFreq ProcessBlack.106lpi.300dpi/106 lpi /300 dpi: "106.066"
+
+*ColorSepScreenFreq CustomColor.106lpi.300dpi/106 lpi /300 dpi: "106.066"
+
+*ColorSepScreenFreq ProcessCyan.106lpi.300dpi/106 lpi /300 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessMagenta.106lpi.300dpi/106 lpi /300 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessYellow.106lpi.300dpi/106 lpi /300 dpi: "100.0"
+
+
+*%  For 106 lpi /600 dpi  =========================
+
+*ColorSepScreenAngle ProcessBlack.106lpi.600dpi/106 lpi /600 dpi: "45.0"
+
+*ColorSepScreenAngle CustomColor.106lpi.600dpi/106 lpi /600 dpi: "45.0"
+
+*ColorSepScreenAngle ProcessCyan.106lpi.600dpi/106 lpi /600 dpi: "71.5651"
+
+*ColorSepScreenAngle ProcessMagenta.106lpi.600dpi/106 lpi /600 dpi: "18.4349"
+
+*ColorSepScreenAngle ProcessYellow.106lpi.600dpi/106 lpi /600 dpi: "0.0"
+
+
+*ColorSepScreenFreq ProcessBlack.106lpi.600dpi/106 lpi /600 dpi: "106.066"
+
+*ColorSepScreenFreq CustomColor.106lpi.600dpi/106 lpi /600 dpi: "106.066"
+
+*ColorSepScreenFreq ProcessCyan.106lpi.600dpi/106 lpi /600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessMagenta.106lpi.600dpi/106 lpi /600 dpi: "94.8683"
+
+*ColorSepScreenFreq ProcessYellow.106lpi.600dpi/106 lpi /600 dpi: "100.0"
+
+
+*%=================================================
+*%		 Font Information
+*%=================================================
+*DefaultFont: Courier
+*Font AvantGarde-Book: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-BookOblique: Standard "(001.006S)" Standard ROM
+*Font AvantGarde-Demi: Standard "(001.007S)" Standard ROM
+*Font AvantGarde-DemiOblique: Standard "(001.007S)" Standard ROM
+*Font Bookman-Demi: Standard "(001.004S)" Standard ROM
+*Font Bookman-DemiItalic: Standard "(001.004S)" Standard ROM
+*Font Bookman-Light: Standard "(001.004S)" Standard ROM
+*Font Bookman-LightItalic: Standard "(001.004S)" Standard ROM
+*Font Courier: Standard "(002.004S)" Standard ROM
+*Font Courier-Bold: Standard "(002.004S)" Standard ROM
+*Font Courier-BoldOblique: Standard "(002.004S)" Standard ROM
+*Font Courier-Oblique: Standard "(002.004S)" Standard ROM
+*Font Helvetica: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Narrow-Bold: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-BoldOblique: Standard "(001.007S)" Standard ROM
+*Font Helvetica-Narrow-Oblique: Standard "(001.006S)" Standard ROM
+*Font Helvetica-Oblique: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Bold: Standard "(001.009S)" Standard ROM
+*Font NewCenturySchlbk-BoldItalic: Standard "(001.007S)" Standard ROM
+*Font NewCenturySchlbk-Italic: Standard "(001.006S)" Standard ROM
+*Font NewCenturySchlbk-Roman: Standard "(001.007S)" Standard ROM
+*Font Palatino-Bold: Standard "(001.005S)" Standard ROM
+*Font Palatino-BoldItalic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Italic: Standard "(001.005S)" Standard ROM
+*Font Palatino-Roman: Standard "(001.005S)" Standard ROM
+*Font Symbol: Special "(001.007S)" Special ROM
+*Font Times-Bold: Standard "(001.007S)" Standard ROM
+*Font Times-BoldItalic: Standard "(001.009S)" Standard ROM
+*Font Times-Italic: Standard "(001.007S)" Standard ROM
+*Font Times-Roman: Standard "(001.007S)" Standard ROM
+*Font ZapfChancery-MediumItalic: Standard "(001.007S)" Standard ROM
+*Font ZapfDingbats: Special "(001.004S)" Special ROM
+*Font Albertus-ExtraBold: Standard "(001.008S)" Standard ROM
+*Font Albertus-Medium: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Bold: Standard "(001.008S)" Standard ROM
+*Font AntiqueOlive-Italic: Standard "(001.008S)" Standard ROM
+*Font Arial: Standard "(001.008S)" Standard ROM
+*Font Arial-Bold: Standard "(001.008S)" Standard ROM
+*Font Arial-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Arial-Italic: Standard "(001.008S)" Standard ROM
+*Font CGOmega: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Bold: Standard "(001.008S)" Standard ROM
+*Font CGOmega-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGOmega-Italic: Standard "(001.008S)" Standard ROM
+*Font CGTimes: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Bold: Standard "(001.008S)" Standard ROM
+*Font CGTimes-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CGTimes-Italic: Standard "(001.008S)" Standard ROM
+*Font Clarendon-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Coronet: Standard "(001.008S)" Standard ROM
+*Font CourierHP: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Bold: Standard "(001.008S)" Standard ROM
+*Font CourierHP-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font CourierHP-Italic: Standard "(001.008S)" Standard ROM
+*Font Garamond-Antiqua: Standard "(001.008S)" Standard ROM
+*Font Garamond-Halbfett: Standard "(001.008S)" Standard ROM
+*Font Garamond-Kursiv: Standard "(001.008S)" Standard ROM
+*Font Garamond-KursivHalbfett: Standard "(001.008S)" Standard ROM
+*Font LetterGothic: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Bold: Standard "(001.008S)" Standard ROM
+*Font LetterGothic-Italic: Standard "(001.008S)" Standard ROM
+*Font Marigold: Standard "(001.008S)" Standard ROM
+*Font SymbolMT: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Bold: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font TimesNewRoman-Italic: Standard "(001.008S)" Standard ROM
+*Font Univers-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Bold: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-BoldItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-Condensed-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Univers-Medium: Standard "(001.008S)" Standard ROM
+*Font Univers-MediumItalic: Standard "(001.008S)" Standard ROM
+*Font Wingdings-Regular: Standard "(001.008S)" Standard ROM
+*?FontQuery: "
+   save
+   { count 1 gt
+      { exch dup 127 string cvs (/) print print (:) print
+      /Font resourcestatus {pop pop (Yes)} {(No)} ifelse =
+      } { exit } ifelse
+   } bind loop
+   (*) = flush
+   restore
+"
+*End
+
+*?FontList: "
+   save
+     (*) {cvn ==} 128 string /Font resourceforall
+     (*) = flush
+   restore
+"
+*End
+
+*%=================================================
+*%		 Printer Messages (verbatim from printer):
+*%=================================================
+*Message: "%%[ exitserver: permanent state may be changed ]%%"
+*Message: "%%[ Flushing: rest of job (to end-of-file) will be ignored ]%%"
+*Message: "\FontName\ not found, using Courier"
+
+*% Status (format: %%[ status: <one of these> ] %%)
+*Status: "warming up"/warming up
+*Status: "idle"/idle
+*Status: "busy"/busy
+*Status: "waiting"/waiting
+*Status: "printing"/printing
+*Status: "initializing"/initializing
+*Status: "printing test page"/printing test page
+*Status: "PrinterError: cover open or no toner cartridge"/cover open or no toner cartridge
+*Status: "PrinterError: cover open"/cover open
+*Status: "PrinterError: needs attention"/needs attention
+*Status: "PrinterError: no toner cartridge"/no toner cartridge
+*Status: "PrinterError: warming up"/warming up
+*Status: "PrinterError: manual feed"/manual feed
+*Status: "PrinterError: out of paper"/out of paper
+*Status: "PrinterError: Paper Jam"/Paper Jam
+*Status: "PrinterError: paper jam"/paper jam
+*Status: "PrinterError: page protect needed"/page protect needed
+*Status: "PrinterError: out of memory"/out of memory
+*Status: "PrinterError: output bin full"/output bin full
+*Status: "PrinterError: resetting printer"/resetting printer
+*Status: "PrinterError: toner is low"/toner is low
+*Status: "PrinterError: off line"/off line
+
+*% Printer Error (format: %%[ PrinterError: <one of these> ]%%)
+*PrinterError: "cover open or no toner cartridge"/cover open or no toner cartridge
+*PrinterError: "cover open"/cover open
+*PrinterError: "needs attention"/needs attention
+*PrinterError: "no toner cartridge"/no toner cartridge
+*PrinterError: "warming up"/warming up
+*PrinterError: "manual feed"/manual feed
+*PrinterError: "out of paper"/out of paper
+*PrinterError: "Paper Jam"/Paper Jam
+*PrinterError: "paper jam"/paper jam
+*PrinterError: "page protect needed"/page protect needed
+*PrinterError: "out of memory"/out of memory
+*PrinterError: "output bin full"/output bin full
+*PrinterError: "resetting printer"/resetting printer
+*PrinterError: "toner is low"/toner is low
+*PrinterError: "off line"/off line
+
+*% Input Sources (format: %%[ status: <stat>; source: <one of these> ]%% )
+*Source: "BiTronics"/BiTronics
+*Source: "other I/O"/other I/O
+*Source: "AppleTalk"/AppleTalk
+*Source: "APPLETALK"/AppleTalk
+*Source: "ATALK"/AppleTalk
+*Source: "LocalTalk"/LocalTalk
+*Source: "Parallel"/Parallel
+*Source: "EtherTalk"/EtherTalk
+*Source: "NOVELL"/NOVELL
+*Source: "DLC/LLC"/DLC/LLC
+*Source: "ETALK"/EtherTalk
+*Source: "TCP/IP"/TCP/IP
+
+*Password: "()"
+*ExitServer: "
+ count 0 eq
+ { false } { true exch startjob } ifelse
+ not {
+     (WARNING: Cannot modify initial VM.) =
+     (Missing or invalid password.) =
+     (Please contact the author of this software.) = flush quit
+     } if
+"
+*End
+*Reset: "
+  count 0 eq { false } { true exch startjob } ifelse
+  not {
+    (WARNING: Cannot reset printer.) =
+    (Missing or invalid password.) =
+    (Please contact the author of this software.) = flush quit
+    } if
+  systemdict /quit get exec
+  (WARNING : Printer Reset Failed.) = flush
+"
+*End
+
+*% =======================================
+*% For HP LaserJet 9050


### PR DESCRIPTION
Reverts adicu/ninja-unix#10

@jhn, the included PPD has support for double sided printing which the default PPD on Mac does not. Reverting the commit to return support.
